### PR TITLE
Fix typo in documentation for `@extract`

### DIFF
--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -106,7 +106,7 @@ function extract_expr(extract_func, dictlike, args)
 end
 
 """
-usage @exctract scene (a, b, c, d)
+usage @extract scene (a, b, c, d)
 """
 macro extract(scene, args)
     extract_expr(getindex, scene, args)


### PR DESCRIPTION
# Description

Addressing a minor annoyance of mine.
I've been bugged by this typo every time I go to the API doc page so I've fixed it (exctract -> extract).

![image](https://user-images.githubusercontent.com/4075136/210290286-5b58fe0b-9d61-4e18-b010-8e27757d21ba.png)

Sorry for the noise with this very small PR. 


## Type of change

Delete options that do not apply:

- [x] Documentation improvement

## Checklist

- [x] Added or changed relevant sections in the documentation
