### PR TITLE
Fix setting a monitor specified via GLFW

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -317,7 +317,12 @@ function apply_config!(screen::Screen, config::ScreenConfig; start_renderloop::B
     GLFW.SetWindowTitle(glw, config.title)
 
     if !isnothing(config.monitor)
-        GLFW.SetWindowMonitor(glw, config.monitor)
+        # Get the size and refreshrate of the window requested
+        props = MonitorProperties(config.monitor)
+        xpos, ypos = 0, 0
+        width, height = props.videomode.width, props.videomode.height
+        refreshRate = props.videomode.refreshrate
+        GLFW.SetWindowMonitor(glw, config.monitor, xpos, ypos, width, height, refreshRate)
     end
 
     function replace_processor!(postprocessor, idx)


### PR DESCRIPTION
# Description

Fixes #2640 

This PR aims to fix spawning a new figure in a manually specified monitor via GLFW.
Currently, setting a monitor in config results in error, where `SetWindowMonitor()` is called without enough number of parameters.

Here I get the missing values from `MonitorProperties()` and call the above mentioned function properly.
However, adding an `@info` check on the parameters reveals that the whole `apply_config!()` function is called in this process twice and the second time the properties are overwritten by defaults somewhere else in the codebase.

A quick fix is to always make a `Figure()` or similar call with `resolution` stated explicitly (as in the example below).
Yet, in GLFW `SetWindowMonitor()` is a function to create a full-screen window (in this case borderless), so maybe applying default values is not ideal in any case (since with the default (800,600) the rest of the screen is just black. But I don't know how to mitigate it.

The MWE to check the working solution:
```julia
using GLMakie
GLMakie.activate!(; monitor = GLMakie.GLFW.GetPrimaryMonitor())
f = Figure(resolution=(2560,1440))
s = display(f)
# This is the only way I found to close the window
GLMakie.destroy!(s)
```

Any suggestions for improvements are definitely welcomed!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
