### PR TITLE
fix changing input types

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -321,7 +321,7 @@ function plot!(scene::Union{Combined, SceneLike}, P::PlotFunc, attributes::Attri
     FinalType, argsconverted = apply_convert!(PreType, attributes, converted)
     converted_node = Observable(argsconverted)
     input_nodes =  convert.(Observable, args)
-    onany(kw_signal, lift(tuple, input_nodes...)) do kwargs, args
+    onany(kw_signal, input_nodes...) do kwargs, args...
         # do the argument conversion inside a lift
         result = convert_arguments(FinalType, args...; kwargs...)
         finaltype, argsconverted_ = apply_convert!(FinalType, attributes, result) # avoid a Core.Box (https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -18,6 +18,14 @@ using Makie:
 
 end
 
+@testset "changing input types" begin
+    input = Observable{Any}(decompose(Point2f, Circle(Point2f(0), 2f0)))
+    f, ax, pl = mesh(input)
+    m = Makie.triangle_mesh(Circle(Point2f(0), 1f0))
+    input[] = m
+    @test pl[1][] == m
+end
+
 @testset "to_vertices" begin
     X1 = [Point(rand(3)...) for i = 1:10]
     V1 = to_vertices(X1)


### PR DESCRIPTION
Incredibly enough, nobody seems to have run into this in a long time...
Seems like changing input types is pretty unpopular.
Changing types _after_ `convert_arguments` isn't expected to work, since that usually changes plot type, but changing the input type to `convert_arguments` should have been working. Might have regressed in some of the observable refactors.
