### PR TITLE
Prototype/Proof of concept fix for Float32 issues

### DIFF
--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -120,7 +120,7 @@ function point_iterator(x::Volume)
     extremata = map(extrema∘to_value, axes)
     minpoint = Point3f(first.(extremata)...)
     widths = last.(extremata) .- first.(extremata)
-    rect = Rect3f(minpoint, Vec3f(widths))
+    rect = Rect3(minpoint, Vec3(widths))
     return unique(decompose(Point, rect))
 end
 
@@ -174,7 +174,7 @@ end
 
 function update_boundingbox!(bb_ref, point)
     if all(isfinite, point)
-        vec = to_ndim(Vec3f, point, 0.0)
+        vec = to_ndim(Vec3, point, 0.0)
         bb_ref[] = update(bb_ref[], vec)
     end
 end
@@ -210,14 +210,14 @@ function _update_rect(rect::Rect{N, T}, point::Point{N, T}) where {N, T}
 end
 
 function limits_from_transformed_points(points_iterator)
-    isempty(points_iterator) && return Rect3f()
+    isempty(points_iterator) && return Rect3()
     first, rest = Iterators.peel(points_iterator)
-    bb = foldl(_update_rect, rest, init = Rect3f(first, zero(first)))
+    bb = foldl(_update_rect, rest, init = Rect3(first, zero(first)))
     return bb
 end
 
 function data_limits(scenelike, exclude=(p)-> false)
-    bb_ref = Base.RefValue(Rect3f())
+    bb_ref = Base.RefValue(Rect3())
     foreach_plot(scenelike) do plot
         if !exclude(plot)
             update_boundingbox!(bb_ref, data_limits(plot))
@@ -231,19 +231,19 @@ function data_limits(plot::Surface)
     mini_maxi = extrema_nan.((plot.x[], plot.y[], plot.z[]))
     mini = first.(mini_maxi)
     maxi = last.(mini_maxi)
-    return Rect3f(mini, maxi .- mini)
+    return Rect3(mini, maxi .- mini)
 end
 
 function data_limits(plot::Heatmap)
     mini_maxi = extrema_nan.((plot.x[], plot.y[]))
-    mini = Vec3f(first.(mini_maxi)..., 0)
-    maxi = Vec3f(last.(mini_maxi)..., 0)
-    return Rect3f(mini, maxi .- mini)
+    mini = Vec3(first.(mini_maxi)..., 0)
+    maxi = Vec3(last.(mini_maxi)..., 0)
+    return Rect3(mini, maxi .- mini)
 end
 
 function data_limits(plot::Image)
     mini_maxi = extrema_nan.((plot.x[], plot.y[]))
-    mini = Vec3f(first.(mini_maxi)..., 0)
-    maxi = Vec3f(last.(mini_maxi)..., 0)
-    return Rect3f(mini, maxi .- mini)
+    mini = Vec3(first.(mini_maxi)..., 0)
+    maxi = Vec3(last.(mini_maxi)..., 0)
+    return Rect3(mini, maxi .- mini)
 end

--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -9,6 +9,7 @@ const FPS = Observable(30)
 const COLOR_ACCENT = Ref(RGBf(((79, 122, 214) ./ 255)...))
 const COLOR_ACCENT_DIMMED = Ref(RGBf(((174, 192, 230) ./ 255)...))
 
+include("data_preprocessor.jl")
 include("blocks.jl")
 include("geometrybasics_extension.jl")
 include("mousestatemachine.jl")

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -864,15 +864,12 @@ function getlimits(la::Axis, dim)
     end
     # get all data limits, minus the excluded plots
     dl = Makie.data_limits(la.scene, exclude)
-    @info "DL $dl"
     boundingbox = apply_inv_autoscale(la.autoscaling, dl)
-    @info "BB $boundingbox"
     # if there are no bboxes remaining, `nothing` signals that no limits could be determined
     Makie.isfinite_rect(boundingbox) || return nothing
 
     # otherwise start with the first box
     mini, maxi = minimum(boundingbox), maximum(boundingbox)
-    @info "output: $mini, $maxi"
     return (mini[dim], maxi[dim])
 end
 

