### PR TITLE
Only apply axis/scene transformations to :data space plots

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -437,7 +437,7 @@ function draw_glyph_collection(scene, ctx, position, glyph_collection, rotation,
 
     glyph_pos = let
         transform_func = scene.transformation.transform_func[]
-        p = Makie.apply_transform(transform_func, position)
+        p = Makie.apply_transform(transform_func, position, space)
 
         Makie.clip_to_space(scene.camera, markerspace) *
         Makie.space_to_clip(scene.camera, space) *
@@ -797,7 +797,7 @@ function draw_mesh3D(
     # and have `func` be fully typed inside closure
     vs = broadcast(meshpoints, (func,)) do v, f
         # Should v get a nan2zero?
-        v = Makie.apply_transform(f, v)
+        v = Makie.apply_transform(f, v, space)
         p4d = to_ndim(Vec4f, scale .* to_ndim(Vec3f, v, 0f0), 1f0)
         view * (model * p4d .+ to_ndim(Vec4f, pos, 0f0))
     end

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -4,7 +4,7 @@
 
 function project_position(scene, transform_func::T, space, point, model, yflip::Bool = true) where T
     # use transform func
-    point = Makie.apply_transform(transform_func, point)
+    point = Makie.apply_transform(transform_func, point, space)
     _project_position(scene, space, point, model, yflip)
 end
 

--- a/RPRMakie/src/meshes.jl
+++ b/RPRMakie/src/meshes.jl
@@ -136,8 +136,9 @@ function to_rpr_object(context, matsys, scene, plot::Makie.Surface)
 
     function grid(x, y, z, trans)
         g = map(CartesianIndices(z)) do i
+            space = to_value(get(plot, :space, :data))
             p = Point3f(Makie.get_dim(x, i, 1, size(z)), Makie.get_dim(y, i, 2, size(z)), z[i])
-            return Makie.apply_transform(trans, p)
+            return Makie.apply_transform(trans, p, space)
         end
         return vec(g)
     end

--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -245,6 +245,19 @@ end
     f
 end
 
+@reference_test "space test in transformed axis" begin
+    f = lines(exp.(0.1*(1.0:100));  axis=(yscale=log10,))
+    poly!(Rect(1, 1, 100, 100), color=:red, space=:pixel)
+    scatter!(2*mod.(1:100:10000, 97), 2*mod.(1:101:10000, 97), color=:blue, space=:pixel)
+    scatter!(Point2f(0, 0.25), space=:clip)
+    lines!([0.5,0.5], [0, 1];  space=:relative)
+    lines!([50,50], [0, 100];  space=:pixel)
+    lines!([0,1], [0.25, 0.25];  space=:clip)
+    scatter!(Point2f(0.5, 0), space=:relative)
+    f
+end
+
+
 # Needs a way to disable autolimits on show
 # @reference_test "interactions after close" begin
 #     # After saving, interactions may be cleaned up:

--- a/WGLMakie/src/imagelike.jl
+++ b/WGLMakie/src/imagelike.jl
@@ -55,10 +55,10 @@ function limits_to_uvmesh(plot)
         positions = Buffer(lift(rect-> decompose(Point2f, rect), rect))
         faces = Buffer(lift(rect -> decompose(GLTriangleFace, rect), rect))
         uv = Buffer(lift(decompose_uv, rect))
-    else
-        grid(x, y, trans) = Makie.matrix_grid(p-> apply_transform(trans, p), x, y, zeros(length(x), length(y)))
+    else 
+        grid(x, y, trans, space) = Makie.matrix_grid(p-> apply_transform(trans, p, space), x, y, zeros(length(x), length(y)))
         rect = lift((x, y) -> Tesselation(Rect2(0f0, 0f0, 1f0, 1f0), (length(x), length(y))), px, py)
-        positions = Buffer(lift(grid, px, py, t))
+        positions = Buffer(lift(grid, px, py, t, get(plot, :space, :data)))
         faces = Buffer(lift(r -> decompose(GLTriangleFace, r), rect))
         uv = Buffer(lift(decompose_uv, rect))
     end
@@ -79,8 +79,8 @@ end
 function create_shader(mscene::Scene, plot::Surface)
     # TODO OWN OPTIMIZED SHADER ... Or at least optimize this a bit more ...
     px, py, pz = plot[1], plot[2], plot[3]
-    grid(x, y, z, trans) = Makie.matrix_grid(p-> apply_transform(trans, p), x, y, z)
-    positions = Buffer(lift(grid, px, py, pz, transform_func_obs(plot)))
+    grid(x, y, z, trans, space) = Makie.matrix_grid(p-> apply_transform(trans, p, space), x, y, z)
+    positions = Buffer(lift(grid, px, py, pz, transform_func_obs(plot), get(plot, :space, :data)))
     rect = lift(z -> Tesselation(Rect2(0f0, 0f0, 1f0, 1f0), size(z)), pz)
     faces = Buffer(lift(r -> decompose(GLTriangleFace, r), rect))
     uv = Buffer(lift(decompose_uv, rect))

--- a/WGLMakie/src/lines.jl
+++ b/WGLMakie/src/lines.jl
@@ -13,8 +13,8 @@ end
 
 function create_shader(scene::Scene, plot::Union{Lines,LineSegments})
     # Potentially per instance attributes
-    positions = lift(plot[1], transform_func_obs(plot)) do points, trans
-        points = apply_transform(trans, topoint(points))
+    positions = lift(plot[1], transform_func_obs(plot), get(plot, :space, :data)) do points, trans, space
+        points = apply_transform(trans, topoint(points), space)
         if plot isa LineSegments
             return points
         else

--- a/WGLMakie/src/meshes.jl
+++ b/WGLMakie/src/meshes.jl
@@ -1,10 +1,10 @@
-function vertexbuffer(x, trans)
+function vertexbuffer(x, trans, space)
     pos = decompose(Point, x)
-    return apply_transform(trans,  pos)
+    return apply_transform(trans,  pos, space)
 end
 
 function vertexbuffer(x::Observable, p)
-    return Buffer(lift(vertexbuffer, x, transform_func_obs(p)))
+    return Buffer(lift(vertexbuffer, x, transform_func_obs(p), get(p, :space, :data)))
 end
 
 facebuffer(x) = facebuffer(GeometryBasics.faces(x))

--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -53,7 +53,8 @@ function create_shader(scene::Scene, plot::MeshScatter)
     per_instance = filter(plot.attributes.attributes) do (k, v)
         return k in per_instance_keys && !(isscalar(v[]))
     end
-    per_instance[:offset] = apply_transform(transform_func_obs(plot),  plot[1])
+    space = get(plot, :space, :data)
+    per_instance[:offset] = apply_transform(transform_func_obs(plot),  plot[1], space)
 
     for (k, v) in per_instance
         per_instance[k] = Buffer(lift_convert(k, v, plot))
@@ -174,7 +175,7 @@ function create_shader(scene::Scene, plot::Scatter)
     attributes[:preprojection] = map(space, mspace, cam.projectionview, cam.resolution) do space, mspace, _, _
         Makie.clip_to_space(cam, mspace) * Makie.space_to_clip(cam, space)
     end
-    attributes[:pos] = apply_transform(transform_func_obs(plot),  plot[1])
+    attributes[:pos] = apply_transform(transform_func_obs(plot),  plot[1], space)
     quad_offset = get(attributes, :marker_offset, Observable(Vec2f(0)))
     attributes[:marker_offset] = Vec3f(0)
     attributes[:quad_offset] = quad_offset
@@ -219,8 +220,8 @@ function create_shader(scene::Scene, plot::Makie.Text{<:Tuple{<:Union{<:Makie.Gl
         gcollection = Observable(glyphcollection)
     end
 
-    glyph_data = map(pos, gcollection, offset, transfunc) do pos, gc, offset, transfunc
-        Makie.text_quads(pos, to_value(gc), offset, transfunc)
+    glyph_data = map(pos, gcollection, offset, transfunc, space) do pos, gc, offset, transfunc, space
+        Makie.text_quads(pos, to_value(gc), offset, transfunc, space)
     end
 
     # unpack values from the one signal:

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -54,8 +54,9 @@ function plot!(plot::Text)
 
     sc = parent_scene(plot)
 
-    onany(linesegs, positions, sc.camera.projectionview, sc.px_area, transform_func_obs(sc)) do segs, pos, _, _, transf
-        pos_transf = scene_to_screen(apply_transform(transf, pos), sc)
+    onany(linesegs, positions, sc.camera.projectionview, sc.px_area, 
+            transform_func_obs(sc), get(plot, :space, :data)) do segs, pos, _, _, transf, space
+        pos_transf = scene_to_screen(apply_transform(transf, pos, space), sc)
         linesegs_shifted[] = map(segs, lineindices[]) do seg, index
             seg + attr_broadcast_getindex(pos_transf, index)
         end

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -188,7 +188,7 @@ function shift_project(scene, plot, pos)
     project(
         camera(scene).projectionview[],
         Vec2f(widths(pixelarea(scene)[])),
-        apply_transform(transform_func_obs(plot)[], pos)
+        apply_transform(transform_func(plot), pos, to_value(get(plot, :space, :data)))
     ) .+ Vec2f(origin(pixelarea(scene)[]))
 end
 

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -302,8 +302,8 @@ _offset_at(o::Vector, i) = o[i]
 Base.getindex(x::ScalarOrVector, i) = x.sv isa Vector ? x.sv[i] : x.sv
 Base.lastindex(x::ScalarOrVector) = x.sv isa Vector ? length(x.sv) : 1
 
-function text_quads(position::VecTypes, gc::GlyphCollection, offset, transfunc)
-    p = apply_transform(transfunc, position)
+function text_quads(position::VecTypes, gc::GlyphCollection, offset, transfunc, space)
+    p = apply_transform(transfunc, position, space)
     pos = [to_ndim(Point3f, p, 0) for _ in gc.origins]
 
     atlas = get_texture_atlas()
@@ -336,8 +336,8 @@ function text_quads(position::VecTypes, gc::GlyphCollection, offset, transfunc)
     return pos, char_offsets, quad_offsets, uvs, scales
 end
 
-function text_quads(position::Vector, gcs::Vector{<: GlyphCollection}, offset, transfunc)
-    ps = apply_transform(transfunc, position)
+function text_quads(position::Vector, gcs::Vector{<: GlyphCollection}, offset, transfunc, space)
+    ps = apply_transform(transfunc, position, space)
     pos = [to_ndim(Point3f, p, 0) for (p, gc) in zip(ps, gcs) for _ in gc.origins]
 
     atlas = get_texture_atlas()

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -196,6 +196,16 @@ transform_func(x) = transform_func_obs(x)[]
 transform_func_obs(x) = transformation(x).transform_func
 
 """
+    apply_transform(f, data, space)
+Apply the data transform func to the data if the space matches one
+of the the transformation spaces (currently only :data is transformed)
+"""
+apply_transform(f, data, space) = space == :data ? apply_transform(f, data) : data  
+function apply_transform(f::Observable, data::Observable, space::Observable) 
+    return lift((f, d, s)-> apply_transform(f, d, s), f, data, space)
+end 
+
+"""
     apply_transform(f, data)
 Apply the data transform func to the data
 """
@@ -373,3 +383,5 @@ end
 # by heatmaps or images
 zvalue2d(x)::Float32 = Makie.translation(x)[][3] + zvalue2d(x.parent)
 zvalue2d(::Nothing)::Float32 = 0f0
+
+

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -82,7 +82,8 @@ function update_axis_camera(camera::Camera, t, lims, xrev::Bool, yrev::Bool)
     nearclip = -10_000f0
     farclip = 10_000f0
 
-    tlims = Makie.apply_transform(t, lims)
+    # we are computing transformed camera position, so this isn't space dependent
+    tlims = Makie.apply_transform(t, lims) 
 
     left, bottom = minimum(tlims)
     right, top = maximum(tlims)

--- a/test/text.jl
+++ b/test/text.jl
@@ -60,7 +60,7 @@
     # Test quad data
     positions, char_offsets, quad_offsets, uvs, scales = Makie.text_quads(
         to_ndim(Point3f, p.position[], 0), glyph_collection,
-        Vec2f(0), Makie.transform_func_obs(scene)[]
+        Vec2f(0), Makie.transform_func_obs(scene)[], :data
     )
 
     # Also doesn't work 

--- a/test/transformations.jl
+++ b/test/transformations.jl
@@ -115,3 +115,31 @@ end
     @test all(Makie.rotatedrect(box, π/4).widths .≈ Rect2f(0, -1/(√2f0), √2f0, √2f0).widths)
 
 end
+
+@testset "Space dependent transforms" begin
+    t1 = sqrt
+    t2 = (sqrt, log)
+    t3 = (sqrt, log, log10)
+
+    p2 = Point(2.0, 5.0)
+    p3 = Point(2.0, 5.0, 4.0)
+
+    spaces_and_desired_transforms = Dict(
+        :data => (x,y) -> y, # uses changes 
+        :clip => (x,y) -> x, # no change 
+        :relative => (x,y) -> x, # no change
+        :pixel => (x,y) -> x, # no transformation
+    )
+    for (space, desired_transform) in spaces_and_desired_transforms
+        @test apply_transform(identity, p2, space) == p2
+        @test apply_transform(identity, p3, space) == p3
+
+        @test apply_transform(t1, p2, space) == desired_transform(p2, Point(sqrt(2.0), sqrt(5.0)))
+        @test apply_transform(t1, p3, space) == desired_transform(p3, Point(sqrt(2.0), sqrt(5.0), sqrt(4.0)))
+
+        @test apply_transform(t2, p2, space) == desired_transform(p2, Point2f(sqrt(2.0), log(5.0)))
+        @test apply_transform(t2, p3, space) == desired_transform(p3, Point3f(sqrt(2.0), log(5.0), 4.0))
+
+        @test apply_transform(t3, p3, space) == desired_transform(p3, Point3f(sqrt(2.0), log(5.0), log10(4.0)))
+    end 
+end


### PR DESCRIPTION
# Description

Fixes #2424 Fixes #2065 

This PR adjusts the behavior of the axis/scene transformations to only apply to plots in the :data space. 

## Notes

Examined and editing almost all places where "apply_transform" was used to switch to the new three parameter version suggested in #2065. 

There were some places where the existing behavior was left. This is due to a quick survey of the surrounding logic suggesting that the existing code assumes things are transformed. Places where this happens:

NO CHANGE src/basic_recipes/hvspan.jl:_apply_x_transform(t::Tuple, v) = apply_transform(t[1], v)
NO CHANGE src/basic_recipes/hvspan.jl:_apply_y_transform(t::Tuple, v) = apply_transform(t[2], v)
NO CHANGE src/layouting/data_limits.jl:        point_t = apply_transform(trans_func, point)
NO CHANGE src/layouting/data_limits.jl:    (to_ndim(Point3f, project(model, apply_transform(trans_func, point)), 0f0) for point in points)
NO CHANGE src/makielayout/blocks/axis.jl:    tlims = Makie.apply_transform(t, lims)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [X] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
