### PR TITLE
Add example for arc plotting function

### DIFF
--- a/docs/examples/plotting_functions/arc.md
+++ b/docs/examples/plotting_functions/arc.md
@@ -1,0 +1,56 @@
+# arc
+
+{{doc arc}}
+
+## Examples
+
+\begin{examplefigure}{svg = true}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+
+arc(Point2f(0), 1, -π, π)
+```
+\end{examplefigure}
+
+\begin{examplefigure}{svg = true}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+f = Figure() 
+Axis(f[1, 1])
+
+for i in 1:10
+    arc!(Point2f(0, i), i, -π, π)
+end
+
+f
+```
+\end{examplefigure}
+
+\begin{examplefigure}{svg = true}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+
+f = Figure()
+Axis(f[1, 1])
+
+for i in 1:4
+    radius = 1/(i*2)
+    left = 1/(i*2)
+    right = (i*2-1)/(i*2)
+    arc!(Point2f(left, 0), radius, 0, π)
+    arc!(Point2f(right, 0), radius, 0, π)
+end
+for i in 3:4
+    radius = 1/(i*(i-1)*2)
+    left = (1/i) + 1/(i*(i-1)*2)
+    right = ((i-1)/i) - 1/(i*(i-1)*2)
+    arc!(Point2f(left, 0), radius, 0, π)
+    arc!(Point2f(right, 0), radius, 0, π)
+end
+
+f
+```
+\end{examplefigure}


### PR DESCRIPTION
# Description

I noticed that there are no examples for the arc() plotting function on the website so I created some.
I tested the changes to the website locally and it works as intended.

## Type of change

Delete options that do not apply:

- [x] Improvement of the Documentation

## Checklist
- [x] Added or changed relevant sections in the documentation


### These are the examples I added:

First two very basic ones:
```julia
using CairoMakie
arc(Point2f(0), 1, -π, π)
```
![example_3177995486812465662](https://user-images.githubusercontent.com/46504550/210386394-6f8c6966-6218-4f57-b946-ca803340c09b.svg)



```julia
using CairoMakie
f = Figure() 
Axis(f[1, 1])

for i in 1:10
    arc!(Point2f(0, i), i, -π, π)
end

f
```

![example_12741175784456680574](https://user-images.githubusercontent.com/46504550/210386443-61ca34ed-5edd-49dd-9a01-0e253ff74433.svg)


And as a last example - creating a Farey sequence diagram to order 4:
```julia
using CairoMakie

f = Figure()
Axis(f[1, 1])

for i in 1:4
    radius = 1/(i*2)
    left = 1/(i*2)
    right = (i*2-1)/(i*2)
    arc!(Point2f(left, 0), radius, 0, π)
    arc!(Point2f(right, 0), radius, 0, π)
end
for i in 3:4
    radius = 1/(i*(i-1)*2)
    left = (1/i) + 1/(i*(i-1)*2)
    right = ((i-1)/i) - 1/(i*(i-1)*2)
    arc!(Point2f(left, 0), radius, 0, π)
    arc!(Point2f(right, 0), radius, 0, π)
end

f
```
![example_446186802487841561](https://user-images.githubusercontent.com/46504550/210387109-289fb5cb-9e74-4845-9910-aa73dfca527d.svg)

