### PR TITLE
use `===` for `Symbol` comparison

### DIFF
--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -67,10 +67,10 @@ end
 Supported options: `[:best => Cairo.ANTIALIAS_BEST, :good => Cairo.ANTIALIAS_GOOD, :subpixel => Cairo.ANTIALIAS_SUBPIXEL, :none => Cairo.ANTIALIAS_NONE]`
 """
 function to_cairo_antialias(sym::Symbol)
-    sym == :best && return Cairo.ANTIALIAS_BEST
-    sym == :good && return Cairo.ANTIALIAS_GOOD
-    sym == :subpixel && return Cairo.ANTIALIAS_SUBPIXEL
-    sym == :none && return Cairo.ANTIALIAS_NONE
+    sym === :best && return Cairo.ANTIALIAS_BEST
+    sym === :good && return Cairo.ANTIALIAS_GOOD
+    sym === :subpixel && return Cairo.ANTIALIAS_SUBPIXEL
+    sym === :none && return Cairo.ANTIALIAS_NONE
     error("Wrong antialias setting: $(sym). Allowed: :best, :good, :subpixel, :none")
 end
 to_cairo_antialias(aa::Int) = aa

--- a/GLMakie/src/GLAbstraction/GLTexture.jl
+++ b/GLMakie/src/GLAbstraction/GLTexture.jl
@@ -476,16 +476,16 @@ map_texture_paramers(s::NTuple{N, Symbol}) where {N} = map(map_texture_paramers,
 
 function map_texture_paramers(s::Symbol)
 
-    s == :clamp_to_edge && return GL_CLAMP_TO_EDGE
-    s == :mirrored_repeat && return GL_MIRRORED_REPEAT
-    s == :repeat && return GL_REPEAT
+    s === :clamp_to_edge && return GL_CLAMP_TO_EDGE
+    s === :mirrored_repeat && return GL_MIRRORED_REPEAT
+    s === :repeat && return GL_REPEAT
 
-    s == :linear && return GL_LINEAR
-    s == :nearest && return GL_NEAREST
-    s == :nearest_mipmap_nearest && return GL_NEAREST_MIPMAP_NEAREST
-    s == :linear_mipmap_nearest && return GL_LINEAR_MIPMAP_NEAREST
-    s == :nearest_mipmap_linear && return GL_NEAREST_MIPMAP_LINEAR
-    s == :linear_mipmap_linear && return GL_LINEAR_MIPMAP_LINEAR
+    s === :linear && return GL_LINEAR
+    s === :nearest && return GL_NEAREST
+    s === :nearest_mipmap_nearest && return GL_NEAREST_MIPMAP_NEAREST
+    s === :linear_mipmap_nearest && return GL_LINEAR_MIPMAP_NEAREST
+    s === :nearest_mipmap_linear && return GL_NEAREST_MIPMAP_LINEAR
+    s === :linear_mipmap_linear && return GL_LINEAR_MIPMAP_LINEAR
 
     error("$s is not a valid texture parameter")
 end
@@ -498,7 +498,7 @@ function TextureParameters(T, NDim;
         z_repeat  = x_repeat, #wrap_r
         anisotropic = 1f0
     )
-    T <: Integer && (minfilter == :linear || magfilter == :linear) && error("Wrong Texture Parameter: Integer texture can't interpolate. Try :nearest")
+    T <: Integer && (minfilter === :linear || magfilter === :linear) && error("Wrong Texture Parameter: Integer texture can't interpolate. Try :nearest")
     repeat = (x_repeat, y_repeat, z_repeat)
     swizzle_mask = if T <: Gray
         GLenum[GL_RED, GL_RED, GL_RED, GL_ONE]

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -434,7 +434,7 @@ function RenderObject(
         end
     end
     buffers = filter(((key, value),) -> isa(value, GLBuffer) || key === :indices, data)
-    uniforms = filter(((key, value),) -> !isa(value, GLBuffer) && key != :indices, data)
+    uniforms = filter(((key, value),) -> !isa(value, GLBuffer) && key !== :indices, data)
     merge!(data, passthrough) # in the end, we insert back the non opengl data, to keep things simple
     program = gl_convert(to_value(program), data) # "compile" lazyshader
     vertexarray = GLVertexArray(Dict(buffers), program)

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -209,7 +209,7 @@ function GLVertexArray(bufferdict::Dict, program::GLProgram)
         if isa(buffer, GLBuffer) && buffer.buffertype == GL_ELEMENT_ARRAY_BUFFER
             bind(buffer)
             indexes = buffer
-        elseif Symbol(name) == :indices
+        elseif Symbol(name) === :indices
             indexes = buffer
         else
             attribute = string(name)
@@ -220,7 +220,7 @@ function GLVertexArray(bufferdict::Dict, program::GLProgram)
                 bufferlengths = ""
                 for (name, buffer) in bufferdict
                     if isa(buffer, GLBuffer) && buffer.buffertype == GL_ELEMENT_ARRAY_BUFFER
-                    elseif Symbol(name) == :indices
+                    elseif Symbol(name) === :indices
                     else
                         bufferlengths *= "\n\t$name has length $(length(buffer))"
                     end
@@ -433,7 +433,7 @@ function RenderObject(
             end
         end
     end
-    buffers = filter(((key, value),) -> isa(value, GLBuffer) || key == :indices, data)
+    buffers = filter(((key, value),) -> isa(value, GLBuffer) || key === :indices, data)
     uniforms = filter(((key, value),) -> !isa(value, GLBuffer) && key != :indices, data)
     merge!(data, passthrough) # in the end, we insert back the non opengl data, to keep things simple
     program = gl_convert(to_value(program), data) # "compile" lazyshader

--- a/GLMakie/src/GLAbstraction/GLUtils.jl
+++ b/GLMakie/src/GLAbstraction/GLUtils.jl
@@ -34,7 +34,7 @@ gen_defaults! dict begin
 end
 """
 macro gen_defaults!(dict, args)
