### PR TITLE
changes to GLMakie to get drawing into a GtkGLArea working

### DIFF
--- a/GLMakie/src/GLAbstraction/GLTexture.jl
+++ b/GLMakie/src/GLAbstraction/GLTexture.jl
@@ -532,8 +532,12 @@ function set_parameters(t::Texture{T, N}, params::TextureParameters=t.parameters
     if N >= 3 && !is_texturearray(t) # for texture arrays, third dimension can not be set
         push!(result, (GL_TEXTURE_WRAP_R, data[:repeat][3]))
     end
-    if GLFW.ExtensionSupported("GL_ARB_texture_filter_anisotropic")
-        push!(result, (GL_TEXTURE_MAX_ANISOTROPY_EXT, params.anisotropic))
+    try
+        if GLFW.ExtensionSupported("GL_ARB_texture_filter_anisotropic")
+            push!(result, (GL_TEXTURE_MAX_ANISOTROPY_EXT, params.anisotropic))
+        end
+    catch e
+        e.code == GLFW.NO_CURRENT_CONTEXT || rethrow(e)
     end
     t.parameters = params
     set_parameters(t, result)

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -269,7 +269,7 @@ end
 Sets up a Postprocessor which copies the color buffer to the screen. Used as a
 final step for displaying the screen.
 """
-function to_screen_postprocessor(framebuffer, shader_cache)
+function to_screen_postprocessor(framebuffer, shader_cache, default_id = 0)
     # draw color buffer
     shader = LazyShader(
         shader_cache,
@@ -287,7 +287,7 @@ function to_screen_postprocessor(framebuffer, shader_cache)
         w, h = size(fb)
 
         # transfer everything to the screen
-        glBindFramebuffer(GL_FRAMEBUFFER, 0)
+        glBindFramebuffer(GL_FRAMEBUFFER, default_id)
         glViewport(0, 0, w, h)
         glClear(GL_COLOR_BUFFER_BIT)
         GLAbstraction.render(pass) # copy postprocess


### PR DESCRIPTION
# Description

I'm working with @SimonDanisch to get GLMakie to draw into a Gtk4 window. This branch has a couple of changes that I had to make to GLMakie to get a plot to appear.

1. GLFW threw an error when calling set_parameters() on a Texture while setting up a framebuffer:
```
ERROR: GLFWError (NO_CURRENT_CONTEXT): Cannot query extension without a current OpenGL or OpenGL ES context
```
Here I just added a try/catch to ignore that error. There's probably a more correct approach.

2. GtkGLArea doesn't use 0 for its default framebuffer ID. I learned about this here:
https://stackoverflow.com/questions/62422683/framebuffer-issue-render-to-texture-with-gtk3-glarea-vs-glfw-identical-opengl

In to_screen_postprocessor(), I added an argument that lets you set default_ID. The default is 0, so GLMakie works fine, but in my code I've hard coded this to 2, which works on my laptop. It would be better to query this number at the beginning of rendering. I suspect if we try to have multiple windows this will become important.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
