### PR TITLE
Add px_per_unit to GLMakie

### DIFF
--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -157,6 +157,7 @@ function ssao_postprocessor(framebuffer, shader_cache)
     full_render = screen -> begin
         fb = screen.framebuffer
         w, h = size(fb)
+        scale = screen.config.px_per_unit
 
         # Setup rendering
         # SSAO - calculate occlusion
@@ -170,8 +171,7 @@ function ssao_postprocessor(framebuffer, shader_cache)
             # scenes. It should be a leaf scene to avoid repeatedly shading
             # the same region (though this is not guaranteed...)
             isempty(scene.children) || continue
-            a = pixelarea(scene)[]
-            glScissor(minimum(a)..., widths(a)...)
+            glScissor(trunc_scale(scale, scene)...)
             # update uniforms
             data1[:projection] = scene.camera.projection[]
             data1[:bias] = scene.ssao.bias[]
@@ -185,7 +185,8 @@ function ssao_postprocessor(framebuffer, shader_cache)
             # Select the area of one leaf scene
             isempty(scene.children) || continue
             a = pixelarea(scene)[]
-            glScissor(minimum(a)..., widths(a)...)
+            # glScissor(minimum(a)..., widths(a)...)
+            glScissor(trunc_scale(scale, scene)...)
             # update uniforms
             data2[:blur_range] = scene.ssao.blur
             GLAbstraction.render(pass2)
@@ -285,8 +286,7 @@ function to_screen_postprocessor(framebuffer, shader_cache, screen_fb_id = nothi
     pass.postrenderfunction = () -> draw_fullscreen(pass.vertexarray.id)
 
     full_render = screen -> begin
-        fb = screen.framebuffer
-        w, h = size(fb)
+        w, h = size(screen)
 
         # transfer everything to the screen
         default_id = isnothing(screen_fb_id) ? 0 : screen_fb_id[]

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -359,9 +359,15 @@ function Screen(;
     # Screen config is managed by the current active theme, so managed by Makie
     config = Makie.merge_screen_config(ScreenConfig, screen_config)
     screen = screen_from_pool(config.debugging)
+    
+    # to avoid error in resize!
+    if !isdefined(screen, :config)
+        screen.config = config
+    end
     if !isnothing(resolution)
         resize!(screen, resolution...)
     end
+    
     apply_config!(screen, config; visible=visible, start_renderloop=start_renderloop)
     return screen
 end

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -124,6 +124,7 @@ const minimal_default = Attributes(
         fullscreen = false,
         debugging = false,
         monitor = nothing,
+        px_per_unit = 1.0,
 
         # Postproccessor
         oit = true,


### PR DESCRIPTION
# Description

This is a prototype for #2522 though I don't have a mac to test anything with. Feel free to mess around with this @jkrumbiegel 

The pr adds `px_per_unit` to the GLMakie screen config, which acts as a multiplier between the window size and the framebuffer size. So with this you can have 2x2 pixels per window resolution pixel by doing

```julia
...
display(GLMakie.Screen(px_per_unit = 2), fig)
```

TODO:
- fix the black outline of LScenes with ssao
- check if any of the screen/framebuffer size calls are expensive and if so avoid them (as far as I can tell GLFW.Get... calls are fairly expensive, but getting the size of a texture is now)
- general cleanup

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
