### PR TITLE
Default to `px_per_unit=2` in CairoMakie

### DIFF
--- a/CairoMakie/src/CairoMakie.jl
+++ b/CairoMakie/src/CairoMakie.jl
@@ -31,7 +31,7 @@ include("primitives.jl")
 include("overrides.jl")
 
 function __init__()
-    activate!()
+    activate!(; px_per_unit=2)
 end
 
 include("precompiles.jl")


### PR DESCRIPTION
# Description

1 is way too blurry in my opinion. I generally use `px_per_unit=8` but the file sizes get a bit large, so I figured 2 was less controversial.

## Type of change

Delete options that do not apply:

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
