### PR TITLE
clean up interactions + remove close(obs)

### DIFF
--- a/src/interaction/observables.jl
+++ b/src/interaction/observables.jl
@@ -1,7 +1,5 @@
 const lift = map
 
-Base.close(obs::Observable) = empty!(obs.listeners)
-
 """
 Observables.off but without throwing an error
 """

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -71,13 +71,9 @@ function register_events!(ax, scene)
 
     register_interaction!(ax, :limitreset, LimitReset())
 
-    register_interaction!(ax,
-        :scrollzoom,
-        ScrollZoom(0.1, Ref{Any}(nothing), Ref{Any}(0), Ref{Any}(0), 0.2))
+    register_interaction!(ax, :scrollzoom, ScrollZoom(0.1, 0.2))
 
-    register_interaction!(ax,
-        :dragpan,
-        DragPan(Ref{Any}(nothing), Ref{Any}(0), Ref{Any}(0), 0.2))
+    register_interaction!(ax, :dragpan, DragPan(0.2))
 
     return
 end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -150,18 +150,27 @@ end
 
 struct ScrollZoom
     speed::Float32
-    reset_timer::Ref{Any}
-    prev_xticklabelspace::Ref{Any}
-    prev_yticklabelspace::Ref{Any}
+    reset_timer::RefValue{Union{Nothing, Timer}}
+    prev_xticklabelspace::RefValue{Float64}
+    prev_yticklabelspace::RefValue{Float64}
     reset_delay::Float32
 end
 
+function ScrollZoom(speed, reset_delay)
+    return ScrollZoom(speed, RefValue{Union{Nothing, Timer}}(nothing), RefValue{Float64}(0), RefValue{Float64}(0), reset_delay)
+end
+
 struct DragPan
-    reset_timer::Ref{Any}
-    prev_xticklabelspace::Ref{Any}
-    prev_yticklabelspace::Ref{Any}
+    reset_timer::RefValue{Union{Nothing, Timer}}
+    prev_xticklabelspace::RefValue{Float64}
+    prev_yticklabelspace::RefValue{Float64}
     reset_delay::Float32
 end
+
+function DragPan(reset_delay)
+    return DragPan(RefValue{Union{Nothing, Timer}}(nothing), RefValue{Float64}(0), RefValue{Float64}(0), reset_delay)
+end
+
 
 struct DragRotate
 end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -151,24 +151,24 @@ end
 struct ScrollZoom
     speed::Float32
     reset_timer::RefValue{Union{Nothing, Timer}}
-    prev_xticklabelspace::RefValue{Float64}
-    prev_yticklabelspace::RefValue{Float64}
+    prev_xticklabelspace::RefValue{Union{Automatic, Float64}}
+    prev_yticklabelspace::RefValue{Union{Automatic, Float64}}
     reset_delay::Float32
 end
 
 function ScrollZoom(speed, reset_delay)
-    return ScrollZoom(speed, RefValue{Union{Nothing, Timer}}(nothing), RefValue{Float64}(0), RefValue{Float64}(0), reset_delay)
+    return ScrollZoom(speed, RefValue{Union{Nothing, Timer}}(nothing), RefValue{Union{Automatic, Float64}}(0.0), RefValue{Union{Automatic, Float64}}(0.0), reset_delay)
 end
 
 struct DragPan
     reset_timer::RefValue{Union{Nothing, Timer}}
-    prev_xticklabelspace::RefValue{Float64}
-    prev_yticklabelspace::RefValue{Float64}
+    prev_xticklabelspace::RefValue{Union{Automatic, Float64}}
+    prev_yticklabelspace::RefValue{Union{Automatic, Float64}}
     reset_delay::Float32
 end
 
 function DragPan(reset_delay)
-    return DragPan(RefValue{Union{Nothing, Timer}}(nothing), RefValue{Float64}(0), RefValue{Float64}(0), reset_delay)
+    return DragPan(RefValue{Union{Nothing, Timer}}(nothing), RefValue{Union{Automatic, Float64}}(0.0), RefValue{Union{Automatic, Float64}}(0.0), reset_delay)
 end
 
 


### PR DESCRIPTION
While cleaning up our Observable handling, I noticed that close isn't used anymore.
When investigating the usage of `close(obs)`, I also tripped over these abstractly typed interactions, which probably isn't super bad, but can also not be good since they're somewhat performance sensitive.