### PR TITLE
Implement point-based converts for complex numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 - Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590](https://github.com/MakieOrg/Makie.jl/pulls/2478)
 - Fixed a small typo which caused an error in the `Stepper` constructor. [#2600](https://github.com/MakieOrg/Makie.jl/pulls/2478)
+- Added conversion recipes for point-based plots from vectors of Complex numbers to 2D points, and from `(::Vector{Complex}, ::Vector{Real})` to 3D points. [#2654](https://github.com/MakieOrg/Makie.jl/pull/2654)
 
 ## v0.19.1
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -507,6 +507,12 @@ end
     fig
 end
 
+@reference_test "Scatter with complex numbers" begin
+    fig = Figure(resolution = (500, 500))
+    scatter(fig[1, 1], [1+0im, 1+.5im, 1+1im, 0+1im])
+    scatter(fig[1, 2], [1+0im, 1+.5im, 1+1im, 0+1im], [1, 2, 3, 4])
+end
+
 @reference_test "Array of Images Scatter" begin
     img = Makie.logo()
     scatter(1:2, 1:2, marker = [img, img], markersize=reverse(size(img) ./ 10), axis=(limits=(0.5, 2.5, 0.5, 2.5),))

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -159,6 +159,11 @@ convert_arguments(P::PointBased, x::ClosedInterval, y::RealVector) = convert_arg
 convert_arguments(P::PointBased, x::RealVector, y::ClosedInterval) = convert_arguments(P, x, LinRange(extrema(y)..., length(x)))
 
 
+# Converts for complex number arrays
+
+convert_arguments(::PointBased, coords::AbstractVector{<:Complex{T}}) where T = (map(x -> Point2{T}(real(x), imag(x)), coords),)
+convert_arguments(::PointBased, coords::AbstractVector{<:Complex{T}}, heights::AbstractVector{<:Real}) where T = (map((x, z) -> Point3{T}(real(x), imag(x), float(z)), coords, heights),)
+
 """
     convert_arguments(P, x)::(Vector)
 


### PR DESCRIPTION
as discussed in #718.

# Description

Adds converts from:
`Vector{Complex{T}}` -> `Vector{Point2{T}}`
`Vector{Complex{T}}, Vector{Real}` -> `Vector{Point3{T}}` where the second input represents z-value.

## Type of change

Delete options that do not apply:

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [X] Added reference image tests for new plotting functions, recipes, visual options, etc.