--- a/src/makielayout/data_preprocessor.jl
+++ b/src/makielayout/data_preprocessor.jl
@@ -1,0 +1,136 @@
+mutable struct LinearTransform{T}
+    scale::T
+    offset::T
+end
+
+LinearTransform{Float64}() = LinearTransform(1.0, 0.0)
+LinearTransform{T}() where {T <: Vec} = LinearTransform(T(1), T(0))
+
+(t::LinearTransform)(x) = @. t.scale * x + t.offset
+Base.inv(t::LinearTransform) = LinearTransform(1.0 ./ t.scale, - t.offset ./ t.scale)
+
+struct AutoScaling{N, T}
+    transforms::NTuple{N, LinearTransform{T}}
+    updater::Observable{Nothing}
+
+    # We want:
+    # 1. 1 / threshold < width / abs_maximum < threshold
+    # 2. -threshold < minimum < maximum < threshold
+    # if either is false, rescale minimum and maximum to -target, target
+
+    threshold::Vec{N, T}
+    target::Vec{N, T}
+end
+
+function AutoScaling(dims::Int, threshold = 1e6, target = 1e3)
+    return AutoScaling(
+        ntuple(_ -> LinearTransform{Float64}(), dims),
+        Observable(nothing), 
+        Vec{dims, Float64}(threshold),
+        Vec{dims, Float64}(target)
+    )
+end
+
+function update_limits!(auto::AutoScaling{2}, limits::Rect2{Float64})
+    @info "Autolimits update"
+    _min = minimum(limits)
+    _max = maximum(limits)
+    @info "Limits: $_min, $_max"
+
+    requires_update = false
+
+    for dim in 1:2
+        x0 = auto.transforms[dim](_min[dim])
+        x1 = auto.transforms[dim](_max[dim])
+
+        check1 = 1.0 / auto.threshold[dim] < x1 - x0 < auto.threshold[dim]
+        check2 = -auto.threshold[dim] < x0
+        check3 = x1 < auto.threshold[dim]
+        @info "[$dim] $x0, $x1, $(x1-x0) $check1 $check2 $check3"
+
+        if !(check1 && check2 && check3)
+            T = auto.transforms[dim]
+            T.scale  = 2 * auto.target[dim] ./ (_max[dim] .- _min[dim]) 
+            T.offset = auto.target[dim] - T.scale .* _max[dim]
+            @info "Tranform $T"
+            requires_update = true
+        end
+    end
+
+    if requires_update
+        notify(auto.updater)
+    end
+
+    return requires_update
+end
+
+function apply_inv_autoscale(auto::AutoScaling{2}, limits::Rect2)
+    x, y = minimum(limits)
+    w, h = widths(limits)
+    Tx, Ty = inv.(auto.transforms)
+    return Rect2{Float64}(Tx(x), Ty(y), Tx.scale * w, Ty.scale * h)
+end
+
+function apply_inv_autoscale(auto::AutoScaling{2}, limits::Rect)
+    x, y, z = minimum(limits)
+    w, h, d = widths(limits)
+    Tx, Ty = inv.(auto.transforms)
+    return Rect3{Float64}(Vec3(Tx(x), Ty(y), z), Vec3(Tx.scale * w, Ty.scale * h, d))
+end
+
+function apply_autoscale(auto::AutoScaling{2}, limits::Rect2)
+    x, y = minimum(limits)
+    w, h = widths(limits)
+    Tx, Ty = auto.transforms
+    return Rect2{Float64}(Tx(x), Ty(y), Tx.scale * w, Ty.scale * h)
+end
+
+function map_autoscale(auto::AutoScaling{2}, args::Tuple{<: Vector{T}}) where {T <: VecTypes}
+    return (map(auto.updater) do _
+        output = map(args[1]) do p
+            T(auto.transforms[1](p[1]), auto.transforms[2].(p[2]))
+        end
+        return output
+    end, )
+end
+
+function map_autoscale(auto::AutoScaling{2}, args::Tuple{<: Vector, <: Vector})
+    return (
+        map(auto.updater) do _ 
+            x = auto.transforms[1].(args[1])
+            @info "transformed: $x"
+            return x
+        end,
+        map(auto.updater) do _ 
+            x = auto.transforms[2].(args[2])
+            @info "transformed: $x"
+            return x
+        end
+    )
+end
+
+function map_autoscale(auto::AutoScaling{2}, args::Tuple{<: Rect2})
+    return (map(auto.updater) do _
+        x, y = minimum(args[1])
+        w, h = widths(args[1])
+        Tx, Ty = auto.transforms
+        return Rect2{Float64}(Tx(x), Ty(y), Tx.scale * w, Ty.scale * h)
+    end,)
+end
+
+function map_autoscale(auto::AutoScaling{2}, args::Tuple{Observable{<: Rect2}})
+    return (map(auto.updater, args...) do _, rect
+        x, y = minimum(rect)
+        w, h = widths(rect)
+        Tx, Ty = auto.transforms
+        return Rect2{Float64}(Tx(x), Ty(y), Tx.scale * w, Ty.scale * h)
+    end,)
+end
+
+# can't be bothered
+function map_autoscale(auto::AutoScaling{2}, args)
+    @info "Skipped $(typeof(args))"
+    return args
+end
+
+# ...

