### PR TITLE
benchmark time for new figure

### DIFF
--- a/metrics/ttfp/benchmark-ttfp.jl
+++ b/metrics/ttfp/benchmark-ttfp.jl
@@ -41,7 +41,7 @@ old = isfile(result) ? JSON.parse(read(result, String)) : [[], [], [], [], []]
 push!.(old[1:3], [t_using, create_time, display_time])
 
 b1 = @benchmark fig = scatter(1:4; color=1:4, colormap=:turbo, markersize=20, visible=true)
-b2 = @benchmark get_colorbuffer(fig)
+b2 = @benchmark get_colorbuffer(fig) setup=(fig=scatter(1:4))
 
 using Statistics
 


### PR DESCRIPTION
It was fun to see, how re-using the screen made display really fast, but we should really benchmark with a new figure here.
Or best both, but I don't want to update the template right and I think we should rather create a new benchmark with e.g. record to show the time improvements of re-using the screen.