### PR TITLE
Add `xlims!`, `ylims!`, `zlims!` support for Intervals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590](https://github.com/MakieOrg/Makie.jl/pulls/2478)
 - Fixed a small typo which caused an error in the `Stepper` constructor. [#2600](https://github.com/MakieOrg/Makie.jl/pulls/2478)
+- Allowed interval notation to be used in limit-setters for Axis and Axis3, i.e., `[x/y/z]lims!([ax], low..high)`.  [#2613](https://github.com/MakieOrg/Makie.jl/pulls/2613)
 
 ## v0.19.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 
 ## master
 
-- Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590](https://github.com/MakieOrg/Makie.jl/pulls/2478)
-- Fixed a small typo which caused an error in the `Stepper` constructor. [#2600](https://github.com/MakieOrg/Makie.jl/pulls/2478)
-- Allowed interval notation to be used in limit-setters for Axis and Axis3, i.e., `[x/y/z]lims!([ax], low..high)`.  [#2613](https://github.com/MakieOrg/Makie.jl/pulls/2613)
+- Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590](https://github.com/MakieOrg/Makie.jl/pull/2478)
+- Fixed a small typo which caused an error in the `Stepper` constructor. [#2600](https://github.com/MakieOrg/Makie.jl/pull/2600)
+- Allowed interval notation to be used in limit-setters for Axis and Axis3, i.e., `[x/y/z]lims!([ax], low..high)`.  [#2613](https://github.com/MakieOrg/Makie.jl/pull/2613)
 
 ## v0.19.1
 

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1265,9 +1265,9 @@ Makie.xlims!(interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(Makie.curre
 Makie.ylims!(interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(Makie.current_axis(), interval)
 Makie.zlims!(interval::IntevalSets.ClosedInterval{<: Real}) = zlims!(Makie.current_axis(), interval)
 
-Makie.xlims!(ax::Axis, interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(ax, interval.left, interval.right)
-Makie.ylims!(ax::Axis, interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(ax, interval.left, interval.right)
-Makie.zlims!(ax::Axis3, interval::IntevalSets.ClosedInterva{<: Real}l) = zlims!(ax, interval.left, interval.right)
+Makie.xlims!(ax, interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(ax, interval.left, interval.right)
+Makie.ylims!(ax, interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(ax, interval.left, interval.right)
+Makie.zlims!(ax, interval::IntevalSets.ClosedInterva{<: Real}l) = zlims!(ax, interval.left, interval.right)
 
 """
     limits!(ax::Axis, xlims, ylims)

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1260,6 +1260,15 @@ Makie.xlims!(ax = current_axis(); low = nothing, high = nothing) = Makie.xlims!(
 Makie.ylims!(ax = current_axis(); low = nothing, high = nothing) = Makie.ylims!(ax, low, high)
 Makie.zlims!(ax = current_axis(); low = nothing, high = nothing) = Makie.zlims!(ax, low, high)
 
+
+Makie.xlims!(interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(Makie.current_axis(), interval)
+Makie.ylims!(interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(Makie.current_axis(), interval)
+Makie.zlims!(interval::IntevalSets.ClosedInterval{<: Real}) = zlims!(Makie.current_axis(), interval)
+
+Makie.xlims!(ax::Axis, interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(ax, interval.left, interval.right)
+Makie.ylims!(ax::Axis, interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(ax, interval.left, interval.right)
+Makie.zlims!(ax::Axis3, interval::IntevalSets.ClosedInterva{<: Real}l) = zlims!(ax, interval.left, interval.right)
+
 """
     limits!(ax::Axis, xlims, ylims)
 

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1261,13 +1261,13 @@ Makie.ylims!(ax = current_axis(); low = nothing, high = nothing) = Makie.ylims!(
 Makie.zlims!(ax = current_axis(); low = nothing, high = nothing) = Makie.zlims!(ax, low, high)
 
 
-Makie.xlims!(interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(Makie.current_axis(), interval)
-Makie.ylims!(interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(Makie.current_axis(), interval)
-Makie.zlims!(interval::IntevalSets.ClosedInterval{<: Real}) = zlims!(Makie.current_axis(), interval)
+Makie.xlims!(interval::IntervalSets.ClosedInterval{<: Real}) = xlims!(Makie.current_axis(), interval)
+Makie.ylims!(interval::IntervalSets.ClosedInterval{<: Real}) = ylims!(Makie.current_axis(), interval)
+Makie.zlims!(interval::IntervalSets.ClosedInterval{<: Real}) = zlims!(Makie.current_axis(), interval)
 
-Makie.xlims!(ax, interval::IntevalSets.ClosedInterval{<: Real}) = xlims!(ax, interval.left, interval.right)
-Makie.ylims!(ax, interval::IntevalSets.ClosedInterval{<: Real}) = ylims!(ax, interval.left, interval.right)
-Makie.zlims!(ax, interval::IntevalSets.ClosedInterva{<: Real}l) = zlims!(ax, interval.left, interval.right)
+Makie.xlims!(ax, interval::IntervalSets.ClosedInterval{<: Real}) = xlims!(ax, interval.left, interval.right)
+Makie.ylims!(ax, interval::IntervalSets.ClosedInterval{<: Real}) = ylims!(ax, interval.left, interval.right)
+Makie.zlims!(ax, interval::IntervalSets.ClosedInterval{<: Real}l) = zlims!(ax, interval.left, interval.right)
 
 """
     limits!(ax::Axis, xlims, ylims)


### PR DESCRIPTION
# Description

With this, one can do `xlims!(0..1)` and it works.  This also extends support for `limits!`, since it calls out to `xlims!`, ...  internally.

Fixes #2611 

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
