### PR TITLE
use premultiplied alpha for cairo argb surfaces

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -557,6 +557,14 @@ end
 
 regularly_spaced_array_to_range(arr::AbstractRange) = arr
 
+function premultiplied_rgba(a::AbstractArray{<:ColorAlpha})
+    map(premultiplied_rgba, a)
+end
+premultiplied_rgba(a::AbstractArray{<:Color}) = RGBA.(a)
+
+premultiplied_rgba(r::RGBA) = RGBA(r.r * r.alpha, r.g * r.alpha, r.b * r.alpha, r.alpha)
+premultiplied_rgba(c::Colorant) = premultiplied_rgba(RGBA(c))
+
 function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive::Union{Heatmap, Image}))
     ctx = screen.context
     image = primitive[3][]
@@ -627,10 +635,10 @@ function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive:
         Cairo.set_source_surface(ctx, s, 0, 0)
         p = Cairo.get_source(ctx)
         # this is needed to avoid blurry edges
-        Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+        # Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
         filt = interpolate ? Cairo.FILTER_BILINEAR : Cairo.FILTER_NEAREST
         Cairo.pattern_set_filter(p, filt)
-        Cairo.fill(ctx)
+        Cairo.paint(ctx)
         Cairo.restore(ctx)
     else
         # find projected image corners

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -635,10 +635,10 @@ function draw_atomic(scene::Scene, screen::CairoScreen, @nospecialize(primitive:
         Cairo.set_source_surface(ctx, s, 0, 0)
         p = Cairo.get_source(ctx)
         # this is needed to avoid blurry edges
-        # Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+        Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
         filt = interpolate ? Cairo.FILTER_BILINEAR : Cairo.FILTER_NEAREST
         Cairo.pattern_set_filter(p, filt)
-        Cairo.paint(ctx)
+        Cairo.fill(ctx)
         Cairo.restore(ctx)
     else
         # find projected image corners

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -111,7 +111,7 @@ function rgbatuple(c)
     return rgbatuple(colorant)
 end
 
-to_uint32_color(c) = reinterpret(UInt32, convert(ARGB32, c))
+to_uint32_color(c) = reinterpret(UInt32, convert(ARGB32, premultiplied_rgba(c)))
 
 ########################################
 #     Image/heatmap -> ARGBSurface     #


### PR DESCRIPTION
# Description

Cairo needs premultiplied alpha for image ARGB32 image surfaces, while everywhere else they don't. So we never noticed, which has been leading to all kinds of artifacts with transparent bitmaps. This should fix all of those hopefully.

Before:

```julia
CairoMakie.activate!()
x = collect(0:2.0)
y = collect(0:2.0)
z = x .* y'
f = Figure()
ax = Axis(f[1, 1], title="CairoMakie", backgroundcolor = :white)
heatmap!(ax, x, y, z, colormap=(:viridis, 0.5))
f
```

![grafik](https://user-images.githubusercontent.com/22495855/192511578-d0f2aa38-0d6a-44db-ba94-07d94273d686.png)

After:

![grafik](https://user-images.githubusercontent.com/22495855/192511597-e147ba14-1005-4301-b86a-96917eff9efb.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
