### PR TITLE
Fix search-page redirect not respecting prefix

### DIFF
--- a/docs/_layout/foot.html
+++ b/docs/_layout/foot.html
@@ -36,6 +36,7 @@
       stork.register("makiesearch", `${storkfolder}/index_page.st`);
     </script>
     {{else}}
+    <img id="search-path-placeholder" src="/search" style="display:none"/>
     <script>
       storkfolder = document.querySelector("#stork-library-path-placeholder").src;
       stork.register("makiesearch", `${storkfolder}/index_box.st`);
@@ -43,8 +44,9 @@
         // Redirect to search-page if enter is pressed in search-box
         var key=e.keyCode || e.which;
         if (key==13){
-          var input = document.getElementById("search-box").value
-          window.location = ("/search?q=" + input)
+          var input = document.getElementById("search-box").value;
+          var path = document.getElementById("search-path-placeholder").src;
+          window.location = (path + "?q=" + input);
         }
       }
     </script>


### PR DESCRIPTION
# Description

Fixes #2486 (issue)

PR #2491 did not fix the issue since the Franklin variable `prefix` is reserved  and an alias for `prepath`.
Instead of renaming the variable I found a better solution using relative paths by making use of the 
`make_links_relative() ` function in `makedocs.jl`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
