### PR TITLE
Make explicit the uint

### DIFF
--- a/GLMakie/assets/shader/postprocessing/SSAO_blur.frag
+++ b/GLMakie/assets/shader/postprocessing/SSAO_blur.frag
@@ -15,7 +15,7 @@ void main(void)
 {
     // occlusion blur
     uvec2 id0 = texture(ids, frag_uv).xy;
-    if (id0.x == 0){
+    if (id0.x == uint(0)){
         fragment_color = texture(color_texture, frag_uv);
         // fragment_color = vec4(1,0,1,1); // show discarded
         return;


### PR DESCRIPTION
# Description

When using the ssao option in activate!, the shader was not compiling properly because it was issuing an implicit cast from int to uint as shown in the screen capture.

![Capture d’écran de 2023-02-03 16-28-49](https://user-images.githubusercontent.com/42340899/216642456-f84ccac4-9bd4-49d2-bee6-49bd90caadcc.png)

Fixes # (issue)

I just made explicit the uint comparison and the compiling is being sucessful.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
