### PR TITLE
Add hide/show interactions to `Legend`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Added ability to hide and show individual plot elements by clicking their corresponding `Legend` entry.
 - Added `BezierPath` which can be constructed from SVG like command list, SVG string or from a `Polygon`.
   Added ability to use `BezierPath` and `Polgyon` as scatter markers.
   Replaced default symbol markers like `:cross` which converted to characters before with more precise `BezierPaths` and adjusted default markersize to 12.

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -214,9 +214,9 @@ function initialize_block!(leg::Legend,
                 justification = map(leg.labeljustification, e.labelhalign) do lj, lha
                     return lj isa Automatic ? lha : lj
                 end
-                label = Label(scene; text=e.label, textsize=e.labelsize, font=e.labelfont, justification=justification,
-                              color=e.labelcolor, halign=e.labelhalign, valign=e.labelvalign)
-                push!(etexts, label)
+                push!(etexts,
+                      Label(scene; text=e.label, textsize=e.labelsize, font=e.labelfont, justification=justification,
+                            color=e.labelcolor, halign=e.labelhalign, valign=e.labelvalign))
 
                 # create the patch rectangle
                 rect = Box(scene; color=e.patchcolor, strokecolor=e.patchstrokecolor, strokewidth=e.patchstrokewidth,
@@ -238,7 +238,7 @@ function initialize_block!(leg::Legend,
                 push!(eshades, shade)
 
                 # add mouseevent to hide/show elements
-                events = addmouseevents!(label.blockscene, label.layoutobservables.computedbbox)
+                events = addmouseevents!(blockscene, shade.layoutobservables.computedbbox)
                 onmouseleftdown(events) do event
                     for el in e.elements
                         el.plot.visible[] = !el.plot.visible[]

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -241,7 +241,10 @@ function initialize_block!(leg::Legend,
                 events = addmouseevents!(blockscene, shade.layoutobservables.computedbbox)
                 onmouseleftdown(events) do event
                     for el in e.elements
-                        el.plot.visible[] = !el.plot.visible[]
+                        isnothing(el) && continue
+                        if hasproperty(el.plot, :visible)
+                            el.plot.visible[] = !el.plot.visible[]
+                        end
                     end
                     shade.visible[] = !shade.visible[]
                     return Consume(true)

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -360,15 +360,15 @@ function LegendEntry(label::AbstractString, contentelement, legend; kwargs...)
 end
 
 
-function LineElement(plot; kwargs...)
+function LineElement(; plot=nothing, kwargs...)
     _legendelement(LineElement, plot, Attributes(kwargs))
 end
 
-function MarkerElement(plot; kwargs...)
+function MarkerElement(; plot=nothing, kwargs...)
     _legendelement(MarkerElement, plot, Attributes(kwargs))
 end
 
-function PolyElement(plot; kwargs...)
+function PolyElement(; plot=nothing, kwargs...)
     _legendelement(PolyElement, plot, Attributes(kwargs))
 end
 
@@ -418,7 +418,8 @@ function scalar_lift(attr, default)
 end
 
 function legendelements(plot::Union{Lines, LineSegments}, legend)
-    LegendElement[LineElement(plot,
+    LegendElement[LineElement(
+        plot = plot,
         color = scalar_lift(plot.color, legend.linecolor),
         linestyle = scalar_lift(plot.linestyle, legend.linestyle),
         linewidth = scalar_lift(plot.linewidth, legend.linewidth))]
@@ -426,7 +427,8 @@ end
 
 
 function legendelements(plot::Scatter, legend)
-    LegendElement[MarkerElement(plot,
+    LegendElement[MarkerElement(
+        plot = plot,
         color = scalar_lift(plot.color, legend.markercolor),
         marker = scalar_lift(plot.marker, legend.marker),
         markersize = scalar_lift(plot.markersize, legend.markersize),
@@ -436,7 +438,8 @@ function legendelements(plot::Scatter, legend)
 end
 
 function legendelements(plot::Union{Poly, Violin, BoxPlot, CrossBar, Density}, legend)
-    LegendElement[PolyElement(plot,
+    LegendElement[PolyElement(
+        plot = plot,
         color = scalar_lift(plot.color, legend.polycolor),
         strokecolor = scalar_lift(plot.strokecolor, legend.polystrokecolor),
         strokewidth = scalar_lift(plot.strokewidth, legend.polystrokewidth),
@@ -445,7 +448,11 @@ end
 
 function legendelements(plot::Band, legend)
     # there seems to be no stroke for Band, so we set it invisible
-    LegendElement[PolyElement(plot, polycolor = scalar_lift(plot.color, legend.polystrokecolor), polystrokecolor = :transparent, polystrokewidth = 0)]
+    LegendElement[PolyElement(
+        plot = plot,
+        polycolor = scalar_lift(plot.color, legend.polystrokecolor),
+        polystrokecolor = :transparent, polystrokewidth = 0
+    )]
 end
 
 # if there is no specific overload available, we go through the child plots and just stack

--- a/src/makielayout/blocks/slider.jl
+++ b/src/makielayout/blocks/slider.jl
@@ -3,7 +3,7 @@ function initialize_block!(sl::Slider)
     topscene = sl.blockscene
 
     sliderrange = sl.range
-    
+
     onany(sl.linewidth, sl.horizontal) do lw, horizontal
         if horizontal
             sl.layoutobservables.autosize[] = (nothing, Float32(lw))

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -899,17 +899,17 @@ end
 abstract type LegendElement end
 
 struct LineElement <: LegendElement
-    plot::AbstractPlot
+    plot::Optional{AbstractPlot}
     attributes::Attributes
 end
 
 struct MarkerElement <: LegendElement
-    plot::AbstractPlot
+    plot::Optional{AbstractPlot}
     attributes::Attributes
 end
 
 struct PolyElement <: LegendElement
-    plot::AbstractPlot
+    plot::Optional{AbstractPlot}
     attributes::Attributes
 end
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -899,14 +899,17 @@ end
 abstract type LegendElement end
 
 struct LineElement <: LegendElement
+    plot::AbstractPlot
     attributes::Attributes
 end
 
 struct MarkerElement <: LegendElement
+    plot::AbstractPlot
     attributes::Attributes
 end
 
 struct PolyElement <: LegendElement
+    plot::AbstractPlot
     attributes::Attributes
 end
 


### PR DESCRIPTION
# Description

Adds the ability to toggle plot elements by clicking on their label inside a `Legend`.
Mimics `gnuplot`s toggling behavior.

![demo_hideshow](https://user-images.githubusercontent.com/26469701/190265965-f0c66919-721d-478b-aa0a-33e22192c9ac.gif)


The functionality relies on `<:AbstractPlot` objects having a `visible` attribute. If there isn't one, we still put a shade above the legend entry.


## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
      I think this not needed.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
      Should we add a ref image that uses `pick` and generates a plot with missing elements? And can I even add one myself?
