### PR TITLE
A little experiment towards better clean up + more typed observables

### DIFF
--- a/MakieCore/Project.toml
+++ b/MakieCore/Project.toml
@@ -1,9 +1,10 @@
-authors = ["Simon Danisch"]
 name = "MakieCore"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
+authors = ["Simon Danisch"]
 version = "0.5.1"
 
 [deps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 
 [compat]

--- a/MakieCore/src/MakieCore.jl
+++ b/MakieCore/src/MakieCore.jl
@@ -8,7 +8,7 @@ end
 using Observables
 using Observables: to_value
 using Base: RefValue
-
+using GeometryBasics
 
 include("types.jl")
 include("attributes.jl")

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -42,16 +42,18 @@ Plots an image on range `x, y` (defaults to dimensions).
 """
 @recipe(Image, x, y, image) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+
         colormap = [:black, :white],
         colorrange = automatic,
         lowclip = automatic,
         highclip = automatic,
         nan_color = :transparent,
+
         interpolate = true,
-        fxaa = false,
-        inspectable = theme(scene, :inspectable),
-        space = :data
     )
 end
 
@@ -86,18 +88,20 @@ Plots a heatmap as an image on `x, y` (defaults to interpretation as dimensions)
 """
 @recipe(Heatmap, x, y, values) do scene
     Attributes(;
-        default_theme(scene)...,
-        colormap = theme(scene, :colormap),
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+
+        colormap = :viridis,
         colorrange = automatic,
         lowclip = automatic,
         highclip = automatic,
         nan_color = :transparent,
+
         linewidth = 0.0,
         interpolate = false,
         levels = 1,
-        fxaa = true,
-        inspectable = theme(scene, :inspectable),
-        space = :data
     )
 end
 
@@ -145,16 +149,22 @@ Available algorithms are:
 """
 @recipe(Volume, x, y, z, volume) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+        ssao = false,
+
         algorithm = :mip,
         isovalue = 0.5,
         isorange = 0.05,
         color = nothing,
-        colormap = theme(scene, :colormap),
+        colormap = :viridis,
         colorrange = (0, 1),
-        fxaa = true,
-        inspectable = theme(scene, :inspectable),
-        space = :data
+
+        diffuse = Vec3f(0.4),
+        specular = Vec3f(0.2),
+        shininess = 32f0,
     )
 end
 
@@ -198,19 +208,25 @@ Plots a surface, where `(x, y)`  define a grid whose heights are the entries in 
 """
 @recipe(Surface, x, y, z) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+        ssao = false,
+
         backlight = 0f0,
         color = nothing,
-        colormap = theme(scene, :colormap),
+        colormap = :viridis,
         colorrange = automatic,
         lowclip = automatic,
         highclip = automatic,
         nan_color = :transparent,
         shading = true,
-        fxaa = true,
         invert_normals = false,
-        inspectable = theme(scene, :inspectable),
-        space = :data
+
+        diffuse = Vec3f(0.4),
+        specular = Vec3f(0.2),
+        shininess = 32f0,
     )
 end
 
