### PR TITLE
fix autocomplete for scenes

### DIFF
--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -76,7 +76,7 @@ Base.merge(target::Attributes, args::Attributes...) = merge!(copy(target), args.
 
 @generated hasfield(x::T, ::Val{key}) where {T, key} = :($(key in fieldnames(T)))
 
-@inline function Base.getproperty(x::T, key::Symbol) where T <: Union{Attributes, Transformable}
+@inline function Base.getproperty(x::Union{Attributes, AbstractPlot}, key::Symbol)
     if hasfield(x, Val(key))
         getfield(x, key)
     else
@@ -84,7 +84,7 @@ Base.merge(target::Attributes, args::Attributes...) = merge!(copy(target), args.
     end
 end
 
-@inline function Base.setproperty!(x::T, key::Symbol, value) where T <: Union{Attributes, Transformable}
+@inline function Base.setproperty!(x::Union{Attributes, AbstractPlot}, key::Symbol, value)
     if hasfield(x, Val(key))
         setfield!(x, key, value)
     else

--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -264,6 +264,6 @@ function merge_attributes!(input::Attributes, theme::Attributes)
     return input
 end
 
-function Base.propertynames(x::T) where T <: Union{Attributes, Transformable}
+function Base.propertynames(x::Union{Attributes, AbstractPlot})
     return (keys(x.attributes)...,)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ using Makie: volume
         @test all(hi .>= (8,8,10))
     end
 
+    include("scenes.jl")
     include("conversions.jl")
     include("quaternions.jl")
     include("projection_math.jl")

--- a/test/scenes.jl
+++ b/test/scenes.jl
@@ -1,0 +1,4 @@
+@testset "Scenes" begin
+    scene = Scene()
+    @test propertynames(scene) == fieldnames(Scene)
+end

--- a/test/scenes.jl
+++ b/test/scenes.jl
@@ -2,7 +2,6 @@
     scene = Scene()
     @test propertynames(scene) == fieldnames(Scene)
     @testset "getproperty(scene, :$field)" for field in fieldnames(Scene)
-            @test getproperty(scene, field) !== missing # well, just don't error
-        end
+        @test getproperty(scene, field) !== missing # well, just don't error
     end
 end

--- a/test/scenes.jl
+++ b/test/scenes.jl
@@ -1,4 +1,8 @@
 @testset "Scenes" begin
     scene = Scene()
     @test propertynames(scene) == fieldnames(Scene)
+    @testset "getproperty(scene, :$field)" for field in fieldnames(Scene)
+            @test getproperty(scene, field) !== missing # well, just don't error
+        end
+    end
 end


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/2283
Overloading a fairly specific propertynames/getproperty for something generic as Transformable was a bit much.
I think the default fieldnames/getfield is just fine for `Scene`.
