### PR TITLE
add anonymized cloudflare tracking to docs

### DIFF
--- a/docs/_layout/foot.html
+++ b/docs/_layout/foot.html
@@ -55,6 +55,9 @@
 
     <!-- <script src="/libs/minimal-mistakes/main.min.js"></script> -->
     <script defer src="https://use.fontawesome.com/releases/v5.8.2/js/all.js" integrity="sha384-DJ25uNYET2XCl5ZF++U8eNxPWqcKohUUBUpKGlNLMchM7q4Wjg2CUpjHLaL8yYPH" crossorigin="anonymous"></script>
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "1d64fe1c797349838c82c16b692ff9b2"}'></script>
+    <!-- End Cloudflare Web Analytics -->
 
     {{ if hasmath }}
         {{ insert foot_katex.html }}


### PR DESCRIPTION
So we can get an idea which pages people visit and which are basically never seen. Should allow us to restructure the content to be more useful. From cloudflare's page:

> Cloudflare Web Analytics does not use any client-side state, such as cookies or localStorage, to collect usage metrics. We also don’t “fingerprint” individuals via their IP address, User Agent string, or any other data for the purpose of displaying analytics.
> 
> Our analytics are non-invasive and respect the privacy of your visitors.
