### PR TITLE
Improve valign halign observable types

### DIFF
--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -342,8 +342,8 @@ function _block(T::Type{<:Block}, fig_or_scene::Union{Figure, Scene},
     layout_height = Observable{Any}(nothing)
     layout_tellwidth = Observable(true)
     layout_tellheight = Observable(true)
-    layout_halign = Observable{Union{Symbol, Float64}}(:center)
-    layout_valign = Observable{Union{Symbol, Float64}}(:center)
+    layout_halign = Observable{GridLayoutBase.HorizontalAlignment}(:center)
+    layout_valign = Observable{GridLayoutBase.VerticalAlignment}(:center)
     layout_alignmode = Observable{Any}(Inside())
 
     lobservables = LayoutObservables(


### PR DESCRIPTION
# Description

Fixes #2280
Supersedes https://github.com/MakieOrg/Makie.jl/pull/2290

By just reusing the types I made once for easier conversion in GridLayoutBase, the axislegend error is fixed and the conversion path is clearly defined.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)