### PR TITLE
GLMakie: add `set_screen_visibility!` and pass reference for screen ID

### DIFF
--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -197,7 +197,7 @@ function ssao_postprocessor(framebuffer, shader_cache)
 end
 
 """
-    fxaa_postprocessor(framebuffer)
+    fxaa_postprocessor(framebuffer, shader_cache)
 
 Returns a PostProcessor that handles fxaa.
 """
@@ -264,12 +264,14 @@ end
 
 
 """
-    to_screen_postprocessor(framebuffer)
+    to_screen_postprocessor(framebuffer, shader_cache, default_id = nothing)
 
 Sets up a Postprocessor which copies the color buffer to the screen. Used as a
-final step for displaying the screen.
+final step for displaying the screen. The argument `screen_fb_id` can be used
+to pass in a reference to the framebuffer ID of the screen. If `nothing` is
+used (the default), 0 is used.
 """
-function to_screen_postprocessor(framebuffer, shader_cache, default_id = 0)
+function to_screen_postprocessor(framebuffer, shader_cache, screen_fb_id = nothing)
     # draw color buffer
     shader = LazyShader(
         shader_cache,
@@ -287,6 +289,8 @@ function to_screen_postprocessor(framebuffer, shader_cache, default_id = 0)
         w, h = size(fb)
 
         # transfer everything to the screen
+        default_id = isnothing(screen_fb_id) ? 0 : screen_fb_id[]
+        # GLFW uses 0, Gtk uses a value that we have to probe at the beginning of rendering
         glBindFramebuffer(GL_FRAMEBUFFER, default_id)
         glViewport(0, 0, w, h)
         glClear(GL_COLOR_BUFFER_BIT)

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -341,7 +341,7 @@ function apply_config!(screen::Screen, config::ScreenConfig; visible::Bool=true,
         stop_renderloop!(screen)
     end
 
-    GLFW.set_visibility!(screen, visible)
+    set_screen_visibility!(screen, visible)
     return screen
 end
 
@@ -361,7 +361,8 @@ function Screen(;
     return screen
 end
 
-GLFW.set_visibility!(screen::Screen, visible::Bool) = GLFW.set_visibility!(screen.glscreen, visible)
+set_screen_visibility!(screen::Screen, visible::Bool) = set_screen_visibility!(screen.glscreen, visible)
+set_screen_visibility!(nw::GLFW.Window, visible::Bool) = GLFW.set_visibility!(nw, visible)
 
 function display_scene!(screen::Screen, scene::Scene)
     empty!(screen)

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -562,7 +562,7 @@ Closes screen and emptying it.
 Doesn't destroy the screen and instead frees it for being re-used again, if `reuse=true`.
 """
 function Base.close(screen::Screen; reuse=true)
-    GLFW.set_visibility!(screen, false)
+    set_screen_visibility!(screen, false)
     stop_renderloop!(screen; close_after_renderloop=false)
     screen.window_open[] = false
     empty!(screen)
@@ -819,7 +819,7 @@ end
 
 function requires_update(screen::Screen)
     if screen.requires_update
-        screen.requires_update = false 
+        screen.requires_update = false
         return true
     end
     for (_, _, robj) in screen.renderlist


### PR DESCRIPTION
# Description

More changes to get GtkMakie working. I needed a screen visibility method that could optionally not call GLFW, and settled on a strategy for passing in the screen ID that uses a reference that can be filled in at the beginning of rendering.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
