### PR TITLE
Add `stack=:dodge` and `stack=:waterfall` to `barplot` to allow easy waterfall charts creation

### DIFF
--- a/docs/examples/plotting_functions/barplot.md
+++ b/docs/examples/plotting_functions/barplot.md
@@ -82,6 +82,30 @@ barplot(tbl.x, tbl.height,
 \end{examplefigure}
 
 \begin{examplefigure}{}
+
+using CairoMakie
+CairoMakie.activate!() # hide
+Makie.inline!(true) # hide
+green, red = Makie.wong_colors()[[3, 6]]
+
+y = [3, 2, 1, -4, 1, -3, -2, 4, -1, 3]
+c = map(v -> v < 0 ? red : green, y) # color bars by sign
+
+fig = Figure()
+waterfall_ax = Axis(fig[1, 1], title="stack=:waterfall")
+barplot!(waterfall_ax, y, color=c, stack=:waterfall)
+
+x = repeat(1:2, inner=5)
+dodge = repeat(1:5, outer=2)
+
+dodge_ax = Axis(fig[2, 1], title="stack=:dodge")
+barplot!(dodge_ax, x, y, color=c, dodge=dodge, stack=:dodge)
+
+fig
+
+\end{examplefigure}
+
+\begin{examplefigure}{}
 ```julia
 colors = Makie.wong_colors()
 

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -11,13 +11,13 @@ using Makie: stack_grouped_from_to
     grp_stack2 = [3, 4,  3,  4]
     y2         = [2, 3, -3, -2]
 
-    from, to = stack_grouped_from_to(grp_stack1, y1, (; x1 = x1, grp_dodge1 = grp_dodge1))
+    from, to = stack_grouped_from_to(grp_stack1, y1, (; x1 = x1, grp_dodge1 = grp_dodge1, is_pos = y1 .> 0))
     from1 = [0.0, 2.0,  0.0, -3.0]
     to1   = [2.0, 5.0, -3.0, -5.0]
     @test from == from1
     @test to   == to1
 
-    from, to = stack_grouped_from_to(grp_stack2, y2, (; x2 = x2, grp_dodge2 = grp_dodge2))
+    from, to = stack_grouped_from_to(grp_stack2, y2, (; x2 = x2, grp_dodge2 = grp_dodge2, is_pos = y2 .> 0))
     from2 = [0.0,  0.0,  0.0,  0.0]
     to2   = [2.0,  3.0, -3.0, -2.0]
     @test from == from2
@@ -32,7 +32,7 @@ using Makie: stack_grouped_from_to
     from_test = [from1; from2][perm]
     to_test = [to1; to2][perm]
 
-    from, to = stack_grouped_from_to(grp_stack, y, (; x = x, grp_dodge = grp_dodge))
+    from, to = stack_grouped_from_to(grp_stack, y, (; x = x, grp_dodge = grp_dodge, is_pos = y .> 0))
     @test from == from_test
     @test to == to_test
 end


### PR DESCRIPTION
# Description

This PR implements the options

```julia
barplot(...; stack=:waterfall, ...)
barplot(...; stack=:dodge, ...)
```

I frequently use what some people call waterfall charts ([plotly](https://plotly.com/python/waterfall-charts/), [python](https://github.com/chrispaulca/waterfall)) to visualize individual positive and negative components that add up to a net result.

Suppose I have a vector `y` of such components and colors `c` to indicate the sign.

```julia
using CairoMakie
green, red = Makie.wong_colors()[[3, 6]]
y = [3, 2, 1, -4, 1, -3, -2, 4, -1, 3]
c = map(v -> v < 0 ? red : green, y) # color bars by sign
```

To achieve something similar with Makie I can recalculate *stacked* `y` values and corresponding `fillto` values.

```julia
y_waterfall = cumsum(y)
fill_waterfall = [0; y_waterfall[1:end-1]]
barplot(y_waterfall, color=c, fillto=fill_waterfall)
```
![waterfall](https://user-images.githubusercontent.com/16589944/193450815-cc565462-4258-4d90-a728-d4c939f73f86.png)

With this PR I can do the same thing with just:

```julia
barplot(y, color=c, stack=:waterfall)
```

Now suppose I want to compare multiple net results grouped by `x` with individual components grouped by `dodge`.

```julia
x = repeat(1:2, inner=5)
dodge = repeat(1:5, outer=2)
```

Here I have to preprocess my data in some way like this:

```julia
y_dodge = similar(y)
fill_dodge = similar(y)
for i in unique(x)
    inds = findall(==(i), x)
    y_dodge[inds] .= cumsum(y[inds])
    fill_dodge[inds] .= [0; y_dodge[inds][1:end-1]]
end
barplot(x, y_dodge, color=c, dodge=dodge, fillto=fill_dodge)
```
![stackdodge](https://user-images.githubusercontent.com/16589944/193450827-c4ae1514-6aa0-42d3-b5a1-e266f833fbae.png)


It would be even more cumbersome if `x` and `dodge` were not sorted properly. This PR enables me to just use:

```julia
barplot(x, y, color=c, dodge=dodge, stack=:dodge)
```

I'm not really sure about the name choices `:waterfall` and `:dodge` though and open to better suggestions.
Something similar was also asked for in https://discourse.julialang.org/t/waterfall-plot-makie-jl/79988.


## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