--- a/src/makielayout/data_preprocessor.jl
+++ b/src/makielayout/data_preprocessor.jl
@@ -32,10 +32,8 @@ function AutoScaling(dims::Int, threshold = 1e6, target = 1e3)
 end
 
 function update_limits!(auto::AutoScaling{2}, limits::Rect2{Float64})
-    @info "Autolimits update"
     _min = minimum(limits)
     _max = maximum(limits)
-    @info "Limits: $_min, $_max"
 
     requires_update = false
 
@@ -46,13 +44,11 @@ function update_limits!(auto::AutoScaling{2}, limits::Rect2{Float64})
         check1 = 1.0 / auto.threshold[dim] < x1 - x0 < auto.threshold[dim]
         check2 = -auto.threshold[dim] < x0
         check3 = x1 < auto.threshold[dim]
-        @info "[$dim] $x0, $x1, $(x1-x0) $check1 $check2 $check3"
 
         if !(check1 && check2 && check3)
             T = auto.transforms[dim]
             T.scale  = 2 * auto.target[dim] ./ (_max[dim] .- _min[dim]) 
             T.offset = auto.target[dim] - T.scale .* _max[dim]
-            @info "Tranform $T"
             requires_update = true
         end
     end
@@ -98,12 +94,10 @@ function map_autoscale(auto::AutoScaling{2}, args::Tuple{<: Vector, <: Vector})
     return (
         map(auto.updater) do _ 
             x = auto.transforms[1].(args[1])
-            @info "transformed: $x"
             return x
         end,
         map(auto.updater) do _ 
             x = auto.transforms[2].(args[2])
-            @info "transformed: $x"
             return x
         end
     )

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -109,15 +109,15 @@ end
 
 function _chosen_limits(rz, ax)
 
-    r = positivize(Rect2f(rz.from, rz.to .- rz.from))
+    r = positivize(Rect2(rz.from, rz.to .- rz.from))
     lims = ax.finallimits[]
     # restrict to y change
     if rz.restrict_x || !ax.xrectzoom[]
-        r = Rect2f(lims.origin[1], r.origin[2], widths(lims)[1], widths(r)[2])
+        r = Rect2(lims.origin[1], r.origin[2], widths(lims)[1], widths(r)[2])
     end
     # restrict to x change
     if rz.restrict_y || !ax.yrectzoom[]
-        r = Rect2f(r.origin[1], lims.origin[2], widths(r)[1], widths(lims)[2])
+        r = Rect2(r.origin[1], lims.origin[2], widths(r)[1], widths(lims)[2])
     end
     return r
 end
@@ -203,11 +203,11 @@ function process_interaction(r::RectangleZoom, event::KeysEvent, ax::Axis)
     return Consume(true)
 end
 
-function positivize(r::Rect2f)
+function positivize(r::Rect2)
     negwidths = r.widths .< 0
     newori = ifelse.(negwidths, r.origin .+ r.widths, r.origin)
     newwidths = ifelse.(negwidths, -r.widths, r.widths)
-    return Rect2f(newori, newwidths)
+    return Rect2(newori, newwidths)
 end
 
 function process_interaction(l::LimitReset, event::MouseEvent, ax::Axis)
@@ -275,11 +275,11 @@ function process_interaction(s::ScrollZoom, event::ScrollEvent, ax::Axis)
         timed_ticklabelspace_reset(ax, s.reset_timer, s.prev_xticklabelspace, s.prev_yticklabelspace, s.reset_delay)
 
         newrect_trans = if ispressed(scene, xzoomkey[])
