### PR TITLE
fix empty!(fig) and empty!(ax)

### DIFF
--- a/GLMakie/src/GLAbstraction/GLBuffer.jl
+++ b/GLMakie/src/GLAbstraction/GLBuffer.jl
@@ -19,7 +19,13 @@ mutable struct GLBuffer{T} <: GPUArray{T, 1}
     end
 end
 
-bind(buffer::GLBuffer) = glBindBuffer(buffer.buffertype, buffer.id)
+function bind(buffer::GLBuffer)
+    if buffer.id == 0
+        error("Binding freed GLBuffer{$(eltype(buffer))}")
+    end
+    glBindBuffer(buffer.buffertype, buffer.id)
+end
+
 #used to reset buffer target
 bind(buffer::GLBuffer, other_target) = glBindBuffer(buffer.buffertype, other_target)
 
@@ -142,6 +148,7 @@ end
 # could be a setindex! operation, with subarrays for buffers
 function unsafe_copy!(a::GLBuffer{T}, readoffset::Int, b::GLBuffer{T}, writeoffset::Int, len::Int) where T
     multiplicator = sizeof(T)
+    @assert a.id != 0 & b.id != 0
     glBindBuffer(GL_COPY_READ_BUFFER, a.id)
     glBindBuffer(GL_COPY_WRITE_BUFFER, b.id)
     glCopyBufferSubData(

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -13,7 +13,7 @@ function render(list::Vector{RenderObject{Pre}}) where Pre
     vertexarray = first(list).vertexarray
     program = vertexarray.program
     glUseProgram(program.id)
-    glBindVertexArray(vertexarray.id)
+    bind(vertexarray)
     for renderobject in list
         Bool(to_value(renderobject.uniforms[:visible])) || continue # skip invisible
         # make sure we only bind new programs and vertexarray when it is actually
@@ -24,7 +24,7 @@ function render(list::Vector{RenderObject{Pre}}) where Pre
                 program = renderobject.vertexarray.program
                 glUseProgram(program.id)
             end
-            glBindVertexArray(vertexarray.id)
+            bind(vertexarray)
         end
         for (key, value) in program.uniformloc
             if haskey(renderobject.uniforms, key)
@@ -75,7 +75,7 @@ function render(renderobject::RenderObject, vertexarray=renderobject.vertexarray
                 end
             end
         end
-        glBindVertexArray(vertexarray.id)
+        bind(vertexarray)
         renderobject.postrenderfunction()
         glBindVertexArray(0)
     end

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -264,6 +264,14 @@ function GLVertexArray(program::GLProgram, buffers::Buffer, triangles::AbstractV
     return obj
 end
 
+function bind(va::GLVertexArray)
+    if va.id == 0
+        error("Binding freed VertexArray")
+    end
+    glBindVertexArray(va.id)
+end
+
+
 function Base.show(io::IO, vao::GLVertexArray)
     show(io, vao.program)
     println(io, "GLVertexArray $(vao.id):")
@@ -384,29 +392,37 @@ end
 # OpenGL has the annoying habit of reusing id's when creating a new context
 # We need to make sure to only free the current one
 function unsafe_free(x::GLProgram)
+    x.id == 0 && return
     is_context_active(x.context) || return
     glDeleteProgram(x.id)
     return
 end
 
 function unsafe_free(x::GLBuffer)
+    # don't free if already freed
+    x.id == 0 && return
     # don't free from other context
     is_context_active(x.context) || return
     id = Ref(x.id)
     glDeleteBuffers(1, id)
+    x.id = 0
     return
 end
 
 function unsafe_free(x::Texture)
+    x.id == 0 && return
     is_context_active(x.context) || return
     id = Ref(x.id)
     glDeleteTextures(x.id)
+    x.id = 0
     return
 end
 
 function unsafe_free(x::GLVertexArray)
+    x.id == 0 && return
     is_context_active(x.context) || return
     id = Ref(x.id)
     glDeleteVertexArrays(1, id)
+    x.id = 0
     return
 end

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -280,10 +280,14 @@ end
 
 function project(scene::Scene, point::T) where T<:StaticVector
     cam = scene.camera
+    area = pixelarea(scene)[]
+    # TODO, I think we need  .+ minimum(area)
+    # Which would be semi breaking at this point though, I suppose
     return project(
         cam.projectionview[] *
         transformationmatrix(scene)[],
-        Vec2f(widths(pixelarea(scene)[])), Point(point)
+        Vec2f(widths(area)),
+        Point(point)
     )
 end
 

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1307,8 +1307,8 @@ function Base.delete!(ax::Axis, plot::AbstractPlot)
 end
 
 function Base.empty!(ax::Axis)
-    for plot in copy(ax.scene.plots)
-        delete!(ax, plot)
+    while !isempty(ax.scene.plots)
+        delete!(ax, ax.scene.plots[end])
     end
     ax
 end

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -122,9 +122,9 @@ function _chosen_limits(rz, ax)
     return r
 end
 
-function _selection_vertices(outer, inner)
+function _selection_vertices(ax_scene, outer, inner)
     _clamp(p, plow, phigh) = Point2f(clamp(p[1], plow[1], phigh[1]), clamp(p[2], plow[2], phigh[2]))
-
+    proj(point) = project(ax_scene, point) .+ minimum(ax_scene.px_area[])
     outer = positivize(outer)
     inner = positivize(inner)
 
@@ -137,8 +137,9 @@ function _selection_vertices(outer, inner)
     ibr = _clamp(bottomright(inner), obl, otr)
     itl = _clamp(topleft(inner), obl, otr)
     itr = _clamp(topright(inner), obl, otr)
-
-    return [obl, obr, otr, otl, ibl, ibr, itr, itl]
+    # We plot the selection vertices in blockscene, which is pixelspace, so we need to manually
+    # project the points to the space of `ax.scene`
+    return [proj(obl), proj(obr), proj(otr), proj(otl), proj(ibl), proj(ibr), proj(itr), proj(itl)]
 end
 
 function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -454,10 +454,12 @@ end
 
 function RectangleZoom(f::Function, ax::Axis; kw...)
     r = RectangleZoom(f; kw...)
-    selection_vertices = lift(_selection_vertices, ax.finallimits, r.rectnode)
+    selection_vertices = lift(_selection_vertices, Observable(ax.scene), ax.finallimits, r.rectnode)
     # manually specify correct faces for a rectangle with a rectangle hole inside
     faces = [1 2 5; 5 2 6; 2 3 6; 6 3 7; 3 4 7; 7 4 8; 4 1 8; 8 1 5]
-    mesh = mesh!(ax.scene, selection_vertices, faces, color = (:black, 0.2), shading = false,
+    # plot to blockscene, so ax.scene stays exclusive for user plots
+    # That's also why we need to pass `ax.scene` to _selection_vertices, so it can project to that space
+    mesh = mesh!(ax.blockscene, selection_vertices, faces, color = (:black, 0.2), shading = false,
                  inspectable = false, visible=r.active, transparency=true)
     # translate forward so selection mesh and frame are never behind data
     translate!(mesh, 0, 0, 100)

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -24,10 +24,10 @@ end
     sc = scatter!(ax, randn(100, 2))
     li = lines!(ax, randn(100, 2))
     hm = heatmap!(ax, randn(20, 20))
-    # axis contains 3 + 1 plots, one for the zoomrectangle
-    @test length(ax.scene.plots) == 4
-    delete!(ax, sc)
+    # axis contains 3 plots
     @test length(ax.scene.plots) == 3
+    delete!(ax, sc)
+    @test length(ax.scene.plots) == 2
     @test sc ∉ ax.scene.plots
     empty!(ax)
     @test isempty(ax.scene.plots)


### PR DESCRIPTION
- [x] throw error when binding free'd opengl resources. This can be silent on lots of platforms, might just work without problems, or can segfault. So, now we throw errors and should discover any problematic frees. Not erroring lead to #2365 and #2361
- [x] fix #2365, by checking for our only shared OpenGL resource (texture_atlas) explicitly in `destroy!(robj)`, which isn't elegant, but since we don't share any other OpenGL resource right now, it should suffice
- [x] fix #2361, which should have happend because we deleted the mesh from `rectanglezoom`  in `empty!(ax)`, which lead to undefined behavior since the axis was still updating the connected OpenGL resources

