### PR TITLE
NFC remove deprecated `Vararg{<:Integer}`

### DIFF
--- a/GLMakie/src/GLAbstraction/AbstractGPUArray.jl
+++ b/GLMakie/src/GLAbstraction/AbstractGPUArray.jl
@@ -29,7 +29,7 @@ end
 
 setindex!(A::GPUArray{T, N}, value::Union{T, Array{T, N}}) where {T, N} = (A[1] = value)
 
-function setindex!(A::GPUArray{T, N}, value, indices::Vararg{<: Integer, N}) where {T, N}
+function setindex!(A::GPUArray{T, N}, value, indices::Vararg{Integer, N}) where {T, N}
     v = Array{T, N}(undef, ntuple(i-> 1, N))
     v[1] = convert(T, value)
     setindex!(A, v, (:).(indices, indices)...)


### PR DESCRIPTION
this caused deprecation errors when running with `--depwarn=yes`

## Type of change

Delete options that do not apply:

- [x ] Bug fix (non-breaking change which fixes an issue)

