### PR TITLE
bring back inline! :(

### DIFF
--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -98,6 +98,8 @@ function device_scaling_factor(surface::Cairo.CairoSurface, sc::ScreenConfig)
     return is_vector_backend(surface) ? sc.pt_per_unit : sc.px_per_unit
 end
 
+const LAST_INLINE = Ref(true)
+
 """
     CairoMakie.activate!(; screen_config...)
 
@@ -108,7 +110,9 @@ Note, that the `screen_config` can also be set permanently via `Makie.set_theme!
 
 $(Base.doc(ScreenConfig))
 """
-function activate!(; type="png", screen_config...)
+function activate!(; inline=LAST_INLINE[], type="png", screen_config...)
+    Makie.inline!(inline)
+    LAST_INLINE[] = inline
     Makie.set_screen_config!(CairoMakie, screen_config)
     if type == "png"
         # So this is a bit counter intuitive, since the display system doesn't let us prefer a mime.

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -99,6 +99,8 @@ mutable struct ScreenConfig
     end
 end
 
+const LAST_INLINE = Ref(false)
+
 """
     GLMakie.activate!(; screen_config...)
 
@@ -109,10 +111,12 @@ Note, that the `screen_config` can also be set permanently via `Makie.set_theme!
 
 $(Base.doc(ScreenConfig))
 """
-function activate!(; screen_config...)
+function activate!(; inline=LAST_INLINE[], screen_config...)
     if haskey(screen_config, :pause_rendering)
         error("pause_rendering got renamed to pause_renderloop.")
     end
+    Makie.inline!(inline)
+    LAST_INLINE[] = inline
     Makie.set_screen_config!(GLMakie, screen_config)
     Makie.set_active_backend!(GLMakie)
     Makie.set_glyph_resolution!(Makie.High)

--- a/WGLMakie/src/WGLMakie.jl
+++ b/WGLMakie/src/WGLMakie.jl
@@ -66,6 +66,9 @@ const TEXTURE_ATLAS_CHANGED = Ref(false)
 function __init__()
     # Activate WGLMakie as backend!
     activate!()
+    # if there is a browserdisplay in stack, dont inline plots
+    browser_display = JSServe.BrowserDisplay() in Base.Multimedia.displays
+    Makie.inline!(!browser_display)
     # We need to update the texture atlas whenever it changes!
     # We do this in three_plot!
     Makie.font_render_callback!() do sd, uv

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,9 +1,3 @@
-function inline!(val=true)
-    @warn("inline!(false/true) has been deprecated, since it was never working properly.
-    Use `display([Backend.Screen()], figure)` to open a window,
-    and otherwise any plot on any backend should be inlined into the plotpane/output by default.")
-end
-
 function register_backend!(backend)
     @warn("`register_backend!` is an internal deprecated function, which shouldn't be used outside Makie.
     if you must really use this function, it's now `set_active_backend!(::Module)")


### PR DESCRIPTION
Guess we couldn't remove it yet, because I forgot the edge case of VSCode repl exposing a plotpane, but directly calling `display(eval_result)`, which made `Makie@0.18` always open a window, without a way to switch that behaviour.

We really want a better solution, especially since `inline!(false)` doesn't currently always open a window, since we can't figure out how to always open a window, when VSCode thinks everything should go into the plotpane ;) 
Fixes https://github.com/MakieOrg/Makie.jl/issues/2331