-            Rectf(newxorigin, yorigin, newxwidth, ywidth)
+            Rect(newxorigin, yorigin, newxwidth, ywidth)
         elseif ispressed(scene, yzoomkey[])
-            Rectf(xorigin, newyorigin, xwidth, newywidth)
+            Rect(xorigin, newyorigin, xwidth, newywidth)
         else
-            Rectf(newxorigin, newyorigin, newxwidth, newywidth)
+            Rect(newxorigin, newyorigin, newxwidth, newywidth)
         end
 
         inv_transf = Makie.inverse_transform(transf)
@@ -346,7 +346,7 @@ function process_interaction(dp::DragPan, event::MouseEvent, ax)
     timed_ticklabelspace_reset(ax, dp.reset_timer, dp.prev_xticklabelspace, dp.prev_yticklabelspace, dp.reset_delay)
 
     inv_transf = Makie.inverse_transform(transf)
-    newrect_trans = Rectf(Vec2f(xori, yori), widths(tlimits_trans))
+    newrect_trans = Rect(Vec2(xori, yori), widths(tlimits_trans))
     tlimits[] = Makie.apply_transform(inv_transf, newrect_trans)
 
     return Consume(true)

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -3,7 +3,7 @@ function LineAxis(parent::Scene; @nospecialize(kwargs...))
     return LineAxis(parent, attrs)
 end
 
-function calculate_horizontal_extends(endpoints)::Tuple{Float32, NTuple{2, Float32}, Bool}
+function calculate_horizontal_extends(endpoints)::Tuple{Float64, NTuple{2, Float64}, Bool}
     if endpoints[1][2] == endpoints[2][2]
         horizontal = true
         extents = (endpoints[1][1], endpoints[2][1])
