### PR TITLE
display png via html preserving size regardless of pixel density

### DIFF
--- a/CairoMakie/src/display.jl
+++ b/CairoMakie/src/display.jl
@@ -99,10 +99,21 @@ function Makie.backend_show(screen::Screen{IMAGE}, io::IO, ::MIME"image/png", sc
     return screen
 end
 
+function Makie.backend_show(screen::Screen{IMAGE}, io::IO, ::Union{MIME"text/html",MIME"application/vnd.webio.application+html",MIME"application/prs.juno.plotpane+html",MIME"juliavscode/html"}, scene::Scene)
+    w, h = widths(scene.px_area[])
+    cairo_draw(screen, scene)
+    png_io = IOBuffer()
+    Cairo.write_to_png(screen.surface, png_io)
+    b64 = Base64.base64encode(String(take!(png_io)))
+    print(io, "<img width=$w height=$h style='object-fit: contain;' src=\"data:image/png;base64, $(b64)\"/>")
+    return screen
+end
+
 # Disabling mimes and showable
 
 const DISABLED_MIMES = Set{String}()
 const SUPPORTED_MIMES = Set([
+    "text/html",
     "image/svg+xml",
     "application/pdf",
     "application/postscript",


### PR DESCRIPTION
# Description

Fixes issue https://github.com/MakieOrg/Makie.jl/issues/2264

## Type of change

Adds the ability to show scenes with `MIME"text/html"` and related types, using the png output and setting the correct width/height on the result.

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.

## Example images

This is in VSCode, displaying with different px_per_unit values.
Note that the relative size of the image doesn't change.
You can see that clarity is ideal at 2 px per unit on my retina screen, which makes sense. However, for zooming in, it can be beneficial to go higher.

<img width="439" alt="image" src="https://user-images.githubusercontent.com/22495855/196954927-6dd5600a-633e-4a31-a937-0a0e4fc7cd5c.png">
<img width="430" alt="image" src="https://user-images.githubusercontent.com/22495855/196955067-fed52a88-d7aa-420e-9eb1-28336764bb13.png">
<img width="433" alt="image" src="https://user-images.githubusercontent.com/22495855/196955117-dd2f04df-e852-4d55-bb71-da706cbc927f.png">
<img width="435" alt="image" src="https://user-images.githubusercontent.com/22495855/196955239-38de278c-4c2f-4980-909b-179331abf169.png">

Here's the same image shown with mime type svg, as you can see the apparent size is the same:

<img width="418" alt="image" src="https://user-images.githubusercontent.com/22495855/196955592-9673d14e-cee5-402b-a503-b164ea6a32f6.png">

When we display with mime type png like before, we can see that the image blows up in size, filling the available plot pane space. This is not desirable, as the pixel density becomes lower again (blurriness) and the text becomes too large:

<img width="667" alt="image" src="https://user-images.githubusercontent.com/22495855/196955928-9511f0e5-3460-4bad-8b97-a0779a36683f.png">

