### PR TITLE
broadcast replaces deprecated method for quantile

### DIFF
--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -99,7 +99,7 @@ function fit_qqplot(x, y; qqline = :none)
         itc, slp = hcat(fill!(similar(h.qx), 1), h.qx) \ h.qy
         ys = @. slp * xs + itc
     else # if qqline == :fitrobust
-        quantx, quanty = quantile(x, [0.25, 0.75]), quantile(y, [0.25, 0.75])
+        quantx, quanty = quantile.(Ref(x), [0.25, 0.75]), quantile.(Ref(y), [0.25, 0.75])
         slp = (quanty[2] - quanty[1]) / (quantx[2] - quantx[1])
         ys = @. quanty + slp * (xs - quantx)
     end


### PR DESCRIPTION
# Description

Very minor change addressing a deprecation warning from Distributions.jl:

```julia
┌ Warning: `quantile(d::UnivariateDistribution, X::AbstractArray)` is deprecated, use `quantile.(d, X)` instead.
│   caller = fit_qqplot(x::Normal{Float64}, y::Vector{Float64}; qqline::Symbol) at distributions.jl:102
└ @ Makie ~/.julia/packages/Makie/xhxRd/src/stats/distributions.jl:102
```

The broadcasted method is perhaps slightly less efficient than the Array method, but since there are only two quantiles being computed, it doesn't really matter and will have full backward compatibility.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
