### PR TITLE
Fix repeated rendering with invisible objects

### DIFF
--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -55,9 +55,9 @@ So rewriting this function could get us a lot of performance for scenes with
 a lot of objects.
 """
 function render(renderobject::RenderObject, vertexarray=renderobject.vertexarray)
+    renderobject.requires_update = false
+    
     if renderobject.visible
-        renderobject.requires_update = false
-
         renderobject.prerenderfunction()
         program = vertexarray.program
         glUseProgram(program.id)


### PR DESCRIPTION
# Description

Fixes comment in #2336

An invisible object currently never resets it update requests. The pr fixes that. (Going from visible -> invisible needs to trigger a render, so the request needs to be true for an object that just became visible. We then need to reset every objects request, whether they rendered (are visible) or not.)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
