### PR TITLE
CI / concurrency - cancel PRs jobs only

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -13,10 +13,8 @@ on:
       - breaking-release
 
 concurrency:
-  # Skip intermediate builds: all builds except for builds on the `master` or `release-*` branches
-  # Cancel intermediate builds: only pull request builds
-  group: docs-${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') || github.run_number }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/cairomakie.yaml
+++ b/.github/workflows/cairomakie.yaml
@@ -17,7 +17,7 @@ on:
     tags: '*'
 
 concurrency:
-  group: cairomakie-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
     tags: '*'
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/glmakie.yaml
+++ b/.github/workflows/glmakie.yaml
@@ -17,7 +17,7 @@ on:
     tags: '*'
 
 concurrency:
-  group: glmakie-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/rprmakie.yaml
+++ b/.github/workflows/rprmakie.yaml
@@ -17,7 +17,7 @@ on:
     tags: '*'
 
 concurrency:
-  group: rprmakie-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/wglmakie.yaml
+++ b/.github/workflows/wglmakie.yaml
@@ -17,7 +17,7 @@ on:
     tags: '*'
 
 concurrency:
-  group: wglmakie-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description

I've noticed that some CI jobs are canceled on `master`. This shouldn't happen, and we want all commits on master to be covered by CI and inspectable for quick visual regression checks.

This PR classifies group into `workflow` and `head_ref` as advised in https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value with a fallback value.

NOTE: we've been using this in `Plots` (for a long time) with the expected concurrency behavior.

## Type of change

CI concurrency.

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
