### PR TITLE
`ReferenceTests`: add `reference_test` counter

### DIFF
--- a/ReferenceTests/src/database.jl
+++ b/ReferenceTests/src/database.jl
@@ -16,6 +16,7 @@ const REGISTERED_TESTS = Set{String}()
 const RECORDING_DIR = Base.RefValue{String}()
 const SKIP_TITLES = Set{String}()
 const SKIP_FUNCTIONS = Set{Symbol}()
+const COUNTER = Ref(0)
 
 """
     @reference_test(name, code)
@@ -35,7 +36,7 @@ macro reference_test(name, code)
                 if $title in $REGISTERED_TESTS
                     error("title must be unique. Duplicate title: $(title)")
                 end
-                println("running: $($title)")
+                println("running $(lpad(COUNTER[] += 1, 3)): $($title)")
                 Makie.set_theme!(resolution=(500, 500))
                 ReferenceTests.RNG.seed_rng!()
                 result = let


### PR DESCRIPTION
It's convenient to know the number of elapsed ref comparisons while running the test suite:
```julia
[...]
Test Summary:                | Pass  Total  Time
VideoStream & screen options |    4      4  3.5s
running   1: lines with gaps
running   2: scatters
running   3: scatter rotations
running   4: scatter image markers
running   5: basic polygon shapes
running   6: BezierPath markers
running   7: complex_bezier_markers
running   8: polygon markers
running   9: heatmap_with_labels
running  10: data space
running  11: single_strings_single_positions
running  12: multi_strings_multi_positions
running  13: single_strings_single_positions_justification
```