### PR TITLE
expand rectzoom to y or x if rectangle is very narrow

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Fixed regression where `Block` alignments could not be specified as numbers anymore [#2108](https://github.com/JuliaPlots/Makie.jl/pull/2108).
 - Added the option to show mirrored ticks on the other side of an Axis using the attributes `xticksmirrored` and `yticksmirrored` [#2105](https://github.com/JuliaPlots/Makie.jl/pull/2105).
 - Fixed a bug where a set of `Axis` wouldn't be correctly linked together if they were only linked in pairs instead of all at the same time [#2116](https://github.com/JuliaPlots/Makie.jl/pull/2116).
+- Changed the rectangle zoom behavior in Axis such that at very narrow rectangle selections, the narrow side is expanded to full width. This makes it much easier to narrow the field of view in one direction [#2120](https://github.com/JuliaPlots/Makie.jl/pull/2120).
 
 ## v0.17.7
 

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -108,15 +108,19 @@ end
 ############################################################################
 
 function _chosen_limits(rz, ax)
+    abs_px = abs.((rz.to_px - rz.from_px))
+    restrict_limit_px = 25
+    restrict_x = rz.restrict_x || !ax.xrectzoom[] || abs_px[1] < restrict_limit_px
+    restrict_y = rz.restrict_y || !ax.yrectzoom[] || abs_px[2] < restrict_limit_px
 
     r = positivize(Rect2f(rz.from, rz.to .- rz.from))
     lims = ax.finallimits[]
     # restrict to y change
-    if rz.restrict_x || !ax.xrectzoom[]
+    if restrict_x
         r = Rect2f(lims.origin[1], r.origin[2], widths(lims)[1], widths(r)[2])
     end
     # restrict to x change
-    if rz.restrict_y || !ax.yrectzoom[]
+    if restrict_y
         r = Rect2f(r.origin[1], lims.origin[2], widths(r)[1], widths(lims)[2])
     end
     return r
@@ -161,6 +165,8 @@ function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)
 
         r.from = prev_data
         r.to = data
+        r.from_px = event.prev_px
+        r.to_px = event.px
         r.rectnode[] = _chosen_limits(r, ax)
         r.active[] = true
         return Consume(true)
@@ -171,6 +177,7 @@ function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)
         data = Makie.apply_transform(inv_transf, rectclamp(event.data, rect))
 
         r.to = data
+        r.to_px = event.px
         r.rectnode[] = _chosen_limits(r, ax)
         return Consume(true)
 

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -113,6 +113,8 @@ function _chosen_limits(rz, ax)
     restrict_x = rz.restrict_x || !ax.xrectzoom[] || abs_px[1] < restrict_limit_px
     restrict_y = rz.restrict_y || !ax.yrectzoom[] || abs_px[2] < restrict_limit_px
 
+    restrict_x && restrict_y && return Rect2f(rz.from, Point2f(0))
+
     r = positivize(Rect2f(rz.from, rz.to .- rz.from))
     lims = ax.finallimits[]
     # restrict to y change

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -140,12 +140,23 @@ mutable struct RectangleZoom
     restrict_y::Bool
     from::Union{Nothing, Point2f}
     to::Union{Nothing, Point2f}
+    from_px::Union{Nothing, Point2f}
+    to_px::Union{Nothing, Point2f}
     rectnode::Observable{Rect2f}
 end
 
 function RectangleZoom(callback::Function; restrict_x=false, restrict_y=false)
-    return RectangleZoom(callback, Observable(false), restrict_x, restrict_y,
-                         nothing, nothing, Observable(Rect2f(0, 0, 1, 1)))
+    return RectangleZoom(
+        callback,
+        Observable(false),
+        restrict_x,
+        restrict_y,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        Observable(Rect2f(0, 0, 1, 1))
+    )
 end
 
 struct ScrollZoom


### PR DESCRIPTION
# Description

Changes the rectangle zoom behavior in Axis such that at very narrow rectangle selections, the narrow side is expanded to full width. This makes it much easier to narrow the field of view in one direction and is a common behavior in comparable tools.

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality.
