### PR TITLE
Assume IMAGE as the default render type in CairoMakie

### DIFF
--- a/CairoMakie/src/cairo-extension.jl
+++ b/CairoMakie/src/cairo-extension.jl
@@ -71,5 +71,5 @@ function get_render_type(surface::Cairo.CairoSurface)
     typ == Cairo.CAIRO_SURFACE_TYPE_PS && return EPS
     typ == Cairo.CAIRO_SURFACE_TYPE_SVG && return SVG
     typ == Cairo.CAIRO_SURFACE_TYPE_IMAGE && return IMAGE
-    error("Unsupported surface type: $(typ)")
+    return IMAGE # By default assume that the render type is IMAGE
 end


### PR DESCRIPTION
As outlined in https://github.com/MakieOrg/Makie.jl/pull/2537 currently CairoMakie.jl cannot be used in combination with Gtk(4).jl. This is a simple fix that should hold for all the different Cairo backends that are possible in combination with Gtk.jl