### PR TITLE
Fix invalid range logscale

### DIFF
--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -576,7 +576,7 @@ end
 
 function validate_limits_for_scale(lims, scale)
     all(x -> begin
-        scale in [log10, log2, log] && lims[1] == lims[2] && return false
+        lims[1] == lims[2] && return false
         x in defined_interval(scale)
     end, lims)
 end

--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -575,10 +575,8 @@ function validate_limits_for_scales(lims::Rect, xsc, ysc)
 end
 
 function validate_limits_for_scale(lims, scale)
-    all(x -> begin
-        lims[1] == lims[2] && return false
-        x in defined_interval(scale)
-    end, lims)
+    lims[1] == lims[2] && return false
+    all(x -> x in defined_interval(scale), lims)
 end
 
 palettesyms(cycle::Cycle) = [c[2] for c in cycle.cycle]

--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -773,6 +773,10 @@ function getlimits(la::Axis, dim)
 
     # otherwise start with the first box
     mini, maxi = minimum(boundingbox), maximum(boundingbox)
+
+    # equal limits not allowed
+    mini[dim] == maxi[dim] && return nothing
+
     return (mini[dim], maxi[dim])
 end
 

--- a/src/makielayout/layoutables/axis.jl
+++ b/src/makielayout/layoutables/axis.jl
@@ -574,7 +574,12 @@ function validate_limits_for_scales(lims::Rect, xsc, ysc)
     nothing
 end
 
-validate_limits_for_scale(lims, scale) = all(x -> x in defined_interval(scale), lims)
+function validate_limits_for_scale(lims, scale)
+    all(x -> begin
+        scale in [log10, log2, log] && lims[1] == lims[2] && return false
+        x in defined_interval(scale)
+    end, lims)
+end
 
 palettesyms(cycle::Cycle) = [c[2] for c in cycle.cycle]
 attrsyms(cycle::Cycle) = [c[1] for c in cycle.cycle]


### PR DESCRIPTION
# Description

Fixes #1670

Avoid equal axis limits and fall back to default ones.

I also modified `validate_limits_for_scale` to error if equal axis limits are encountered even if no log scale is set. Is this ok?
Previously this did not error on standard axis, e.g.
```julia
lines(1:10,1:10, axis=(; limits=(1,1,1,5))
```
worked.

Should I also add units test for this?

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added unit tests for new algorithms, conversion methods, etc.
