### PR TITLE
Fix closing of GLMakie windows on Mac

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -548,8 +548,6 @@ function destroy!(screen::Screen)
     # otherwise, during rendertask clean up we may run into a destroyed window
     wait(screen)
     screen.rendertask = nothing
-    @info "stop renderloop"
-    stop_renderloop!(screen, close_after_renderloop = false)
     destroy!(screen.glscreen)
     # Since those are sets, we can just delete them from there, even if they weren't in there (e.g. reuse=false)
     delete!(SCREEN_REUSE_POOL, screen)

--- a/src/display.jl
+++ b/src/display.jl
@@ -42,6 +42,7 @@ function push_screen!(scene::Scene, screen::MakieScreen)
         # when screen closes, it should set the scene isopen event to false
         # so that's when we can remove the screen
         if !is_open
+            close(screen)
             delete_screen!(scene, screen)
             # deregister itself after letting other listeners run
             if !isnothing(deregister)


### PR DESCRIPTION
- actually close the window when it's supposed to be closed
- add unrelated missing null check found in the course of debugging

# Description

Fixes #393, fixes #482, fixes #658, fixes #682

I always suspected that windows not closing were an issue of glfw on Mac, given that it always seemed to work ok on Linux and Windows. There actually is a problem with glfw as it was explained to me here https://github.com/glfw/glfw/issues/1766#issuecomment-1370149706 but following down that trail I noticed that it is a separate issue from windows not disappearing at all. The stuck process, which is really what the glfw issue is about, is not so bad for user experience, because it doesn't get in the way (unlike stuck windows). So I once more followed the chain of events that happen when the x button is pressed on the window:

- The glfw ShouldClose callback triggers
- the `scene.events.window_open` observable is set to `false`
- this triggers a function that removes everything from the scene but doesn't actually call `close` on it. Why this worked on Linux and Windows I don't know. `close` does the stuff that actually hides a window..
- `close` actually also sets `window_open[] = false`. To avoid an infinite loop, I put this behind a check. Not sure if this would actually need to be removed, but I'm not sure when else `close` could be called so it seems better to leave it in.

Hopefully this doesn't conflict with Linux and Windows behavior and settles that annoying issue once and for all.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
