### PR TITLE
[CairoMakie] Use to_cairo_color in lines and scatter

### DIFF
--- a/CairoMakie/src/overrides.jl
+++ b/CairoMakie/src/overrides.jl
@@ -2,29 +2,6 @@
 #                    Poly - the not so primitive, primitive                    #
 ################################################################################
 
-
-function to_cairo_color(colors::AbstractVector{<: Number}, plot_object)
-    return numbers_to_colors(colors, plot_object)
-end
-
-function to_cairo_color(color::Makie.AbstractPattern, plot_object)
-    cairopattern = Cairo.CairoPattern(color)
-    Cairo.pattern_set_extend(cairopattern, Cairo.EXTEND_REPEAT);
-    return cairopattern
-end
-
-function to_cairo_color(color, plot_object)
-    return to_color(color)
-end
-
-function set_source(ctx::Cairo.CairoContext, pattern::Cairo.CairoPattern)
-    return Cairo.set_source(ctx, pattern)
-end
-
-function set_source(ctx::Cairo.CairoContext, color::Colorant)
-    return Cairo.set_source_rgba(ctx, rgbatuple(color)...)
-end
-
 """
 Special method for polys so we don't fall back to atomic meshes, which are much more
 complex and slower to draw than standard paths with single color.

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -30,9 +30,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Unio
     space = to_value(get(primitive, :space, :data))
     projected_positions = project_position.(Ref(scene), Ref(space), positions, Ref(model))
 
-    if color isa AbstractArray{<: Number}
-        color = numbers_to_colors(color, primitive)
-    end
+    color = to_cairo_color(color, primitive)
 
     # color is now a color or an array of colors
     # if it's an array of colors, each segment must be stroked separately
@@ -185,11 +183,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Scat
 
     font = to_font(to_value(get(primitive, :font, Makie.defaultfont())))
 
-    colors = if color isa AbstractArray{<: Number}
-        numbers_to_colors(color, primitive)
-    else
-        color
-    end
+    colors = to_cairo_color(color, primitive)
 
     markerspace = to_value(get(primitive, :markerspace, :pixel))
     space = to_value(get(primitive, :space, :data))

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -118,6 +118,32 @@ end
 to_uint32_color(c) = reinterpret(UInt32, convert(ARGB32, premultiplied_rgba(c)))
 
 ########################################
+#        Common color utilities        #
+########################################
+
+function to_cairo_color(colors::AbstractVector{<: Number}, plot_object)
+    return numbers_to_colors(colors, plot_object)
+end
+
+function to_cairo_color(color::Makie.AbstractPattern, plot_object)
+    cairopattern = Cairo.CairoPattern(color)
+    Cairo.pattern_set_extend(cairopattern, Cairo.EXTEND_REPEAT);
+    return cairopattern
+end
+
+function to_cairo_color(color, plot_object)
+    return to_color(color)
+end
+
+function set_source(ctx::Cairo.CairoContext, pattern::Cairo.CairoPattern)
+    return Cairo.set_source(ctx, pattern)
+end
+
+function set_source(ctx::Cairo.CairoContext, color::Colorant)
+    return Cairo.set_source_rgba(ctx, rgbatuple(color)...)
+end
+
+########################################
 #     Image/heatmap -> ARGBSurface     #
 ########################################
 


### PR DESCRIPTION
# Description

Cleans up some of the code by using `to_cairo_color` everywhere.  Also moves the `to_cairo_color` code to `utils.jl` so that all color handling stuff is in one place.
