### PR TITLE
Fix a typo in Stepper constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## master
 
-- Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590]
+- Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590](https://github.com/MakieOrg/Makie.jl/pulls/2478)
+- Fixed a small typo which caused an error in the `Stepper` constructor. [#2600](https://github.com/MakieOrg/Makie.jl/pulls/2478)
 
 ## v0.19.1
 

--- a/src/recording.jl
+++ b/src/recording.jl
@@ -26,14 +26,14 @@ mutable struct RamStepper
     format::Symbol
 end
 
-function Stepper(figlike::FigureLike; backend=current_backend(), format=:png, visible=false, connect=false, srceen_kw...)
-    screen = getscreen(backend, get_scene(figlike), JuliaNative; visible=visible, start_renderloop=false, srceen_kw...)
+function Stepper(figlike::FigureLike; backend=current_backend(), format=:png, visible=false, connect=false, screen_kw...)
+    screen = getscreen(backend, get_scene(figlike), JuliaNative; visible=visible, start_renderloop=false, screen_kw...)
     display(screen, figlike; connect=connect)
     return RamStepper(figlike, screen, Matrix{RGBf}[], format)
 end
 
-function Stepper(figlike::FigureLike, path::String, step::Int; format=:png, backend=current_backend(), visible=false, connect=false, screen_config...)
-    screen = getscreen(backend, get_scene(figlike), JuliaNative; visible=visible, start_renderloop=false, srceen_kw...)
+function Stepper(figlike::FigureLike, path::String, step::Int; format=:png, backend=current_backend(), visible=false, connect=false, screen_kw...)
+    screen = getscreen(backend, get_scene(figlike), JuliaNative; visible=visible, start_renderloop=false, screen_kw...)
     display(screen, figlike; connect=connect)
     return FolderStepper(figlike, screen, path, format, step)
 end


### PR DESCRIPTION
# Description

There was a typo in a kwarg, which caused an error when trying to construct a Stepper.  This PR fixes that and 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Added an entry in NEWS.md (for new features and breaking changes)