@@ -248,16 +264,18 @@ Creates a connected line plot for each element in `(x, y, z)`, `(x, y)` or `posi
 """
 @recipe(Lines, positions) do scene
     Attributes(;
-        default_theme(scene)...,
-        linewidth = theme(scene, :linewidth),
-        color = theme(scene, :linecolor),
-        colormap = theme(scene, :colormap),
+        fxaa = false,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+
+        linewidth = 1,
+        color = :black,
+        colormap = :viridis,
         colorrange = automatic,
         linestyle = nothing,
-        fxaa = false,
+
         cycle = [:color],
-        inspectable = theme(scene, :inspectable),
-        space = :data
     )
 end
 
@@ -335,20 +353,28 @@ Plots a 3D or 2D mesh. Supported `mesh_object`s include `Mesh` types from [Geome
 """
 @recipe(Mesh, mesh) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+        ssao = false,
+
         color = :black,
         backlight = 0f0,
-        colormap = theme(scene, :colormap),
+
+        colormap = :viridis,
         colorrange = automatic,
         lowclip = automatic,
         highclip = automatic,
         nan_color = :transparent,
+
+        diffuse = Vec3f(0.4),
+        specular = Vec3f(0.2),
+        shininess = 32f0,
+
         interpolate = true,
         shading = true,
-        fxaa = true,
-        inspectable = theme(scene, :inspectable),
         cycle = [:color => :patchcolor],
-        space = :data
     )
 end
 
@@ -391,12 +417,18 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
 """
 @recipe(Scatter, positions) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = false,
+        space = :data,
+        markerspace = :pixel,
+        overdraw = false,
+        depth_shift = 0f0,
+        ssao = false,
+
         color = theme(scene, :markercolor),
-        colormap = theme(scene, :colormap),
+        colormap = :viridis,
         colorrange = automatic,
-        marker = theme(scene, :marker),
-        markersize = theme(scene, :markersize),
+        marker = :circle,
+        markersize = 12,
 
         strokecolor = theme(scene, :markerstrokecolor),
         strokewidth = theme(scene, :markerstrokewidth),
@@ -408,11 +440,7 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
         transform_marker = false, # Applies the plots transformation to marker
         distancefield = nothing,
         uv_offset_width = (0.0, 0.0, 0.0, 0.0),
-        space = :data,
-        markerspace = :pixel,
-        fxaa = false,
         cycle = [:color],
-        inspectable = theme(scene, :inspectable)
     )
 end
 
@@ -458,18 +486,25 @@ Plots a mesh for each element in `(x, y, z)`, `(x, y)`, or `positions` (similar 
 """
 @recipe(MeshScatter, positions) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+        depth_shift = 0f0,
+        ssao = false,
+
         color = :black,
-        colormap = theme(scene, :colormap),
+        colormap = :viridis,
         colorrange = automatic,
+
+        diffuse = Vec3f(0.4),
+        specular = Vec3f(0.2),
+        shininess = 32f0,
+
         marker = :Sphere,
         markersize = 0.1,
         rotations = 0.0,
         backlight = 0f0,
-        space = :data,
         shading = true,
-        fxaa = true,
-        inspectable = theme(scene, :inspectable),
         cycle = [:color],
     )
 end
@@ -514,9 +549,15 @@ Plots one or multiple texts passed via the `text` keyword.
 """
 @recipe(Text, positions) do scene
     Attributes(;
-        default_theme(scene)...,
+        fxaa = false,
+        space = :data,
+        markerspace = :pixel,
+        overdraw = false,
+        depth_shift = 0f0,
+
         color = theme(scene, :textcolor),
-        font = theme(scene, :font),
+        font = "TeX Gyre Heros Makie",
+
         strokecolor = (:black, 0.0),
         strokewidth = 0,
         align = (:left, :bottom),
@@ -525,11 +566,8 @@ Plots one or multiple texts passed via the `text` keyword.
         position = (0.0, 0.0),
         justification = automatic,
         lineheight = 1.0,
-        space = :data,
-        markerspace = :pixel,
         offset = (0.0, 0.0),
         word_wrap_width = -1,
-        inspectable = theme(scene, :inspectable)
     )
 end
 
@@ -577,22 +615,22 @@ Plots polygons, which are defined by
 """
 @recipe(Poly) do scene
     Attributes(;
+        fxaa = true,
+        space = :data,
+        overdraw = false,
+
         color = theme(scene, :patchcolor),
-        visible = theme(scene, :visible),
         strokecolor = theme(scene, :patchstrokecolor),
-        colormap = theme(scene, :colormap),
+        strokewidth = theme(scene, :patchstrokewidth),
+
+        colormap = :viridis,
         colorrange = automatic,
         lowclip = automatic,
         highclip = automatic,
         nan_color = :transparent,
-        strokewidth = theme(scene, :patchstrokewidth),
+
         shading = false,
-        fxaa = true,
         linestyle = nothing,
-        overdraw = false,
-        transparency = false,
         cycle = [:color => :patchcolor],
-        inspectable = theme(scene, :inspectable),
-        space = :data
     )
 end

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -55,8 +55,8 @@ end
 # Since we can use Combined like a scene in some circumstances, we define this alias
 theme(x::SceneLike, args...) = theme(x.parent, args...)
 theme(x::AbstractScene) = x.theme
-theme(x::AbstractScene, key) = deepcopy(x.theme[key])
-theme(x::AbstractPlot, key) = deepcopy(x.attributes[key])
+theme(x::AbstractScene, key) = to_value(x.theme[key])
+theme(x::AbstractPlot, key) = to_value(attributes(x)[key])
 
 Attributes(x::AbstractPlot) = attributes(x)
 

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -58,7 +58,7 @@ theme(x::AbstractScene) = x.theme
 theme(x::AbstractScene, key) = deepcopy(x.theme[key])
 theme(x::AbstractPlot, key) = deepcopy(x.attributes[key])
 
-Attributes(x::AbstractPlot) = x.attributes
+Attributes(x::AbstractPlot) = attributes(x)
 
 default_theme(scene, T) = Attributes()
 

--- a/MakieCore/src/types.jl
+++ b/MakieCore/src/types.jl
@@ -46,8 +46,15 @@ const SceneLike = Union{AbstractScene, ScenePlot}
 Main structure for holding attributes, for theming plots etc!
 Will turn all values into observables, so that they can be updated.
 """
-struct Attributes
-    attributes::Dict{Symbol, Observable}
+mutable struct Attributes
+    attributes::Dict{Symbol, Any}
+    observables::Dict{Symbol, Observable}
+    convert::Bool
+    plotkey::Symbol
+end
+
+function Attributes(attr::Dict{Symbol, Any})
+    Attributes(attr, Dict{Symbol, Observable}(), false, :nothing)
 end
 
 struct Combined{Typ, T} <: ScenePlot{Typ}

--- a/MakieCore/src/types.jl
+++ b/MakieCore/src/types.jl
@@ -64,6 +64,21 @@ struct Combined{Typ, T} <: ScenePlot{Typ}
     input_args::Tuple
     converted::Tuple
     plots::Vector{AbstractPlot}
+
+    model::Observable{Mat4f}
+    inspectable::Observable{Bool}
+    transparency::Observable{Bool}
+    visible::Observable{Bool}
+end
+
+function Combined{Typ, T}(
+        parent, transformation, attributes, input_args, converted, plots;
+        inspectable=true, transparency=false, visible=true) where {Typ, T}
+
+    return Combined{Typ, T}(
+        parent, transformation, attributes, input_args, converted, plots,
+        transformation.model, inspectable, transparency, visible)
+
 end
 
 function Base.show(io::IO, plot::Combined)

--- a/src/basic_recipes/arrows.jl
+++ b/src/basic_recipes/arrows.jl
@@ -22,29 +22,24 @@ grid.
 $(ATTRIBUTES)
 """
 @recipe(Arrows, points, directions) do scene
-    attr = merge!(
-        default_theme(scene),
-        Attributes(
-            arrowhead = automatic,
-            arrowtail = automatic,
-            color = :black,
-            linecolor = automatic,
-            arrowsize = automatic,
-            linestyle = nothing,
-            align = :origin,
-            normalize = false,
-            lengthscale = 1f0,
-            colormap = theme(scene, :colormap),
-            quality = 32,
-            inspectable = theme(scene, :inspectable),
-            markerspace = :pixel,
-        )
+    Attributes(;
+        arrowhead = automatic,
+        arrowtail = automatic,
+        color = :black,
+        linecolor = automatic,
+        arrowcolor = automatic,
+        arrowsize = automatic,
+        linewidth = automatic,
+        linestyle = nothing,
+        align = :origin,
+        normalize = false,
+        lengthscale = 1f0,
+        colormap = :viridis,
+        quality = 32,
+        markerspace = :pixel,
+
+        fxaa = automatic,
     )
-    attr[:fxaa] = automatic
-    attr[:linewidth] = automatic
-    # connect arrow + linecolor by default
-    get!(attr, :arrowcolor, attr[:linecolor])
-    attr
 end
 
 # For the matlab/matplotlib users

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -73,7 +73,7 @@ $(ATTRIBUTES)
             rotation = axisnames_rotation3d,
             textsize = (6.0, 6.0, 6.0),
             align = axisnames_align3d,
-            font = lift(to_3tuple, theme(scene, :font)),
+            font = to_3tuple(theme(scene, :font)),
             gap = 3
         ),
 
@@ -87,7 +87,7 @@ $(ATTRIBUTES)
             textsize = (tsize, tsize, tsize),
             align = tickalign3d,
             gap = 3,
-            font = lift(to_3tuple, theme(scene, :font)),
+            font = to_3tuple(theme(scene, :font)),
         ),
 
         frame = Attributes(

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -16,12 +16,9 @@ The attribute levels can be either
 $(ATTRIBUTES)
 """
 @recipe(Contour) do scene
-    default = default_theme(scene)
-    # pop!(default, :color)
     Attributes(;
-        default...,
         color = nothing,
-        colormap = theme(scene, :colormap),
+        colormap = :viridis,
         colorrange = Makie.automatic,
         levels = 5,
         linewidth = 1.0,

--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -11,24 +11,24 @@ convert_arguments(::Type{<: Poly}, m::GeometryBasics.GeometryPrimitive) = (m,)
 function plot!(plot::Poly{<: Tuple{Union{GeometryBasics.Mesh, GeometryPrimitive}}})
     mesh!(
         plot, lift(triangle_mesh, plot[1]),
-        color = plot[:color],
-        colormap = plot[:colormap],
-        colorrange = plot[:colorrange],
-        lowclip = plot[:lowclip],
-        highclip = plot[:highclip],
-        nan_color = plot[:nan_color],
-        shading = plot[:shading],
-        visible = plot[:visible],
-        overdraw = plot[:overdraw],
-        inspectable = plot[:inspectable],
-        transparency = plot[:transparency],
-        space = plot[:space]
+        color = plot.color,
+        colormap = plot.colormap,
+        colorrange = plot.colorrange,
+        lowclip = plot.lowclip,
+        highclip = plot.highclip,
+        nan_color = plot.nan_color,
+        shading = plot.shading,
+        visible = plot.visible,
+        overdraw = plot.overdraw,
+        inspectable = plot.inspectable,
+        transparency = plot.transparency,
+        space = plot.space
     )
     wireframe!(
         plot, plot[1],
-        color = plot[:strokecolor], linestyle = plot[:linestyle], space = plot[:space],
-        linewidth = plot[:strokewidth], visible = plot[:visible], overdraw = plot[:overdraw],
-        inspectable = plot[:inspectable], transparency = plot[:transparency]
+        color = plot.strokecolor, linestyle = plot.linestyle, space = plot.space,
+        linewidth = plot.strokewidth, visible = plot.visible, overdraw = plot.overdraw,
+        inspectable = plot.inspectable, transparency = plot.transparency
     )
 end
 

--- a/src/interaction/observables.jl
+++ b/src/interaction/observables.jl
@@ -1,6 +1,11 @@
 const lift = map
 
-Base.close(obs::Observable) = empty!(obs.listeners)
+function Base.close(obs::Observable)
+    for input in obs.inputs
+        off(input)
+    end
+    empty!(obs.listeners)
+end
 
 """
 Observables.off but without throwing an error

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -1,20 +1,21 @@
 function default_theme(scene)
     Attributes(
         # color = theme(scene, :color),
-        linewidth = 1,
+        inspectable = theme(scene, :inspectable),
         transformation = automatic,
         model = automatic,
-        visible = true,
         transparency = false,
+        visible = true,
         overdraw = false,
+        space = :data,
+        nan_color = RGBAf(0,0,0,0),
+
+        linewidth = 1,
         diffuse = Vec3f(0.4),
         specular = Vec3f(0.2),
         shininess = 32f0,
-        nan_color = RGBAf(0,0,0,0),
         ssao = false,
-        inspectable = theme(scene, :inspectable),
         depth_shift = 0f0,
-        space = :data
     )
 end
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -18,8 +18,6 @@ function default_theme(scene)
     )
 end
 
-
-
 function color_and_colormap!(plot, intensity = plot[:color])
     if isa(intensity[], AbstractArray{<: Number})
         haskey(plot, :colormap) || error("Plot $(typeof(plot)) needs to have a colormap to allow the attribute color to be an array of numbers")
@@ -81,7 +79,7 @@ function calculated_attributes!(::Type{<: Scatter}, plot)
 
     replace_automatic!(plot, :marker_offset) do
         # default to middle
-        lift(x-> to_2d_scale(map(x-> x .* -0.5f0, x)), plot[:markersize])
+        return lift(x-> to_2d_scale(map(x-> x .* -0.5f0, x)), plot.markersize)
     end
 
     replace_automatic!(plot, :markerspace) do
@@ -102,8 +100,10 @@ function calculated_attributes!(::Type{T}, plot) where {T<:Union{Lines, LineSegm
     if T <: LineSegments
         for attr in [:color, :linewidth]
             # taken from @edljk  in PR #77
+
             if haskey(plot, attr) && isa(plot[attr][], AbstractVector) && (length(pos) ÷ 2) == length(plot[attr][])
-                plot[attr] = lift(plot[attr]) do cols
+                obs = pop!(plot, attr)
+                plot[attr] = lift(obs) do cols
                     map(i -> cols[(i + 1) ÷ 2], 1:(length(cols) * 2))
                 end
             end
@@ -231,6 +231,7 @@ function (PlotType::Type{<: AbstractPlot{Typ}})(scene::SceneLike, attributes::At
     end
     # create the plot, with the full attributes, the input signals, and the final signals.
     plot_obj = FinalType(scene, transformation, plot_attributes, input, seperate_tuple(args))
+
     calculated_attributes!(plot_obj)
     plot_obj
 end

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -187,7 +187,8 @@ function with_theme(f, theme = Theme(); kwargs...)
     end
 end
 
-theme(::Nothing, key::Symbol) = deepcopy(current_default_theme()[key])
+
+theme(::Nothing, key::Symbol) = current_default_theme()[key]
 
 """
     update_theme!(with_theme::Theme; kwargs...)

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -59,8 +59,11 @@ value is nothing
 function replace_automatic!(f, dict, key)
     haskey(dict, key) || return (dict[key] = f())
     val = dict[key]
-    to_value(val) == automatic && return (dict[key] = f())
-    val
+    if to_value(val) == automatic
+        delete!(dict, key)
+        dict[key] = f()
+    end
+    return val
 end
 
 is_unitrange(x) = (false, 0:0)


### PR DESCRIPTION
I rediscovered while looking at the GLMakie backend code, that we actually are already pretty strict about atomic plot attributes, in the sense that the output type of `convert_attributes` is not allowed to change. So, e.g. if we set color to a single color, we may never change it to an array of colors, alowing to restrict color to `Observable{RGBAf}`.

So, at least for atomic plots, we should be able to always create strictly typed observables of the type `typeof(conver_arguments(...))`.
In this PR, I'm rewriting `Attributes` to lazily convert via `convert_attributes` to always return a typed observable...
Still needs to be optional though since `Attributes` are used for so many things, but with a bit larger refactor, we may be able to flip the switch on that.
Still an experiment, but may greatly help with not doing conversions multiple times, have better typed Observables and have better ways to completely clean up the observable connections of a plot.
If this works out well, we may want to make our own Attribute type for atomic plots (which then can also finally lock in the set of allowed attributes), and use a simpler type for the rest of the `Attribute` uses.