@@ -29,17 +29,17 @@ function calculate_protrusion(
 
     label_is_empty::Bool = iswhitespace(label) || isempty(label)
 
-    real_labelsize::Float32 = if label_is_empty
+    real_labelsize::Float64 = if label_is_empty
         0f0
     else
         boundingbox(labeltext).widths[horizontal[] ? 2 : 1]
     end
 
-    labelspace::Float32 = (labelvisible && !label_is_empty) ? real_labelsize + labelpadding : 0f0
+    labelspace::Float64 = (labelvisible && !label_is_empty) ? real_labelsize + labelpadding : 0f0
 
-    _tickspace::Float32 = (ticksvisible && !isempty(ticklabel_annotation_obs[])) ? tickspace : 0f0
+    _tickspace::Float64 = (ticksvisible && !isempty(ticklabel_annotation_obs[])) ? tickspace : 0f0
 
-    ticklabelgap::Float32 = (ticklabelsvisible && actual_ticklabelspace > 0) ? actual_ticklabelspace + ticklabelpad : 0f0
+    ticklabelgap::Float64 = (ticklabelsvisible && actual_ticklabelspace > 0) ? actual_ticklabelspace + ticklabelpad : 0f0
 
     return _tickspace + ticklabelgap + labelspace
 end
@@ -49,7 +49,7 @@ function create_linepoints(
         pos_ext_hor,
         flipped::Bool, spine_width::Number, trimspine::Union{Bool, Tuple{Bool, Bool}}, tickpositions::Vector{Point2f}, tickwidth::Number)
 
-    (position::Float32, extents::NTuple{2, Float32}, horizontal::Bool) = pos_ext_hor
+    (position::Float64, extents::NTuple{2, Float64}, horizontal::Bool) = pos_ext_hor
 
     if trimspine isa Bool
         trimspine = (trimspine, trimspine)
@@ -141,7 +141,7 @@ function update_ticklabel_node(
 
     nticks = length(tickvalues[])
 
-    ticklabelgap::Float32 = spinewidth[] + tickspace[] + ticklabelpad[]
+    ticklabelgap::Float64 = spinewidth[] + tickspace[] + ticklabelpad[]
 
     shift = if horizontal[]
         Point2f(0f0, flipped ? ticklabelgap : -ticklabelgap)
@@ -185,11 +185,11 @@ end
 function update_tickpos_string(closure_args, tickvalues_labels_unfiltered, reversed::Bool, scale)
 
     tickstrings, tickpositions, tickvalues, pos_extents_horizontal, limits_obs = closure_args
-    limits = limits_obs[]::NTuple{2, Float32}
+    limits = limits_obs[]::NTuple{2, Float64}
 
     tickvalues_unfiltered, tickstrings_unfiltered = tickvalues_labels_unfiltered
 
-    position::Float32, extents_uncorrected::NTuple{2, Float32}, horizontal::Bool = pos_extents_horizontal[]
+    position::Float64, extents_uncorrected::NTuple{2, Float64}, horizontal::Bool = pos_extents_horizontal[]
 
     extents = reversed ? reverse(extents_uncorrected) : extents_uncorrected
 
@@ -226,8 +226,8 @@ function update_tickpos_string(closure_args, tickvalues_labels_unfiltered, rever
     return
 end
 
-function update_minor_ticks(minortickpositions, limits::NTuple{2, Float32}, pos_extents_horizontal, minortickvalues, scale, reversed::Bool)
-    position::Float32, extents_uncorrected::NTuple{2, Float32}, horizontal::Bool = pos_extents_horizontal
+function update_minor_ticks(minortickpositions, limits::NTuple{2, Float64}, pos_extents_horizontal, minortickvalues, scale, reversed::Bool)
+    position::Float64, extents_uncorrected::NTuple{2, Float64}, horizontal::Bool = pos_extents_horizontal
 
     extents = reversed ? reverse(extents_uncorrected) : extents_uncorrected
 
@@ -265,8 +265,8 @@ function LineAxis(parent::Scene, attrs::Attributes)
 
     pos_extents_horizontal = lift(calculate_horizontal_extends, endpoints; ignore_equal_values=true)
     horizontal = lift(x-> x[3], pos_extents_horizontal)
-    # Tuple constructor converts more than `convert(NTuple{2, Float32}, x)` but we still need the conversion to Float32 tuple:
-    limits = lift(x-> convert(NTuple{2, Float32}, Tuple(x)), attrs.limits; ignore_equal_values=true)
+    # Tuple constructor converts more than `convert(NTuple{2, Float64}, x)` but we still need the conversion to Float64 tuple:
+    limits = lift(x-> convert(NTuple{2, Float64}, Tuple(x)), attrs.limits; ignore_equal_values=true)
     flipped = lift(x-> convert(Bool, x), attrs.flipped; ignore_equal_values=true)
 
     ticksnode = Observable(Point2f[]; ignore_equal_values=true)
@@ -372,13 +372,13 @@ function LineAxis(parent::Scene, attrs::Attributes)
             horizontal::Bool, flip_vertical_label::Bool
         return if labelrotation isa Automatic
             if horizontal
-                0f0
+                0.0
             else
-                (flip_vertical_label ? -0.5f0 : 0.5f0) * π
+                (flip_vertical_label ? -0.5 : 0.5) * π
             end
         else
-            Float32(labelrotation)
-        end::Float32
+            Float64(labelrotation)
+        end::Float64
     end
 
     labeltext = text!(
@@ -391,25 +391,25 @@ function LineAxis(parent::Scene, attrs::Attributes)
     # translate axis labels on explicit rotations
     # in order to prevent plot and axis overlap
     onany(labelrotation, flipped, horizontal) do labelrotation, flipped, horizontal
-        xs::Float32, ys::Float32 = if labelrotation isa Automatic
-            0f0, 0f0
+        xs::Float64, ys::Float64 = if labelrotation isa Automatic
+            0.0, 0.0
         else
             wx, wy = widths(boundingbox(labeltext))
             sign::Int = flipped ? 1 : -1
             if horizontal
-                0f0, Float32(sign * 0.5f0 * wy)
+                0.0, Float64(sign * 0.5 * wy)
             else
-                Float32(sign * 0.5f0 * wx), 0f0
+                Float64(sign * 0.5 * wx), 0.0
             end
         end
-        translate!(labeltext, xs, ys, 0f0)
+        translate!(labeltext, xs, ys, 0.0)
     end
 
     decorations[:labeltext] = labeltext
 
-    tickvalues = Observable(Float32[]; ignore_equal_values=true)
+    tickvalues = Observable(Float64[]; ignore_equal_values=true)
 
-    tickvalues_labels_unfiltered = Observable{Tuple{Vector{Float32},Vector{AbstractString}}}()
+    tickvalues_labels_unfiltered = Observable{Tuple{Vector{Float64},Vector{AbstractString}}}()
     map!(tickvalues_labels_unfiltered, pos_extents_horizontal, limits, ticks, tickformat, attrs.scale) do (position, extents, horizontal),
             limits, ticks, tickformat, scale
         get_ticks(ticks, scale, tickformat, limits...)
@@ -422,7 +422,7 @@ function LineAxis(parent::Scene, attrs::Attributes)
         Observable((tickstrings, tickpositions, tickvalues, pos_extents_horizontal, limits)),
         tickvalues_labels_unfiltered, reversed, attrs.scale)
 
-    minortickvalues = Observable(Float32[]; ignore_equal_values=true)
+    minortickvalues = Observable(Float64[]; ignore_equal_values=true)
     minortickpositions = Observable(Point2f[]; ignore_equal_values=true)
 
     onany(tickvalues, minorticks) do tickvalues, minorticks
@@ -759,5 +759,5 @@ function get_minor_tickvalues(i::IntervalsBetween, scale::Union{typeof(log), typ
 end
 
 function get_minor_tickvalues(v::AbstractVector{<:Real}, _, _, _, _)
-    Float32.(v)
+    Float64.(v)
 end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -121,14 +121,14 @@ IntervalsBetween(n) = IntervalsBetween(n, true)
 
 mutable struct LineAxis
     parent::Scene
-    protrusion::Observable{Float32}
+    protrusion::Observable{Float64}
     attributes::Attributes
     elements::Dict{Symbol, Any}
     tickpositions::Observable{Vector{Point2f}}
-    tickvalues::Observable{Vector{Float32}}
+    tickvalues::Observable{Vector{Float64}}
     ticklabels::Observable{Vector{AbstractString}}
     minortickpositions::Observable{Vector{Point2f}}
-    minortickvalues::Observable{Vector{Float32}}
+    minortickvalues::Observable{Vector{Float64}}
 end
 
 struct LimitReset end
@@ -188,8 +188,9 @@ end
     scene::Scene
     xaxislinks::Vector{Axis}
     yaxislinks::Vector{Axis}
-    targetlimits::Observable{Rect2f}
-    finallimits::Observable{Rect2f}
+    targetlimits::Observable{Rect2{Float64}}
+    finallimits::Observable{Rect2{Float64}}
+    autoscaling::AutoScaling{2, Float64}
     cycler::Cycler
     palette::Attributes
     block_limit_linking::Observable{Bool}


### PR DESCRIPTION
# Description

Fixes #1373 and related in `Axis`. Tangentially also fixes `range step cannot be zero` issues since I changed that to use Float64.

The idea of this is to introduce an `AutoScale` object that scales values to Float32 friendly range. The scaling is based on axis limits and applied to data before creating a plot object. 

Example:
```julia
ys = 1e9 .+ collect(1:10) # eps(1f9) = 64
xs = collect(1:10)
f, a, p = scatter(xs, ys)
autolimits!(a) # needed in REPL
```

![Screenshot from 2023-01-04 09-18-00](https://user-images.githubusercontent.com/10947937/210514296-81382e7a-bf6d-4c55-90fb-b4304a5002a3.png)

Summary of what's happening with this pr:
1. empty Axis is created with default values (including a `1 * x + 0` scaling in AutoScale)
2. The plot is inserted with its input data reacting to `AutoScale`. Since there is no scaling yet it just duplicated data so far.
3. A limit update gets triggered which fetches the data limits of the plot. The scaling is inverted here to get the original input data
4. The update of final limit calls `update_limit!(autoscale, limits)` which notices that the limits are not in Float32 firendly range. The scaling gets updated
5. The scaling update triggers a recomputation of the scaled input data and camera matrices
6. Via the `autolimits!(a)` call the process starts over from (3) but the scaling is already fine, so no extra updates there.

Some Notes:
- I probably changed way more to Float64 than necessary. I just replaced everything in a few places.
- Maybe it makes sense to have this as a transform_func instead?
- This will probably break if plots are rotated. And not work in 3D for similar reasons. Though I think the Float32 Problems are mainly an issue in 2D.
- There are lots of signatures not caught in `map_autoscale`
- updates of `AutoScale` should retrigger limit updates if and only if limits are picked automatically.
- Adjusting `plot.input_args` is probably a bad idea since that `plot.converted` is sometimes used. E.g. in DataInspector...

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
