### PR TITLE
Remove stencil buffer

### DIFF
--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -68,7 +68,6 @@ function OIT_postprocessor(framebuffer, shader_cache)
         # Blend transparent onto opaque
         glDrawBuffer(color_id)
         glViewport(0, 0, w, h)
-        # glDisable(GL_STENCIL_TEST)
         GLAbstraction.render(pass)
     end
 
@@ -162,7 +161,6 @@ function ssao_postprocessor(framebuffer, shader_cache)
         # SSAO - calculate occlusion
         glDrawBuffer(normal_occ_id)  # occlusion buffer
         glViewport(0, 0, w, h)
-        # glDisable(GL_STENCIL_TEST)
         glEnable(GL_SCISSOR_TEST)
 
         for (screenid, scene) in screen.screens

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -68,7 +68,7 @@ function OIT_postprocessor(framebuffer, shader_cache)
         # Blend transparent onto opaque
         glDrawBuffer(color_id)
         glViewport(0, 0, w, h)
-        glDisable(GL_STENCIL_TEST)
+        # glDisable(GL_STENCIL_TEST)
         GLAbstraction.render(pass)
     end
 
@@ -162,7 +162,7 @@ function ssao_postprocessor(framebuffer, shader_cache)
         # SSAO - calculate occlusion
         glDrawBuffer(normal_occ_id)  # occlusion buffer
         glViewport(0, 0, w, h)
-        glDisable(GL_STENCIL_TEST)
+        # glDisable(GL_STENCIL_TEST)
         glEnable(GL_SCISSOR_TEST)
 
         for (screenid, scene) in screen.screens

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -10,13 +10,13 @@ function setup!(screen)
                 a = pixelarea(scene)[]
                 rt = (minimum(a)..., widths(a)...)
                 glViewport(rt...)
-                bits = GL_STENCIL_BUFFER_BIT
-                glClearStencil(id)
+                # bits = GL_STENCIL_BUFFER_BIT
+                # glClearStencil(id)
                 if scene.clear
                     c = scene.backgroundcolor[]
                     glScissor(rt...)
                     glClearColor(red(c), green(c), blue(c), alpha(c))
-                    bits |= GL_COLOR_BUFFER_BIT
+                    bits = GL_COLOR_BUFFER_BIT
                     glClear(bits)
                 end
             end
@@ -55,13 +55,13 @@ function render_frame(screen::Screen; resize_buffers=true)
     w, h = size(fb)
 
     # prepare stencil (for sub-scenes)
-    glEnable(GL_STENCIL_TEST)
+    # glEnable(GL_STENCIL_TEST)
     glBindFramebuffer(GL_FRAMEBUFFER, fb.id)
     glDrawBuffers(length(fb.render_buffer_ids), fb.render_buffer_ids)
-    glEnable(GL_STENCIL_TEST)
-    glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
-    glStencilMask(0xff)
-    glClearStencil(0)
+    # glEnable(GL_STENCIL_TEST)
+    # glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
+    # glStencilMask(0xff)
+    # glClearStencil(0)
     glClearColor(0, 0, 0, 0)
     glClear(GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT | GL_COLOR_BUFFER_BIT)
 
@@ -71,8 +71,8 @@ function render_frame(screen::Screen; resize_buffers=true)
 
     # render with SSAO
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE)
-    glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
-    glStencilMask(0x00)
+    # glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
+    # glStencilMask(0x00)
     GLAbstraction.render(screen) do robj
         return !Bool(robj[:transparency][]) && Bool(robj[:ssao][])
     end
@@ -81,14 +81,14 @@ function render_frame(screen::Screen; resize_buffers=true)
 
     # render no SSAO
     glDrawBuffers(2, [GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1])
-    glEnable(GL_STENCIL_TEST)
-    glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
-    glStencilMask(0x00)
+    # glEnable(GL_STENCIL_TEST)
+    # glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
+    # glStencilMask(0x00)
     # render all non ssao
     GLAbstraction.render(screen) do robj
         return !Bool(robj[:transparency][]) && !Bool(robj[:ssao][])
     end
-    glDisable(GL_STENCIL_TEST)
+    # glDisable(GL_STENCIL_TEST)
 
     # TRANSPARENT RENDER
     # clear sums to 0
@@ -101,14 +101,14 @@ function render_frame(screen::Screen; resize_buffers=true)
     glClear(GL_COLOR_BUFFER_BIT)
     # draw
     glDrawBuffers(3, [GL_COLOR_ATTACHMENT2, GL_COLOR_ATTACHMENT1, GL_COLOR_ATTACHMENT3])
-    glEnable(GL_STENCIL_TEST)
-    glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
-    glStencilMask(0x00)
+    # glEnable(GL_STENCIL_TEST)
+    # glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE)
+    # glStencilMask(0x00)
     # Render only transparent objects
     GLAbstraction.render(screen) do robj
         return Bool(robj[:transparency][])
     end
-    glDisable(GL_STENCIL_TEST)
+    # glDisable(GL_STENCIL_TEST)
 
     # TRANSPARENT BLEND
     screen.postprocessors[2].render(screen)
@@ -141,14 +141,14 @@ function GLAbstraction.render(filter_elem_func, screen::Screen)
             scene.visible[] || continue
             a = pixelarea(scene)[]
             glViewport(minimum(a)..., widths(a)...)
-            if scene.clear
-                glStencilFunc(GL_EQUAL, screenid, 0xff)
-            else
-                # if we don't clear, that means we have a screen that is overlaid
-                # on top of another, which means it doesn't have a stencil value
-                # so we can't do the stencil test
-                glStencilFunc(GL_ALWAYS, screenid, 0xff)
-            end
+            # if scene.clear
+            #     glStencilFunc(GL_EQUAL, screenid, 0xff)
+            # else
+            #     # if we don't clear, that means we have a screen that is overlaid
+            #     # on top of another, which means it doesn't have a stencil value
+            #     # so we can't do the stencil test
+            #     glStencilFunc(GL_ALWAYS, screenid, 0xff)
+            # end
 
             render(elem)
         end

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -1,4 +1,4 @@
-const ScreenID = UInt8
+const ScreenID = UInt16
 const ZIndex = Int
 # ID, Area, clear, is visible, background color
 const ScreenArea = Tuple{ScreenID, Scene}


### PR DESCRIPTION
# Description

I wanted to give fixing the scene id problem (#665) an attempt and tried removing all the stencil code bits to see what actually breaks... which seems to be nothing? Locally all tests still passed. I also tested all combinations of ssao, fxaa and transparancy with

```julia
fig = Figure()
ax = Axis(fig[1, 1])
scatter!(ax, rand(10000), color = rand(RGBf, 10000))
top = campixel(ax.blockscene)
text!(
    top, Point2f(400), text = "Testing", strokewidth=2f0, strokecolor = :white, 
    ssao = true, fxaa = !true, transparency = true
)
```

and get the same ordering as before.

From my understanding the stencil code restricts rendering to scene areas which is also what `glViewport` and `glScissor` do... So I guess it's redundant? Translating Axis and LScene content is still correctly cut off at least.

Fixes #665. (Well not yet but we can remove/freely type screenid if we remove stencil tests)


