### PR TITLE
Fix CairoMakie Gtk.jl example

### DIFF
--- a/CairoMakie/README.md
+++ b/CairoMakie/README.md
@@ -38,7 +38,8 @@ function drawonto(canvas, figure)
     @guarded draw(canvas) do _
         scene = figure.scene
         resize!(scene, Gtk.width(canvas), Gtk.height(canvas))
-        screen = CairoMakie.Screen(scene, Gtk.cairo_surface(canvas), getgc(canvas), nothing)
+        config = CairoMakie.ScreenConfig(1.0, 1.0, :good, true, true)
+        screen = CairoMakie.Screen(scene, config, Gtk.cairo_surface(canvas))
         CairoMakie.cairo_draw(screen, scene)
     end
 end


### PR DESCRIPTION
# Description

The CairoMakie Gtk.jl example did not work.

However, this change alone was not sufficient. In https://github.com/MakieOrg/Makie.jl/blob/master/CairoMakie/src/cairo-extension.jl#L74 I had to add
```
    typ == Cairo.CAIRO_SURFACE_TYPE_QUARTZ && return SVG # not sure which type to chose here.
```
I did not include that change in this PR, since I don't know how to properly handle other platforms than Mac.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


