### PR TITLE
skip legend entry if label is nothing

### DIFF
--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -196,6 +196,8 @@ function initialize_block!(leg::Legend,
                 # fill missing entry attributes with those carried by the legend
                 merge!(e.attributes, preset_attrs)
 
+                isnothing(e.label[]) && continue
+
                 # create the label
                 justification = map(leg.labeljustification, e.labelhalign) do lj, lha
                     return lj isa Automatic ? lha : lj
@@ -309,7 +311,7 @@ legendelements(le::LegendElement, legend) = LegendElement[le]
 legendelements(les::AbstractArray{<:LegendElement}, legend) = LegendElement[les...]
 
 
-function LegendEntry(label::AbstractString, contentelements::AbstractArray, legend; kwargs...)
+function LegendEntry(label::Optional{AbstractString}, contentelements::AbstractArray, legend; kwargs...)
     attrs = Attributes(label = label)
 
     kwargattrs = Attributes(kwargs)
@@ -319,7 +321,7 @@ function LegendEntry(label::AbstractString, contentelements::AbstractArray, lege
     LegendEntry(elems, attrs)
 end
 
-function LegendEntry(label::AbstractString, contentelement, legend; kwargs...)
+function LegendEntry(label::Optional{AbstractString}, contentelement, legend; kwargs...)
     attrs = Attributes(label = label)
 
     kwargattrs = Attributes(kwargs)
@@ -464,7 +466,7 @@ one content element. A content element can be an `AbstractPlot`, an array of
 """
 function Legend(fig_or_scene,
         contents::AbstractArray,
-        labels::AbstractArray{<:AbstractString},
+        labels::AbstractArray{<:Optional{AbstractString}},
         title::Optional{<:AbstractString} = nothing;
         kwargs...)
 


### PR DESCRIPTION
# Description

Implements #2300 

```julia
using CairoMakie
CairoMakie.activate!()

fig = Figure()
ax  = Axis(fig[1, 1])
scatter!(rand(3), rand(3), label=nothing)
lines!(rand(3), rand(3), label="line")
lines!(rand(3), rand(3), label="sers")
axislegend()

save("mwe.pdf", fig)
```
![image](https://user-images.githubusercontent.com/26469701/197050025-8d5b3968-2242-4acf-90e7-c32184cc4d91.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)