### PR TITLE
Add a few more precompiles

### DIFF
--- a/GLMakie/src/precompiles.jl
+++ b/GLMakie/src/precompiles.jl
@@ -10,15 +10,22 @@ macro compile(block)
 end
 
 let
-    @precompile_all_calls begin
-        GLMakie.activate!()
-        screen = GLMakie.singleton_screen(false)
-        close(screen)
-        destroy!(screen)
-        base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
-        shared_precompile = joinpath(base_path, "shared-precompile.jl")
-        include(shared_precompile)
+    @precompile_setup begin
+        x = rand(5)
+        @precompile_all_calls begin
+            GLMakie.activate!()
+            screen = GLMakie.singleton_screen(false)
+            close(screen)
+            destroy!(screen)
+            base_path = normpath(joinpath(dirname(pathof(Makie)), "..", "precompile"))
+            shared_precompile = joinpath(base_path, "shared-precompile.jl")
+            include(shared_precompile)
+            try
+                display(plot(x))
+            catch
+            end
+            closeall()
+        end
     end
-    closeall()
     nothing
 end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -10,10 +10,10 @@ struct DataAspect end
 
 
 struct Cycler
-    counters::Dict{Type, Int}
+    counters::IdDict{Type, Int}
 end
 
-Cycler() = Cycler(Dict{Type, Int}())
+Cycler() = Cycler(IdDict{Type, Int}())
 
 
 struct Cycle

--- a/src/precompiles.jl
+++ b/src/precompiles.jl
@@ -19,3 +19,8 @@ let
     end
     nothing
 end
+
+for T in (DragPan, RectangleZoom, LimitReset)
+    precompile(process_interaction, (T, MouseEvent, Axis))
+end
+precompile(process_axis_event, (Axis, MouseEvent))


### PR DESCRIPTION
On my machine, this drops TTFP from 1.75s to just under 1s.

Note the second commit changes an internal type to `IdDict`. Happy to omit that if it would somehow be problematic.