### PR TITLE
tests: use unit framerate for debugging

### DIFF
--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -201,7 +201,7 @@ end
     title_str = Observable("t = 0.00")
     sp = streamplot(sf, -2..2, -2..2;
                     linewidth=2, colormap=:magma, axis=(;title=title_str))
-    Record(sp, LinRange(0, 20, 5)) do i
+    Record(sp, LinRange(0, 20, 5); framerate=1) do i
         sf[] = Base.Fix2(v, i)
         title_str[] = "t = $(round(i; sigdigits=2))"
     end
@@ -211,7 +211,7 @@ end
 @reference_test "Line changing colour" begin
     fig, ax, lineplot = lines(RNG.rand(10); linewidth=10)
     N = 20
-    Record(fig, 1:N; framerate=20) do i
+    Record(fig, 1:N; framerate=1) do i
         lineplot.color = RGBf(i / N, (N - i) / N, 0) # animate scene
     end
 end

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -136,7 +136,7 @@ end
 
     linesegments!(ax, linepoints, linestyle=:dot)
 
-    Record(fig, 1:2) do i
+    Record(fig, 1:2; framerate=1) do i
         t[] = i / 10
     end
 end
@@ -374,7 +374,7 @@ end
     wf = wireframe!(ax, xrange, xrange, lift(x -> x .+ 1.0, surf[3]),
         linewidth=2f0, color=lift(x -> to_colormap(x)[5], surf[:colormap])
     )
-    Record(fig, range(5, stop=40, length=3)) do i
+    Record(fig, range(5, stop=40, length=3); framerate=1) do i
         surf[3] = surf_func(i)
     end
 end
@@ -424,7 +424,7 @@ end
     Makie.translate!(p, 0, 0, 0)
     colors = to_colormap(:RdYlBu)
     N = 5
-    Record(f, 1:N) do i
+    Record(f, 1:N; framerate=1) do i
         t = i/(N/5)
         if length(lineplots) < 20
             p = lines!(


### PR DESCRIPTION
Use a unit framerate in the tests (since typically examples have small number of frames).
Useful for debugging / regression checks.