### PR TITLE
Fix `visible=false` not picked up by `spy` in `GLMakie`

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -225,7 +225,7 @@ function draw_atomic(screen::GLScreen, scene::Scene, @nospecialize(x::Union{Scat
             # connect camera
             connect_camera!(gl_attributes, cam, get(gl_attributes, :space, :data))
             filter!(gl_attributes) do (k, v,)
-                k in (:color_map, :color, :color_norm, :scale, :model, :projectionview)
+                k in (:color_map, :color, :color_norm, :scale, :model, :projectionview, :visible)
             end
             if !(gl_attributes[:color][] isa AbstractVector{<: Number})
                 delete!(gl_attributes, :color_norm)

--- a/src/basic_recipes/spy.jl
+++ b/src/basic_recipes/spy.jl
@@ -21,7 +21,8 @@ $(ATTRIBUTES)
         colorrange = automatic,
         framecolor = :black,
         framesize = 1,
-        inspectable = theme(scene, :inspectable)
+        inspectable = theme(scene, :inspectable),
+        visible = theme(scene, :visible)
     )
 end
 

--- a/src/basic_recipes/spy.jl
+++ b/src/basic_recipes/spy.jl
@@ -75,8 +75,9 @@ function plot!(p::Spy)
         p,
         lift(first, xycol), color = lift(last, xycol),
         marker = marker, markersize = markersize, colorrange = p.colorrange,
-        colormap = p.colormap, inspectable = p.inspectable
+        colormap = p.colormap, inspectable = p.inspectable, visible = p.visible
     )
 
-    lines!(p, rect, color = p.framecolor, linewidth = p.framesize, inspectable = p.inspectable)
+    lines!(p, rect, color = p.framecolor, linewidth = p.framesize, inspectable = p.inspectable,
+           visible = p.visible)
 end


### PR DESCRIPTION
# Description

When using `GLMakie`, passing `visible=false` into `spy` did not have any effects, because the `visible` attribute was not forwarded when a `FastPixel` marker was used for `scatter`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)