### PR TITLE
Fix searchpage redirect not respecting prefix

### DIFF
--- a/docs/_layout/foot.html
+++ b/docs/_layout/foot.html
@@ -36,6 +36,9 @@
       stork.register("makiesearch", `${storkfolder}/index_page.st`);
     </script>
     {{else}}
+    <!-- Franklin.jl ignores page variables inside script tags therefore we
+    need this placeholder to get the prefix variable -->
+    <label id="prefix-placeholder" style="display:none">{{prefix}}</label>
     <script>
       storkfolder = document.querySelector("#stork-library-path-placeholder").src;
       stork.register("makiesearch", `${storkfolder}/index_box.st`);
@@ -44,7 +47,12 @@
         var key=e.keyCode || e.which;
         if (key==13){
           var input = document.getElementById("search-box").value
-          window.location = ("/search?q=" + input)
+          var prefix = document.getElementById("prefix-placeholder").innerHTML
+          if (prefix.length == 0) {
+            window.location = ("/search?q=" + input)
+          } else {
+            window.location = ("/" + prefix + "/search?q=" + input)
+          }
         }
       }
     </script>

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,6 +19,7 @@ generate_rss = true
 website_title = "Franklin Template"
 website_descr = "Example website using Franklin"
 prepath = get(ENV, "PREVIEW_FRANKLIN_PREPATH", "")
+prefix = get(ENV, "FRANKLIN_PREFIX", "")
 website_url = get(ENV, "PREVIEW_FRANKLIN_WEBSITE_URL", "docs.makie.org")
 +++
 

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -32,6 +32,8 @@ deploydecision = deploy_folder(cfg; repo, push_preview, devbranch="master", devu
 
 @info "Setting PREVIEW_FRANKLIN_WEBSITE_URL to $repo"
 ENV["PREVIEW_FRANKLIN_WEBSITE_URL"] = repo
+@info "Setting FRANKLIN_PREFIX to $(deploydecision.subfolder)"
+ENV["FRANKLIN_PREFIX"] = deploydecision.subfolder
 
 """
 Converts the string `s` which might be an absolute path,


### PR DESCRIPTION
# Description

Fixes #2486 

This fixes the redirect to the searchpage by using the `deploydecision.subfolder `variable. 
It works locally and now hopefully on the live page too.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
