### PR TITLE
Revert "Fix searchpage redirect not respecting prefix"

### DIFF
--- a/docs/_layout/foot.html
+++ b/docs/_layout/foot.html
@@ -36,9 +36,6 @@
       stork.register("makiesearch", `${storkfolder}/index_page.st`);
     </script>
     {{else}}
-    <!-- Franklin.jl ignores page variables inside script tags therefore we
-    need this placeholder to get the prefix variable -->
-    <label id="prefix-placeholder" style="display:none">{{prefix}}</label>
     <script>
       storkfolder = document.querySelector("#stork-library-path-placeholder").src;
       stork.register("makiesearch", `${storkfolder}/index_box.st`);
@@ -47,12 +44,7 @@
         var key=e.keyCode || e.which;
         if (key==13){
           var input = document.getElementById("search-box").value
-          var prefix = document.getElementById("prefix-placeholder").innerHTML
-          if (prefix.length == 0) {
-            window.location = ("/search?q=" + input)
-          } else {
-            window.location = ("/" + prefix + "/search?q=" + input)
-          }
+          window.location = ("/search?q=" + input)
         }
       }
     </script>

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,7 +19,6 @@ generate_rss = true
 website_title = "Franklin Template"
 website_descr = "Example website using Franklin"
 prepath = get(ENV, "PREVIEW_FRANKLIN_PREPATH", "")
-prefix = get(ENV, "FRANKLIN_PREFIX", "")
 website_url = get(ENV, "PREVIEW_FRANKLIN_WEBSITE_URL", "docs.makie.org")
 +++
 

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -32,8 +32,6 @@ deploydecision = deploy_folder(cfg; repo, push_preview, devbranch="master", devu
 
 @info "Setting PREVIEW_FRANKLIN_WEBSITE_URL to $repo"
 ENV["PREVIEW_FRANKLIN_WEBSITE_URL"] = repo
-@info "Setting FRANKLIN_PREFIX to $(deploydecision.subfolder)"
-ENV["FRANKLIN_PREFIX"] = deploydecision.subfolder
 
 """
 Converts the string `s` which might be an absolute path,


### PR DESCRIPTION
Reverts MakieOrg/Makie.jl#2491

This broke https://docs.makie.org/dev/ because the paths are now all double-prefixed:

<img width="644" alt="image" src="https://user-images.githubusercontent.com/22495855/207316262-69024172-3a65-4ea7-9c44-58aab9c84f7a.png">