-    args.head == :block || error("second argument needs to be a block of form
+    args.head === :block || error("second argument needs to be a block of form
     begin
         a = 55
         b = a * 2 # variables, like a, will get made visible in local scope
@@ -54,14 +54,14 @@ macro gen_defaults!(dict, args)
         doc_strings           = :()
         if Meta.isexpr(elem, :(=))
             key_name, value_expr = elem.args
-            if isa(key_name, Expr) && key_name.head == :(::) # we need to convert to a julia type
+            if isa(key_name, Expr) && key_name.head === :(::) # we need to convert to a julia type
                 key_name, convert_target = key_name.args
                 convert_target = :(GLAbstraction.signal_convert($convert_target, $key_name))
             else
                 convert_target = :($key_name)
             end
             key_sym = Expr(:quote, key_name)
-            if isa(value_expr, Expr) && value_expr.head == :call && value_expr.args[1] == :(=>)  # we might need to insert a convert target
+            if isa(value_expr, Expr) && value_expr.head === :call && value_expr.args[1] === :(=>)  # we might need to insert a convert target
                 value_expr, target = value_expr.args[2:end]
                 undecided = []
                 if isa(target, Expr)

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -29,18 +29,18 @@ function to_range(x::AbstractArray)
 end
 
 function to_glvisualize_key(k)
-    k == :rotations && return :rotation
-    k == :markersize && return :scale
-    k == :glowwidth && return :glow_width
-    k == :glowcolor && return :glow_color
-    k == :strokewidth && return :stroke_width
-    k == :strokecolor && return :stroke_color
-    k == :positions && return :position
-    k == :linewidth && return :thickness
-    k == :marker_offset && return :quad_offset
-    k == :colormap && return :color_map
-    k == :colorrange && return :color_norm
-    k == :transform_marker && return :scale_primitive
+    k === :rotations && return :rotation
+    k === :markersize && return :scale
+    k === :glowwidth && return :glow_width
+    k === :glowcolor && return :glow_color
+    k === :strokewidth && return :stroke_width
+    k === :strokecolor && return :stroke_color
+    k === :positions && return :position
+    k === :linewidth && return :thickness
+    k === :marker_offset && return :quad_offset
+    k === :colormap && return :color_map
+    k === :colorrange && return :color_norm
+    k === :transform_marker && return :scale_primitive
     return k
 end
 

--- a/MakieRecipes/src/pipeline_integration.jl
+++ b/MakieRecipes/src/pipeline_integration.jl
@@ -153,7 +153,7 @@ function translate_to_makie!(st, pa)
 
         pa[:linewidth] = get(pa, :linewidth, 1)
 
-    elseif st == :scatter
+    elseif st === :scatter
         if !isnothing(get(pa, :color, nothing))
             # pa[:color] = pa[:color]
         end
@@ -192,11 +192,11 @@ function translate_to_makie!(st, pa)
     elseif st ∈ (:surface, :heatmap, :image)
         haskey(pa, :fill_z) && (pa[:color] = pa[:fill_z])
         pa[:shading] = false # set shading to false, default in Plots
-    elseif st == :contour
+    elseif st === :contour
         # pa[:levels] = pa[:levels]
-    elseif st == :bar
+    elseif st === :bar
         haskey(pa, :widths) && (pa[:width] = pa[:widths])
-    elseif st == :shape
+    elseif st === :shape
         if haskey(pa, :nodecolor)
             if pa[:nodecolor] isa Int
                 pa[:color] = get(pa, :palette, default_palette).colors[pa[:nodecolor]]
@@ -237,7 +237,7 @@ function set_series_color!(scene, st, plotattributes)
     has_color = (haskey(plotattributes, :color) && plotattributes[:color] !== automatic) || any(
         if st ∈ (:path, :path3d, :curves)
             haskey.(Ref(plotattributes), (:linecolor, :line_z, :seriescolor))
-        elseif st == :scatter
+        elseif st === :scatter
             haskey.(Ref(plotattributes), (:markercolor, :marker_z, :seriescolor))
         elseif st ∈ (:shape, :heatmap, :image, :surface, :contour, :bar)
             haskey.(Ref(plotattributes), (:fillcolor, :fill_z, :seriescolor, :cgrad))

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -31,17 +31,17 @@ function code_to_keyboard(code::String)
     sym = Symbol(button)
     return if isdefined(Keyboard, sym)
         return getfield(Keyboard, sym)
-    elseif sym == :backquote
+    elseif sym === :backquote
         return Keyboard.grave_accent
-    elseif sym == :pageup
+    elseif sym === :pageup
         return Keyboard.page_up
-    elseif sym == :pagedown
+    elseif sym === :pagedown
         return Keyboard.page_down
-    elseif sym == :end
+    elseif sym === :end
         return Keyboard._end
-    elseif sym == :capslock
+    elseif sym === :capslock
         return Keyboard.caps_lock
-    elseif sym == :contextmenu
+    elseif sym === :contextmenu
         return Keyboard.menu
     else
         return Keyboard.unknown

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -6,7 +6,7 @@ function lift_convert(key, value, plot)
     val = lift(value) do value
         return wgl_convert(value, Key{key}(), Key{plotkey(plot)}())
     end
-    if key == :colormap && val[] isa AbstractArray
+    if key === :colormap && val[] isa AbstractArray
         return ShaderAbstractions.Sampler(val)
     else
         return val

--- a/docs/examples/plotting_functions/violin.md
+++ b/docs/examples/plotting_functions/violin.md
@@ -42,9 +42,9 @@ N = 1000
 xs = rand(1:3, N)
 dodge = rand(1:2, N)
 side = rand([:left, :right], N)
-color = @. ifelse(side == :left, :orange, :teal)
+color = @. ifelse(side === :left, :orange, :teal)
 ys = map(side) do s
-    return s == :left ? randn() : rand()
+    return s === :left ? randn() : rand()
 end
 
 violin(xs, ys, dodge = dodge, side = side, color = color)
@@ -61,11 +61,11 @@ N = 1000
 xs = rand(1:3, N)
 side = rand([:left, :right], N)
 color = map(xs, side) do x, s
-    colors = s == :left ? [:red, :orange, :yellow] : [:blue, :teal, :cyan]
+    colors = s === :left ? [:red, :orange, :yellow] : [:blue, :teal, :cyan]
     return colors[x]
 end
 ys = map(side) do s
-    return s == :left ? randn() : rand()
+    return s === :left ? randn() : rand()
 end
 
 violin(xs, ys, side = side, color = color)

--- a/metrics/ttfp/benchmark-ttfp.jl
+++ b/metrics/ttfp/benchmark-ttfp.jl
@@ -19,7 +19,7 @@ function get_colorbuffer(fig)
     end
 end
 
-if Package == :WGLMakie
+if Package === :WGLMakie
     import Electron
     WGLMakie.JSServe.use_electron_display()
 end

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -131,9 +131,9 @@ function Makie.plot!(plot::Errorbars{T}) where T <: Tuple{AbstractVector{<:VecTy
     x_y_low_high = plot[1]
 
     is_in_y_direction = lift(plot.direction) do dir
-        if dir == :y
+        if dir === :y
             true
-        elseif dir == :x
+        elseif dir === :x
             false
         else
             error("Invalid direction $dir. Options are :x and :y.")
@@ -158,9 +158,9 @@ function Makie.plot!(plot::Rangebars{T}) where T <: Tuple{AbstractVector{<:VecTy
     val_low_high = plot[1]
 
     is_in_y_direction = lift(plot.direction) do dir
-        if dir == :y
+        if dir === :y
             true
-        elseif dir == :x
+        elseif dir === :x
             false
         else
             error("Invalid direction $dir. Options are :x and :y.")

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -143,7 +143,7 @@ function plot!(
 
     if any(x -> x isa AbstractString, category_labels)
         ulabels = unique(category_labels)
-        if !haskey(allattrs, :orientation) || allattrs.orientation[] == :vertical
+        if !haskey(allattrs, :orientation) || allattrs.orientation[] === :vertical
             ax.xticks = (1:length(ulabels), ulabels)
         else
             ax.yticks = (1:length(ulabels), ulabels)
@@ -240,12 +240,12 @@ function plot!(plot::RainClouds)
 
 
     # Set-up
-    if plot.orientation[] == :horizontal
+    if plot.orientation[] === :horizontal
         # flip side to when horizontal
-        side = side == :left ? :right : :left
+        side = side === :left ? :right : :left
     end
-    (side == :left) && (side_nudge_direction = 1.0)
-    (side == :right) && (side_nudge_direction = -1.0)
+    (side === :left) && (side_nudge_direction = 1.0)
+    (side === :right) && (side_nudge_direction = -1.0)
     side_scatter_nudge_with_direction = side_scatter_nudge * side_nudge_direction
     side_boxplot_nudge_with_direction = boxplot_nudge * side_nudge_direction
 
@@ -282,10 +282,10 @@ function plot!(plot::RainClouds)
                 isempty(ixs) && continue
                 xoffset = final_x_positions[ixs[1]] - recenter_to_boxplot_nudge_value
                 hist!(plot, view(data_array, ixs); offset=xoffset,
-                        scale_to=(side == :left ? -1 : 1)*cloud_width*width_ratio, bins=edges,
+                        scale_to=(side === :left ? -1 : 1)*cloud_width*width_ratio, bins=edges,
                         # yes, we really do want :x when orientation is :vertical
                         # an :x directed histogram has a vertical orientation
-                        direction=plot.orientation[] == :vertical ? :x : :y,
+                        direction=plot.orientation[] === :vertical ? :x : :y,
                         color=getuniquevalue(plot.color[], ixs))
             end
         else
@@ -295,7 +295,7 @@ function plot!(plot::RainClouds)
 
     scatter_x = final_x_positions .+ side_scatter_nudge_with_direction.*width_ratio .+
                 jitter .- recenter_to_boxplot_nudge_value.*width_ratio
-    if plot.orientation[] == :vertical
+    if plot.orientation[] === :vertical
         scatter!(plot, scatter_x, data_array; markersize=markersize, plot.color, plot.cycle)
     else
         scatter!(plot, data_array, scatter_x; markersize=markersize, plot.color, plot.cycle)

--- a/src/basic_recipes/stairs.jl
+++ b/src/basic_recipes/stairs.jl
@@ -63,7 +63,7 @@ function plot!(p::Stairs{<:Tuple{<:AbstractVector{<:Point2}}})
         end
     end
 
-    lines!(p, steppoints; [x for x in pairs(p.attributes) if x[1] != :step]...)
+    lines!(p, steppoints; [x for x in pairs(p.attributes) if x[1] !== :step]...)
     p
 end
 

--- a/src/basic_recipes/stairs.jl
+++ b/src/basic_recipes/stairs.jl
@@ -26,7 +26,7 @@ function plot!(p::Stairs{<:Tuple{<:AbstractVector{<:Point2}}})
     points = p[1]
 
     steppoints = lift(points, p.step) do points, step
-        if step == :pre
+        if step === :pre
             s_points = Vector{Point2f}(undef, length(points) * 2 - 1)
             s_points[1] = point = points[1]
             for i in 1:length(points)-1
@@ -36,7 +36,7 @@ function plot!(p::Stairs{<:Tuple{<:AbstractVector{<:Point2}}})
                 point = nextpoint
             end
             s_points
-        elseif step == :post
+        elseif step === :post
             s_points = Vector{Point2f}(undef, length(points) * 2 - 1)
             s_points[1] = point = points[1]
             for i in 1:length(points)-1
@@ -46,7 +46,7 @@ function plot!(p::Stairs{<:Tuple{<:AbstractVector{<:Point2}}})
                 point = nextpoint
             end
             s_points
-        elseif step == :center
+        elseif step === :center
             s_points = Vector{Point2f}(undef, length(points) * 2)
             s_points[1] = point = points[1]
             for i in 1:length(points)-1

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -226,17 +226,17 @@ function texelems_and_glyph_collection(str::LaTeXString, fontscale_px, halign, v
         end
     end
 
-    xshift = if halign == :center
+    xshift = if halign === :center
         width(bb) ./ 2
-    elseif halign == :left
+    elseif halign === :left
         minimum(bb)[1]
-    elseif halign == :right
+    elseif halign === :right
         maximum(bb)[1]
     end
 
-    yshift = if valign == :center
+    yshift = if valign === :center
         maximum(bb)[2] - (height(bb) / 2)
-    elseif valign == :top
+    elseif valign === :top
         maximum(bb)[2]
     else
         minimum(bb)[2]
@@ -385,21 +385,21 @@ function apply_alignment_and_justification!(lines, ju, al)
         ginfo.origin[2] + ginfo.extent.descender * ginfo.size[2]
     end
 
-    al_offset_x = if al[1] == :center
+    al_offset_x = if al[1] === :center
         max_x / 2
-    elseif al[1] == :left
+    elseif al[1] === :left
         0f0
-    elseif al[1] == :right
+    elseif al[1] === :right
         max_x
     else
         0f0
     end
 
-    al_offset_y = if al[2] == :center
+    al_offset_y = if al[2] === :center
         0.5 * (top_y + bottom_y)
-    elseif al[2] == :bottom
+    elseif al[2] === :bottom
         bottom_y
-    elseif al[2] == :top
+    elseif al[2] === :top
         top_y
     else
         0f0
@@ -421,20 +421,20 @@ end
 function float_justification(ju, al)::Float32
     halign = al[1]
     float_justification = if ju === automatic
-        if halign == :left || halign == 0
+        if halign === :left || halign == 0
             0.0f0
-        elseif halign == :right || halign == 1
+        elseif halign === :right || halign == 1
             1.0f0
-        elseif halign == :center || halign == 0.5
+        elseif halign === :center || halign == 0.5
             0.5f0
         else
             0.5f0
         end
-    elseif ju == :left
+    elseif ju === :left
         0.0f0
-    elseif ju == :right
+    elseif ju === :right
         1.0f0
-    elseif ju == :center
+    elseif ju === :center
         0.5f0
     else
         Float32(ju)

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -103,9 +103,9 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     text_offset = map(p.offset, textpadding, p.triangle_size, p.placement, p.align) do o, pad, ts, placement, align
         l, r, b, t = pad
 
-        if placement == :left 
+        if placement === :left 
             return Vec2f(-o - r - ts, b - align * (b + t))
-        elseif placement == :right
+        elseif placement === :right
             return Vec2f( o + l + ts, b - align * (b + t))
         elseif placement in (:below, :down, :bottom)
             return Vec2f(l - align * (l + r), -o - t - ts)
@@ -118,9 +118,9 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     end
 
     text_align = map(p.placement, p.align) do placement, align
-        if placement == :left 
+        if placement === :left 
             return (1.0, align)
-        elseif placement == :right
+        elseif placement === :right
             return (0.0, align)
         elseif placement in (:below, :down, :bottom)
             return (align, 1.0)
@@ -180,10 +180,10 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         o = origin(bb); w = widths(bb)
         scale!(mp, s, s, s)
         
-        if placement == :left 
+        if placement === :left 
             translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], 0))
             rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
-        elseif placement == :right
+        elseif placement === :right
             translate!(mp, Vec3f(o[1], o[2] + align * w[2], 0))
             rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
         elseif placement in (:below, :down, :bottom)
@@ -212,7 +212,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         #  |    ____
         #  |   |
 
-        shift = if placement == :left 
+        shift = if placement === :left 
             Vec2f[
                 (l, b + 0.5h), (l, t), (r, t), 
                 (r,     b + align * h + 0.5s), 
@@ -220,7 +220,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
                 (r,     b + align * h - 0.5s),
                 (r, b), (l, b), (l, b + 0.5h)
             ]
-        elseif placement == :right
+        elseif placement === :right
             Vec2f[
                 (l + 0.5w, b), (l, b), 
                 (l,   b + align * h - 0.5s), 

--- a/src/basic_recipes/tricontourf.jl
+++ b/src/basic_recipes/tricontourf.jl
@@ -55,10 +55,10 @@ function compute_contourf_colormap(levels, cmap, elow, ehigh)
 
     _cmap = to_colormap(cmap)
 
-    if elow === :auto && !(ehigh === :auto)
+    if elow === :auto && ehigh !== :auto
         cm_base = cgrad(_cmap, n + 1; categorical=true)[2:end]
         cm = cgrad(cm_base, levels_scaled; categorical=true)
-    elseif ehigh === :auto && !(elow === :auto)
+    elseif ehigh === :auto && elow !== :auto
         cm_base = cgrad(_cmap, n + 1; categorical=true)[1:(end - 1)]
         cm = cgrad(cm_base, levels_scaled; categorical=true)
     elseif ehigh === :auto && elow === :auto

--- a/src/basic_recipes/tricontourf.jl
+++ b/src/basic_recipes/tricontourf.jl
@@ -55,13 +55,13 @@ function compute_contourf_colormap(levels, cmap, elow, ehigh)
 
     _cmap = to_colormap(cmap)
 
-    if elow == :auto && !(ehigh == :auto)
+    if elow === :auto && !(ehigh === :auto)
         cm_base = cgrad(_cmap, n + 1; categorical=true)[2:end]
         cm = cgrad(cm_base, levels_scaled; categorical=true)
-    elseif ehigh == :auto && !(elow == :auto)
+    elseif ehigh === :auto && !(elow === :auto)
         cm_base = cgrad(_cmap, n + 1; categorical=true)[1:(end - 1)]
         cm = cgrad(cm_base, levels_scaled; categorical=true)
-    elseif ehigh == :auto && elow == :auto
+    elseif ehigh === :auto && elow === :auto
         cm_base = cgrad(_cmap, n + 2; categorical=true)[2:(end - 1)]
         cm = cgrad(cm_base, levels_scaled; categorical=true)
     else
@@ -73,7 +73,7 @@ end
 function compute_lowcolor(el, cmap)
     if isnothing(el)
         return RGBAf(0, 0, 0, 0)
-    elseif el === automatic || el == :auto
+    elseif el === automatic || el === :auto
         return RGBAf(to_colormap(cmap)[begin])
     else
         return to_color(el)::RGBAf
@@ -83,7 +83,7 @@ end
 function compute_highcolor(eh, cmap)
     if isnothing(eh)
         return RGBAf(0, 0, 0, 0)
-    elseif eh === automatic || eh == :auto
+    elseif eh === automatic || eh === :auto
         return RGBAf(to_colormap(cmap)[end])
     else
         return to_color(eh)::RGBAf

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -502,7 +502,7 @@ function _rotate_cam!(scene, cam::Camera3D, angles::VecTypes, from_mouse=false)
 
     # TODO maybe generalize this to arbitrary center?
     # calculate positions from rotated vectors
-    if cam.attributes[:rotation_center][] == :lookat
+    if cam.attributes[:rotation_center][] === :lookat
         cam.eyeposition[] = lookat - viewdir
     else
         cam.lookat[] = eyepos + viewdir

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -826,15 +826,15 @@ end
 "The linestyle patterns are inspired by the LaTeX package tikZ as seen here https://tex.stackexchange.com/questions/45275/tikz-get-values-for-predefined-dash-patterns."
 
 function line_diff_pattern(ls::Symbol, gaps = :normal)
-    if ls == :solid
+    if ls === :solid
         nothing
-    elseif ls == :dash
+    elseif ls === :dash
         line_diff_pattern("-", gaps)
-    elseif ls == :dot
+    elseif ls === :dot
         line_diff_pattern(".", gaps)
-    elseif ls == :dashdot
+    elseif ls === :dashdot
         line_diff_pattern("-.", gaps)
-    elseif ls == :dashdotdot
+    elseif ls === :dashdotdot
         line_diff_pattern("-..", gaps)
     else
         error(
@@ -1294,7 +1294,7 @@ convert_attribute(value, ::key"isovalue", ::key"volume") = Float32(value)
 convert_attribute(value, ::key"isorange", ::key"volume") = Float32(value)
 
 function convert_attribute(value::Symbol, ::key"marker", ::key"meshscatter")
-    if value == :Sphere
+    if value === :Sphere
         return normal_mesh(Sphere(Point3f(0), 1f0))
     else
         error("Unsupported marker: $(value)")

--- a/src/event-recorder.jl
+++ b/src/event-recorder.jl
@@ -10,7 +10,7 @@ function record_events(f, scene::Scene, path::String)
     result = Vector{Pair{Float64,Pair{Symbol,Any}}}()
     for field in fieldnames(Events)
         # These are not Observables
-        (field == :mousebuttonstate || field == :keyboardstate) && continue
+        (field === :mousebuttonstate || field === :keyboardstate) && continue
         on(getfield(scene.events, field); priority=typemax(Int)) do value
             value = isa(value, Set) ? copy(value) : value
             push!(result, time() => (field => value))
@@ -35,7 +35,7 @@ function replay_events(f, scene::Scene, path::String)
     sort!(events; by=first)
     for i in 1:length(events)
         t1, (field, value) = events[i]
-        (field == :mousebuttonstate || field == :keyboardstate) && continue
+        (field === :mousebuttonstate || field === :keyboardstate) && continue
         Base.invokelatest() do
             return getfield(scene.events, field)[] = value
         end

--- a/src/jl_rasterizer/main.jl
+++ b/src/jl_rasterizer/main.jl
@@ -48,7 +48,7 @@ function FixedGeomView(T, max_primitives, primitive_in, primitive_out)
     buffer = Vector{Tuple{Point4f, T}}(undef, max_primitives)
     # TODO implement primitive_in and out correctly
     # this is for triangle_strip and 4 max_primitives
-    if max_primitives != 4 || primitive_out != :triangle_strip
+    if max_primitives != 4 || primitive_out !== :triangle_strip
         error("Not implemented for max_primitives == $max_primitives and primitive_out == $primitive_out.")
     end
     geometry_view = if primitive_out === :triangle_strip

--- a/src/jl_rasterizer/main.jl
+++ b/src/jl_rasterizer/main.jl
@@ -51,7 +51,7 @@ function FixedGeomView(T, max_primitives, primitive_in, primitive_out)
     if max_primitives != 4 || primitive_out != :triangle_strip
         error("Not implemented for max_primitives == $max_primitives and primitive_out == $primitive_out.")
     end
-    geometry_view = if primitive_out == :triangle_strip
+    geometry_view = if primitive_out === :triangle_strip
         TriangleStripView(buffer)
     else
         error("$primitive_out not supported. Only :triangle_strip supported right now")

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -170,20 +170,20 @@ function glyph_collection(
     # shift all x values by the justification amount needed for each line
     # if justification is automatic it depends on alignment
     float_justification = if justification === automatic
-        if halign == :left || halign == 0
+        if halign === :left || halign == 0
             0.0f0
-        elseif halign == :right || halign == 1
+        elseif halign === :right || halign == 1
             1.0f0
-        elseif halign == :center || halign == 0.5
+        elseif halign === :center || halign == 0.5
             0.5f0
         else
             0.5f0
         end
-    elseif justification == :left
+    elseif justification === :left
         0.0f0
-    elseif justification == :right
+    elseif justification === :right
         1.0f0
-    elseif justification == :center
+    elseif justification === :center
         0.5f0
     else
         Float32(justification)
@@ -205,11 +205,11 @@ function glyph_collection(
     # compute x values after left/center/right alignment
     halign = if halign isa Number
         Float32(halign)
-    elseif halign == :left
+    elseif halign === :left
         0.0f0
-    elseif halign == :center
+    elseif halign === :center
         0.5f0
-    elseif halign == :right
+    elseif halign === :right
         1.0f0
     else
         error("Invalid halign $halign. Valid values are <:Number, :left, :center and :right.")
@@ -230,16 +230,16 @@ function glyph_collection(
     overall_height = first_line_ascender - ys[end] - last_line_descender
 
     # compute y values after top/center/bottom/baseline alignment
-    ys_aligned = if valign == :baseline
+    ys_aligned = if valign === :baseline
         ys .- first_line_ascender .+ overall_height .+ last_line_descender
     else
         va = if valign isa Number
             Float32(valign)
-        elseif valign == :top
+        elseif valign === :top
             1f0
-        elseif valign == :bottom
+        elseif valign === :bottom
             0f0
-        elseif valign == :center
+        elseif valign === :center
             0.5f0
         else
             error("Invalid valign $valign. Valid values are <:Number, :bottom, :baseline, :top, and :center.")
@@ -288,7 +288,7 @@ function padded_vcat(arrs::AbstractVector{T}, fillvalue) where T <: AbstractVect
 end
 
 function alignment2num(x::Symbol)
-    (x == :center) && return 0.5f0
+    (x === :center) && return 0.5f0
     (x in (:left, :bottom)) && return 0.0f0
     (x in (:right, :top)) && return 1.0f0
     return 0.0f0 # 0 default, or better to error?

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -200,7 +200,7 @@ transform_func_obs(x) = transformation(x).transform_func
 Apply the data transform func to the data if the space matches one
 of the the transformation spaces (currently only :data is transformed)
 """
-apply_transform(f, data, space) = space == :data ? apply_transform(f, data) : data  
+apply_transform(f, data, space) = space === :data ? apply_transform(f, data) : data  
 function apply_transform(f::Observable, data::Observable, space::Observable) 
     return lift((f, d, s)-> apply_transform(f, d, s), f, data, space)
 end 

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -9,9 +9,7 @@ function has_forwarded_layout end
 
 macro Block(name::Symbol, body::Expr = Expr(:block))
 
-    if !(body.head === :block)
-        error("A Block needs to be defined within a `begin end` block")
-    end
+    body.head === :block || error("A Block needs to be defined within a `begin end` block")
 
     structdef = quote
         mutable struct $name <: Makie.Block

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -9,7 +9,7 @@ function has_forwarded_layout end
 
 macro Block(name::Symbol, body::Expr = Expr(:block))
 
-    if !(body.head == :block)
+    if !(body.head === :block)
         error("A Block needs to be defined within a `begin end` block")
     end
 
@@ -27,7 +27,7 @@ macro Block(name::Symbol, body::Expr = Expr(:block))
     attrs = extract_attributes!(body)
 
     i_forwarded_layout = findfirst(
-        x -> x isa Expr && x.head == :macrocall &&
+        x -> x isa Expr && x.head === :macrocall &&
             x.args[1] == Symbol("@forwarded_layout"),
         body.args
     )
@@ -155,7 +155,7 @@ function make_attr_dict_expr(attrs, sceneattrsym, curthemesym)
     pairs = map(attrs) do a
 
         d = a.default
-        if d isa Expr && d.head == :macrocall && d.args[1] == Symbol("@inherit")
+        if d isa Expr && d.head === :macrocall && d.args[1] == Symbol("@inherit")
             if length(d.args) != 4
                 error("@inherit works with exactly 2 arguments, expression was $d")
             end
@@ -196,8 +196,8 @@ end
 
 function extract_attributes!(body)
     i = findfirst(
-        (x -> x isa Expr && x.head == :macrocall && x.args[1] == Symbol("@attributes") &&
-            x.args[3] isa Expr && x.args[3].head == :block),
+        (x -> x isa Expr && x.head === :macrocall && x.args[1] == Symbol("@attributes") &&
+            x.args[3] isa Expr && x.args[3].head === :block),
         body.args
     )
     if i === nothing
@@ -231,7 +231,7 @@ function extract_attributes!(body)
     args = filter(x -> !(x isa LineNumberNode), attrs_block.args)
 
     function extract_attr(arg)
-        has_docs = arg isa Expr && arg.head == :macrocall && arg.args[1] isa GlobalRef
+        has_docs = arg isa Expr && arg.head === :macrocall && arg.args[1] isa GlobalRef
 
         if has_docs
             docs = arg.args[3]
@@ -241,7 +241,7 @@ function extract_attributes!(body)
             attr = arg
         end
 
-        if !(attr isa Expr && attr.head == :(=) && length(attr.args) == 2)
+        if !(attr isa Expr && attr.head === :(=) && length(attr.args) == 2)
             error("$attr is not a valid attribute line like :x[::Type] = default_value")
         end
         left = attr.args[1]
@@ -250,7 +250,7 @@ function extract_attributes!(body)
             attr_symbol = left
             type = Any
         else
-            if !(left isa Expr && left.head == :(::) && length(left.args) == 2)
+            if !(left isa Expr && left.head === :(::) && length(left.args) == 2)
                 error("$left is not a Symbol or an expression such as x::Type")
             end
             attr_symbol = left.args[1]::Symbol

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -154,7 +154,7 @@ function compute_protrusions(title, titlesize, titlegap, titlevisible, spinewidt
 
     top += titlespace + subtitlespace
 
-    if yaxisposition == :left
+    if yaxisposition === :left
         left = yaxisprotrusion
     else
         right = yaxisprotrusion
@@ -263,9 +263,9 @@ function initialize_block!(ax::Axis; palette = nothing)
     onany(update_axis_camera, camera(scene), scene.transformation.transform_func, finallimits, ax.xreversed, ax.yreversed)
 
     xaxis_endpoints = lift(ax.xaxisposition, scene.px_area; ignore_equal_values=true) do xaxisposition, area
-        if xaxisposition == :bottom
+        if xaxisposition === :bottom
             return bottomline(Rect2f(area))
-        elseif xaxisposition == :top
+        elseif xaxisposition === :top
             return topline(Rect2f(area))
         else
             error("Invalid xaxisposition $xaxisposition")
@@ -273,17 +273,17 @@ function initialize_block!(ax::Axis; palette = nothing)
     end
 
     yaxis_endpoints = lift(ax.yaxisposition, scene.px_area; ignore_equal_values=true) do yaxisposition, area
-        if yaxisposition == :left
+        if yaxisposition === :left
             return leftline(Rect2f(area))
-        elseif yaxisposition == :right
+        elseif yaxisposition === :right
             return rightline(Rect2f(area))
         else
             error("Invalid yaxisposition $yaxisposition")
         end
     end
 
-    xaxis_flipped = lift(x->x == :top, ax.xaxisposition; ignore_equal_values=true)
-    yaxis_flipped = lift(x->x == :right, ax.yaxisposition; ignore_equal_values=true)
+    xaxis_flipped = lift(x->x === :top, ax.xaxisposition; ignore_equal_values=true)
+    yaxis_flipped = lift(x->x === :right, ax.yaxisposition; ignore_equal_values=true)
 
     xspinevisible = lift(xaxis_flipped, ax.bottomspinevisible, ax.topspinevisible; ignore_equal_values=true) do xflip, bv, tv
         xflip ? tv : bv
@@ -341,7 +341,7 @@ function initialize_block!(ax::Axis; palette = nothing)
     ax.yaxis = yaxis
 
     xoppositelinepoints = lift(scene.px_area, ax.spinewidth, ax.xaxisposition; ignore_equal_values=true) do r, sw, xaxpos
-        if xaxpos == :top
+        if xaxpos === :top
             y = bottom(r)
             p1 = Point2f(left(r) - 0.5sw, y)
             p2 = Point2f(right(r) + 0.5sw, y)
@@ -355,7 +355,7 @@ function initialize_block!(ax::Axis; palette = nothing)
     end
 
     yoppositelinepoints = lift(scene.px_area, ax.spinewidth, ax.yaxisposition; ignore_equal_values=true) do r, sw, yaxpos
-        if yaxpos == :right
+        if yaxpos === :right
             x = left(r)
             p1 = Point2f(x, bottom(r) - 0.5sw)
             p2 = Point2f(x, top(r) + 0.5sw)
@@ -411,30 +411,30 @@ function initialize_block!(ax::Axis; palette = nothing)
 
     onany(xaxis.minortickpositions, scene.px_area) do tickpos, area
         local pxheight::Float32 = height(scene.px_area[])
-        local offset::Float32 = ax.xaxisposition[] == :bottom ? pxheight : -pxheight
+        local offset::Float32 = ax.xaxisposition[] === :bottom ? pxheight : -pxheight
         update_gridlines!(xminorgridnode, Point2f(0, offset), tickpos)
     end
 
     onany(yaxis.minortickpositions, scene.px_area) do tickpos, area
         local pxwidth::Float32 = width(scene.px_area[])
-        local offset::Float32 = ax.yaxisposition[] == :left ? pxwidth : -pxwidth
+        local offset::Float32 = ax.yaxisposition[] === :left ? pxwidth : -pxwidth
         update_gridlines!(yminorgridnode, Point2f(offset, 0), tickpos)
     end
 
     subtitlepos = lift(scene.px_area, ax.titlegap, ax.titlealign, ax.xaxisposition, xaxis.protrusion; ignore_equal_values=true) do a,
         titlegap, align, xaxisposition, xaxisprotrusion
 
-        x = if align == :center
+        x = if align === :center
             a.origin[1] + a.widths[1] / 2
-        elseif align == :left
+        elseif align === :left
             a.origin[1]
-        elseif align == :right
+        elseif align === :right
             a.origin[1] + a.widths[1]
         else
             error("Title align $align not supported.")
         end
 
-        yoffset = top(a) + titlegap + (xaxisposition == :top ? xaxisprotrusion : 0f0)
+        yoffset = top(a) + titlegap + (xaxisposition === :top ? xaxisprotrusion : 0f0)
 
         return Point2f(x, yoffset)
     end
@@ -515,16 +515,16 @@ end
 
 function mirror_ticks(tickpositions, ticksize, tickalign, px_area, side, axisposition)
     a = px_area[][]
-    if side == :x
-        opp = axisposition == :bottom ? top(a) : bottom(a)
-        sign =  axisposition == :bottom ? 1 : -1
+    if side === :x
+        opp = axisposition === :bottom ? top(a) : bottom(a)
+        sign =  axisposition === :bottom ? 1 : -1
     else
-        opp = axisposition == :left ? right(a) : left(a)
-        sign = axisposition == :left ? 1 : -1
+        opp = axisposition === :left ? right(a) : left(a)
+        sign = axisposition === :left ? 1 : -1
     end
     d = ticksize * sign
     points = Vector{Point2f}(undef, 2*length(tickpositions))
-    if side == :x
+    if side === :x
         for (i, (x, _)) in enumerate(tickpositions)
             points[2i-1] = Point2f(x, opp - d * tickalign)
             points[2i] = Point2f(x, opp + d - d * tickalign)

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -78,11 +78,11 @@ function initialize_block!(ax::Axis3)
 
     titlepos = lift(scene.px_area, ax.titlegap, ax.titlealign) do a, titlegap, align
 
-        x = if align == :center
+        x = if align === :center
             a.origin[1] + a.widths[1] / 2
-        elseif align == :left
+        elseif align === :left
             a.origin[1]
-        elseif align == :right
+        elseif align === :right
             a.origin[1] + a.widths[1]
         else
             error("Title align $align not supported.")
@@ -175,9 +175,9 @@ function calculate_matrices(limits, px_area, elev, azim, perspectiveness, aspect
 
 
     t = Makie.translationmatrix(-Float64.(limits.origin))
-    s = if aspect == :equal
+    s = if aspect === :equal
         scales = 2 ./ Float64.(ws)
-    elseif aspect == :data
+    elseif aspect === :data
         scales = 2 ./ max.(maximum(ws), Float64.(ws))
     elseif aspect isa VecTypes{3}
         scales = 2 ./ Float64.(ws) .* Float64.(aspect) ./ maximum(aspect)
@@ -249,7 +249,7 @@ function projectionmatrix(viewmatrix, limits, eyepos, radius, azim, elev, angle,
             ratio_x = maxx
             ratio_y = maxy
 
-            if viewmode == :fitzoom
+            if viewmode === :fitzoom
                 if ratio_y > ratio_x
                     pm = Makie.scalematrix(Vec3(1/ratio_y, 1/ratio_y, 1)) * pm
                 else

--- a/src/makielayout/blocks/intervalslider.jl
+++ b/src/makielayout/blocks/intervalslider.jl
@@ -95,11 +95,11 @@ function initialize_block!(isl::IntervalSlider)
 
     state = Observable(:none)
     button_magnifications = lift(state) do state
-        if state == :none
+        if state === :none
             [1.0, 1.0]
-        elseif state == :min
+        elseif state === :min
             [1.25, 1.0]
-        elseif state == :both
+        elseif state === :both
             [1.25, 1.25]
         else
             [1.0, 1.25]
@@ -133,7 +133,7 @@ function initialize_block!(isl::IntervalSlider)
                 snapindex = closest_fractionindex(isl.range[], fraction)
                 fraction = (snapindex - 1) / (length(isl.range[]) - 1)
             end
-            if state[] == :min
+            if state[] === :min
                 # if the mouse crosses over the current max, reverse
                 if fraction > displayed_sliderfractions[][2]
                     state[] = :max
@@ -155,7 +155,7 @@ function initialize_block!(isl::IntervalSlider)
             if isl.selected_indices[] != newindices
                 isl.selected_indices[] = newindices
             end
-        elseif state[] == :both
+        elseif state[] === :both
             fracdif = fraction - startfraction[]
 
             clamped_fracdif = clamp(fracdif, -start_disp_fractions[][1], 1 - start_disp_fractions[][2])

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -5,8 +5,8 @@ function initialize_block!(leg::Legend,
 
     # by default, `tellwidth = true` and `tellheight = false` for vertical legends
     # and vice versa for horizontal legends
-    real_tellwidth = @lift $(leg.tellwidth) === automatic ? $(leg.orientation) == :vertical : $(leg.tellwidth)
-    real_tellheight = @lift $(leg.tellheight) === automatic ? $(leg.orientation) == :horizontal : $(leg.tellheight)
+    real_tellwidth = @lift $(leg.tellwidth) === automatic ? $(leg.orientation) === :vertical : $(leg.tellwidth)
+    real_tellheight = @lift $(leg.tellheight) === automatic ? $(leg.orientation) === :horizontal : $(leg.tellheight)
     setfield!(leg, :_tellheight, real_tellheight)
     setfield!(leg, :_tellwidth, real_tellwidth)
 
@@ -71,26 +71,26 @@ function initialize_block!(leg::Legend,
             etexts = entrytexts[g]
             erects = entryrects[g]
 
-            subgl = if leg.orientation[] == :vertical
-                if leg.titleposition[] == :left
+            subgl = if leg.orientation[] === :vertical
+                if leg.titleposition[] === :left
                     isnothing(title) || (grid[g, 1] = title)
                     grid[g, 2] = GridLayout(halign = leg.gridshalign[], valign = leg.gridsvalign[])
-                elseif leg.titleposition[] == :top
+                elseif leg.titleposition[] === :top
                     isnothing(title) || (grid[2g - 1, 1] = title)
                     grid[2g, 1] = GridLayout(halign = leg.gridshalign[], valign = leg.gridsvalign[])
                 end
-            elseif leg.orientation[] == :horizontal
-                if leg.titleposition[] == :left
+            elseif leg.orientation[] === :horizontal
+                if leg.titleposition[] === :left
                     isnothing(title) || (grid[1, 2g-1] = title)
                     grid[1, 2g] = GridLayout(halign = leg.gridshalign[], valign = leg.gridsvalign[])
-                elseif leg.titleposition[] == :top
+                elseif leg.titleposition[] === :top
                     isnothing(title) || (grid[1, g] = title)
                     grid[2, g] = GridLayout(halign = leg.gridshalign[], valign = leg.gridsvalign[])
                 end
             end
 
             for (n, (et, er)) in enumerate(zip(etexts, erects))
-                i, j = leg.orientation[] == :vertical ? rowcol(n) : reverse(rowcol(n))
+                i, j = leg.orientation[] === :vertical ? rowcol(n) : reverse(rowcol(n))
                 subgl[i, 2j-1] = er
                 subgl[i, 2j] = et
             end
@@ -102,31 +102,31 @@ function initialize_block!(leg::Legend,
         end
 
         for r in 1:nrows(grid)-1
-            if leg.orientation[] == :horizontal
-                if leg.titleposition[] == :left
+            if leg.orientation[] === :horizontal
+                if leg.titleposition[] === :left
                     # nothing
-                elseif leg.titleposition[] == :top
+                elseif leg.titleposition[] === :top
                     rowgap!(grid, r, leg.titlegap[])
                 end
-            elseif leg.orientation[] == :vertical
-                if leg.titleposition[] == :left
+            elseif leg.orientation[] === :vertical
+                if leg.titleposition[] === :left
                     rowgap!(grid, r, leg.groupgap[])
-                elseif leg.titleposition[] == :top
+                elseif leg.titleposition[] === :top
                     rowgap!(grid, r, r % 2 == 1 ? leg.titlegap[] : leg.groupgap[])
                 end
             end
         end
         for c in 1:ncols(grid)-1
-            if leg.orientation[] == :horizontal
-                if leg.titleposition[] == :left
+            if leg.orientation[] === :horizontal
+                if leg.titleposition[] === :left
                     colgap!(grid, c, c % 2 == 1 ? leg.titlegap[] : leg.groupgap[])
-                elseif leg.titleposition[] == :top
+                elseif leg.titleposition[] === :top
                     colgap!(grid, c, leg.groupgap[])
                 end
-            elseif leg.orientation[] == :vertical
-                if leg.titleposition[] == :left
+            elseif leg.orientation[] === :vertical
+                if leg.titleposition[] === :left
                     colgap!(grid, c, leg.titlegap[])
-                elseif leg.titleposition[] == :top
+                elseif leg.titleposition[] === :top
                     # nothing here
                 end
             end

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -79,8 +79,8 @@ function initialize_block!(m::Menu; default = 1)
             round_to_IRect2D(BBox(
                 left(bbox),
                 right(bbox),
-                d == :down ? max(0, bottom(bbox) - h) : top(bbox),
-                d == :down ? bottom(bbox) : min(top(bbox) + h, top(blockscene.px_area[]))))
+                d === :down ? max(0, bottom(bbox) - h) : top(bbox),
+                d === :down ? bottom(bbox) : min(top(bbox) + h, top(blockscene.px_area[]))))
     end
 
     menuscene = Scene(blockscene, scenearea, camera = campixel!, clear=true)

--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -225,7 +225,7 @@ varname => default_value pairs.
     )
 """
 macro documented_attributes(exp)
-    if exp.head != :block
+    if exp.head !== :block
         error("Not a block")
     end
 

--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -232,7 +232,7 @@ macro documented_attributes(exp)
     expressions = filter(x -> !(x isa LineNumberNode), exp.args)
 
     vars_and_exps = map(expressions) do e
-        if e.head == :macrocall && e.args[1] == GlobalRef(Core, Symbol("@doc"))
+        if e.head === :macrocall && e.args[1] == GlobalRef(Core, Symbol("@doc"))
             varname = e.args[4].args[1]
             var_exp = e.args[4].args[2]
             str_exp = e.args[3]

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -196,7 +196,7 @@ function Scene(;
     if lights isa Automatic
         lightposition = to_value(get(m_theme, :lightposition, nothing))
         if !isnothing(lightposition)
-            position = if lightposition == :eyeposition
+            position = if lightposition === :eyeposition
                 scene.camera.eyeposition
             else
                 m_theme.lightposition

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -88,10 +88,10 @@ function Makie.plot!(plot::BoxPlot)
         args...,
     ) do x, y, color, weights, width, range, show_outliers, whiskerwidth, show_notch, orientation, gap, dodge, n_dodge, dodge_gap
         x̂, boxwidth = compute_x_and_width(x, width, gap, dodge, n_dodge, dodge_gap)
-        if !(whiskerwidth == :match || whiskerwidth >= 0)
+        if !(whiskerwidth === :match || whiskerwidth >= 0)
             error("whiskerwidth must be :match or a positive number. Found: $whiskerwidth")
         end
-        ww = whiskerwidth == :match ? boxwidth : whiskerwidth * boxwidth
+        ww = whiskerwidth === :match ? boxwidth : whiskerwidth * boxwidth
         outlier_points = Point2f[]
         centers = Float32[]
         medians = Float32[]
@@ -154,7 +154,7 @@ function Makie.plot!(plot::BoxPlot)
         end
 
         # for horizontal boxplots just flip all components
-        if orientation == :horizontal
+        if orientation === :horizontal
             outlier_points = flip_xy.(outlier_points)
             t_segments = flip_xy.(t_segments)
         elseif orientation != :vertical

--- a/src/stats/boxplot.jl
+++ b/src/stats/boxplot.jl
@@ -157,7 +157,7 @@ function Makie.plot!(plot::BoxPlot)
         if orientation === :horizontal
             outlier_points = flip_xy.(outlier_points)
             t_segments = flip_xy.(t_segments)
-        elseif orientation != :vertical
+        elseif orientation !== :vertical
             error("Invalid orientation $orientation. Valid options: :horizontal or :vertical.")
         end
 

--- a/src/stats/crossbar.jl
+++ b/src/stats/crossbar.jl
@@ -65,7 +65,7 @@ function Makie.plot!(plot::CrossBar)
 
         # for horizontal crossbars just flip all components
         fpoint, frect = Point2f, Rectf
-        if orientation == :horizontal
+        if orientation === :horizontal
             fpoint, frect = flip_xy ∘ fpoint, flip_xy ∘ frect
         end
 

--- a/src/stats/density.jl
+++ b/src/stats/density.jl
@@ -101,12 +101,12 @@ function plot!(plot::Density{<:Tuple{<:AbstractVector}})
 
     colorobs = Observable{RGBColors}()
     map!(colorobs, plot.color, lowerupper, plot.direction) do c, lu, dir
-        if (dir == :x && c == :x) || (dir == :y && c == :y)
-            dim = dir == :x ? 1 : 2
+        if (dir === :x && c === :x) || (dir === :y && c === :y)
+            dim = dir === :x ? 1 : 2
             return Float32[l[dim] for l in lu[1]]
-        elseif (dir == :y && c == :x) || (dir == :x && c == :y)
+        elseif (dir === :y && c === :x) || (dir === :x && c === :y)
             o = Float32(plot.offset[])
-            dim = dir == :x ? 2 : 1
+            dim = dir === :x ? 2 : 1
             return vcat(Float32[l[dim] - o for l in lu[1]], Float32[l[dim] - o for l in lu[2]])::Vector{Float32}
         else
             return to_color(c)

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -91,14 +91,14 @@ function fit_qqplot(x, y; qqline = :none)
     end
     h = qqbuild(x, y)
     points = Point2f.(h.qx, h.qy)
-    qqline == :none && return points, Point2f[]
+    qqline === :none && return points, Point2f[]
     xs = collect(extrema(h.qx))
-    if qqline == :identity
+    if qqline === :identity
         ys = xs
-    elseif qqline == :fit
+    elseif qqline === :fit
         itc, slp = hcat(fill!(similar(h.qx), 1), h.qx) \ h.qy
         ys = @. slp * xs + itc
-    else # if qqline == :fitrobust
+    else # if qqline === :fitrobust
         quantx, quanty = quantile.(Ref(x), [0.25, 0.75]), quantile.(Ref(y), [0.25, 0.75])
         slp = (quanty[2] - quanty[1]) / (quantx[2] - quantx[1])
         ys = @. quanty + slp * (xs - quantx)

--- a/src/stats/violin.jl
+++ b/src/stats/violin.jl
@@ -56,13 +56,13 @@ function plot!(plot::Violin)
 
         # for horizontal violin just flip all componentes
         point_func = Point2f
-        if orientation == :horizontal
+        if orientation === :horizontal
             point_func = flip_xy ∘ point_func
         end
 
         # Allow `side` to be either scalar or vector
         sides = broadcast(x̂, vside) do _, s
-            return s == :left ? - 1 : s == :right ? 1 : 0
+            return s === :left ? - 1 : s === :right ? 1 : 0
         end
 
         sa = StructArray((x = x̂, side = sides))

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -94,7 +94,7 @@ function nan_extrema(array)
 end
 
 function extract_expr(extract_func, dictlike, args)
-    if args.head != :tuple
+    if args.head !== :tuple
         error("Usage: args need to be a tuple. Found: $args")
     end
     expr = Expr(:block)

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -174,9 +174,9 @@ end
     fig = Figure()
     ax = Axis(fig[1, 1], palette = (patchcolor = [:blue, :green],))
     pl = density!(rand(10); color = Cycled(2))
-    @test pl.color[] == :green
+    @test pl.color[] === :green
     pl = density!(rand(10); color = Cycled(1))
-    @test pl.color[] == :blue
+    @test pl.color[] === :blue
 end
 
 @testset "briefly empty ticklabels" begin

--- a/test/statistical_tests.jl
+++ b/test/statistical_tests.jl
@@ -280,18 +280,18 @@ end
     fig, ax, p = violin(x, y, side = :left, color = :blue)
     @test p isa Violin
     @test p.plots[1] isa Poly
-    @test p.plots[1][:color][] == :blue
+    @test p.plots[1][:color][] === :blue
     @test p.plots[2] isa LineSegments
-    @test p.plots[2][:color][] == :white
-    @test p.plots[2][:visible][] == :false
+    @test p.plots[2][:color][] === :white
+    @test p.plots[2][:visible][] === :false
 
     # test categorical
     x = repeat(["a", "b", "c", "d"], 250)
     fig2, ax2, p2 = violin(x, y, side = :left, color = :blue)
     @test p2 isa Violin
     @test p2.plots[1] isa Poly
-    @test p2.plots[1][:color][] == :blue
+    @test p2.plots[1][:color][] === :blue
     @test p2.plots[2] isa LineSegments
-    @test p2.plots[2][:color][] == :white
-    @test p2.plots[2][:visible][] == :false
+    @test p2.plots[2][:color][] === :white
+    @test p2.plots[2][:visible][] === :false
 end


### PR DESCRIPTION
# Description

Using `==` instead of `===` can cause invalidations (see e.g. https://github.com/JuliaPlots/Plots.jl/pull/4622) and it's common convention to use `===` for `Symbol`s anyway.

```bash
$ grep -irl ' == :' | xargs sed -i 's, == :, === :,g'
$ grep -irl ' != :' | xargs sed -i 's, != :, !== :,g'
```

## Type of change

Non-functional change.

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
