### PR TITLE
Implement unsafe_copy! for a fragment of a buffer

### DIFF
--- a/GLMakie/src/GLAbstraction/GLTexture.jl
+++ b/GLMakie/src/GLAbstraction/GLTexture.jl
@@ -340,6 +340,15 @@ function unsafe_copy!(dest::Array{T, N}, source::Texture{T, N}) where {T,N}
     nothing
 end
 
+# After updating to OpenGL 4.5 or higher, we can use glGetTextureSubImage to copy 
+# a piece of texture back from GPU buffer.
+function unsafe_copy!(dest::Array{T, N}, source::Texture{T, N}, xrange::UnitRange, yrange::UnitRange) where {T,N}
+    bind(source)
+    glReadPixels(first(xrange), first(yrange), length(xrange), length(yrange), source.format, source.pixeltype, dest)
+    bind(source, 0)
+    nothing
+end
+
 gpu_data(t::TextureBuffer{T}) where {T} = gpu_data(t.buffer)
 gpu_getindex(t::TextureBuffer{T}, i::UnitRange{Int64}) where {T} = t.buffer[i]
 


### PR DESCRIPTION
Addresses a feature discussed on [Discord](https://discord.com/channels/996787732149981214/1065777618672164924).

Quick summary:
I wanted to access parts of rendered image (e.g. to check color values at a particular point of a plot).
@SimonDanisch guided me towards implementation using `glReadPixels` and suggested implementing it in an `unsafe_copy!` function. This is already present in the pull request, however I wanted to get feedback on two things (apart from general feedback about the function itself):
1. We got to this point, because what I was trying at the beginning was doing something like `buffer[:color][1,1]` which errored with `no get_index implemented` message. I presume just implementing `unsafe_copy!` is not enough, right? What else I should do to make it work? Or maybe it is not a good idea?
2. In the interactive example below, you can see that I am transposing the copied pixel matrix before plotting, since it seems to be oriented differently then original. Is this an effect of some coding mistake on my part or e.g. array layout between OpenGL and Julia? And should we do something about it in the `unsafe_copy!` function or somewhere else, or just leave it to the users with a note?

Here is a small demo, implementing a "magnifying glass" to see the details of one plot currently under the mouse tip.
It updates on movement.
```julia
using GLMakie
using ColorTypes

p = Makie.GeometryBasics.Polygon(
    Point2f[(0, 0), (2, 0), (3, 1), (1, 1)],
    [Point2f[(0.75, 0.25), (1.75, 0.25), (2.25, 0.75), (1.25, 0.75)]]
)

fig, ax, plt = poly(p, color = [:blue, :green, :yellow, :red, :blue, :green, :yellow, :red])
screen = display(fig)

buff = screen.framebuffer.buffers[:color]

pxx = Observable(zeros(RGBA{GLMakie.GLAbstraction.FixedPointNumbers.N0f8}, (20,20)))

ax2 = Axis(fig[1,2])
poly!(ax2,
    [Rect(i, j, 1, 1) for i in 1:20 for j in 1:20],
    color = @lift([$(pxx)'...])
)

on(events(ax.scene).mouseposition) do event
    x, y = events(ax.scene).mouseposition[]
    if x > 20 && y > 20 && x < 780 && y < 780
        xrange = round(Int, x) .+ (0:19)
        yrange = round(Int, y) .+ (0:19)
        GLMakie.GLAbstraction.unsafe_copy!(pxx.val, buff, xrange, yrange)
        notify(pxx)
    end
end
```
![mglass](https://user-images.githubusercontent.com/16628635/214442413-12e29c38-1a94-48b3-a47f-f6484c7a58ad.png)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
