### PR TITLE
Call empty! in block deletion

### DIFF
--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -494,6 +494,9 @@ end
 
 function Base.delete!(block::Block)
     block.parent === nothing && return
+    
+    # detach plots, cameras, transformations, px_area
+    empty!(block.blockscene)
 
     s = get_topscene(block.parent)
     deleteat!(


### PR DESCRIPTION
# Description

See https://discourse.julialang.org/t/removing-row-from-gridlayout/93196

Still shouldn't completely clean up a block, but remove plots and a decent chunk of observables.

Add a description of your PR here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
