### PR TITLE
stop pretending rich text is AbstractString

### DIFF
--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -121,7 +121,7 @@ end
 # conversion stopper for previous methods
 convert_arguments(::Type{<: Text}, gcs::AbstractVector{<:GlyphCollection}) = (gcs,)
 convert_arguments(::Type{<: Text}, gc::GlyphCollection) = (gc,)
-convert_arguments(::Type{<: Text}, vec::AbstractVector{<:Tuple{<:AbstractString, <:Point}}) = (vec,)
+convert_arguments(::Type{<: Text}, vec::AbstractVector{<:Tuple{<:Any, <:Point}}) = (vec,)
 convert_arguments(::Type{<: Text}, strings::AbstractVector{<:AbstractString}) = (strings,)
 convert_arguments(::Type{<: Text}, string::AbstractString) = (string,)
 
@@ -137,10 +137,10 @@ function plot!(plot::Text{<:Tuple{<:AbstractArray{<:AbstractString}}})
 end
 
 # overload text plotting for a vector of tuples of a string and a point each
-function plot!(plot::Text{<:Tuple{<:AbstractArray{<:Tuple{<:AbstractString, <:Point}}}})    
+function plot!(plot::Text{<:Tuple{<:AbstractArray{<:Tuple{<:Any, <:Point}}}})    
     strings_and_positions = plot[1]
 
-    strings = Observable{Vector{AbstractString}}(first.(strings_and_positions[]))
+    strings = Observable{Vector{Any}}(first.(strings_and_positions[]))
 
     positions = Observable(
         Point3f[to_ndim(Point3f, last(x), 0) for x in  strings_and_positions[]] # avoid Any for zero elements
@@ -263,7 +263,7 @@ end
 
 iswhitespace(l::LaTeXString) = iswhitespace(replace(l.s, '$' => ""))
 
-struct RichText <: AbstractString
+struct RichText
     type::Symbol
     children::Vector{Union{RichText,String}}
     attributes::Dict{Symbol, Any}
@@ -282,14 +282,8 @@ function Base.String(r::RichText)
     end
 end
 
-Base.ncodeunits(r::RichText) = ncodeunits(String(r)) # needed for isempty
-
 function Base.show(io::IO, ::MIME"text/plain", r::RichText)
     print(io, "RichText: \"$(String(r))\"")
-end
-
-function Base.:(==)(r1::RichText, r2::RichText)
-    r1.type == r2.type && r1.children == r2.children && r1.attributes == r2.attributes
 end
 
 rich(args...; kwargs...) = RichText(:span, args...; kwargs...)

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -27,7 +27,7 @@ function calculate_protrusion(
 
     horizontal, labeltext, ticklabel_annotation_obs = closure_args
 
-    label_is_empty::Bool = iswhitespace(label) || isempty(label)
+    label_is_empty::Bool = iswhitespace(label)
 
     real_labelsize::Float32 = if label_is_empty
         0f0

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -289,7 +289,7 @@ function LineAxis(parent::Scene, attrs::Attributes)
 
     map!(calculate_real_ticklabel_align, realticklabelalign, ticklabelalign, horizontal, flipped, ticklabelrotation)
 
-    ticklabel_annotation_obs = Observable(Tuple{AbstractString, Point2f}[]; ignore_equal_values=true)
+    ticklabel_annotation_obs = Observable(Tuple{Any, Point2f}[]; ignore_equal_values=true)
     ticklabels = nothing # this gets overwritten later to be used in the below
     ticklabel_ideal_space = Observable(0f0; ignore_equal_values=true)
 
@@ -409,14 +409,14 @@ function LineAxis(parent::Scene, attrs::Attributes)
 
     tickvalues = Observable(Float32[]; ignore_equal_values=true)
 
-    tickvalues_labels_unfiltered = Observable{Tuple{Vector{Float32},Vector{AbstractString}}}()
+    tickvalues_labels_unfiltered = Observable{Tuple{Vector{Float32},Vector{Any}}}()
     map!(tickvalues_labels_unfiltered, pos_extents_horizontal, limits, ticks, tickformat, attrs.scale) do (position, extents, horizontal),
             limits, ticks, tickformat, scale
         get_ticks(ticks, scale, tickformat, limits...)
     end
 
     tickpositions = Observable(Point2f[]; ignore_equal_values=true)
-    tickstrings = Observable(AbstractString[]; ignore_equal_values=true)
+    tickstrings = Observable(Any[]; ignore_equal_values=true)
 
     onany(update_tickpos_string,
         Observable((tickstrings, tickpositions, tickvalues, pos_extents_horizontal, limits)),

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -126,7 +126,7 @@ mutable struct LineAxis
     elements::Dict{Symbol, Any}
     tickpositions::Observable{Vector{Point2f}}
     tickvalues::Observable{Vector{Float32}}
-    ticklabels::Observable{Vector{AbstractString}}
+    ticklabels::Observable{Vector{Any}}
     minortickpositions::Observable{Vector{Point2f}}
     minortickvalues::Observable{Vector{Float32}}
 end


### PR DESCRIPTION
It's annoying in several circumstances that RichText hits dispatches intended for String types. And the `AbstractString` vector typings don't have any performance benefits either.