### PR TITLE
Add scroll-to-pan

### DIFF
--- a/docs/examples/blocks/axis.md
+++ b/docs/examples/blocks/axis.md
@@ -919,6 +919,7 @@ You can zoom in an axis by scrolling in and out.
 If you press x or y while scrolling, the zoom movement is restricted to that dimension.
 These keys can be changed with the attributes `xzoomkey` and `yzoomkey`.
 You can also restrict the zoom dimensions all the time by setting the axis attributes `xzoomlock` or `yzoomlock` to `true`.
+Note that if scroll pan is enabled (see below), scroll zoom will require (left or right) `shift` to be pressed.
 
 ### Drag pan
 
@@ -926,6 +927,16 @@ You can pan around the axis by right-clicking and dragging.
 If you press x or y while panning, the pan movement is restricted to that dimension.
 These keys can be changed with the attributes `xpankey` and `ypankey`.
 You can also restrict the pan dimensions all the time by setting the axis attributes `xpanlock` or `ypanlock` to `true`.
+
+### Scroll pan
+
+Users of trackpads and mice with wheels (especially both horizontal and vertical) may like to pan using these as is typically possible in other programs. This is not enabled by default, but can be (on a per-axis basis) by calling `register_interaction`:
+
+```
+register_interaction!(ax, :scrollpan, GLMakie.Makie.ScrollPan(20.0, 0.2))
+```
+
+When this interaction is enabled, in order to not conflict, the scroll zoom will require (left or right) `shift` to be pressed.
 
 ### Limit reset
 

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -297,10 +297,15 @@ function add_translation!(scene, cam::Camera3D)
     end
 
     on(camera(scene), scene.events.scroll) do scroll
-        if is_mouseinside(scene) && ispressed(scene, scroll_mod[])
+        if is_mouseinside(scene)
+          if ispressed(scene, scroll_mod[])
             zoom_step = (1f0 + 0.1f0 * zoomspeed[]) ^ -scroll[2]
             zoom!(scene, cam, zoom_step, shift_lookat[], cad[])
-            return Consume(true)
+          else
+            camspeed = compute_diff([scroll[1], scroll[2]])
+            translate_cam!(scene, cam, 10f0 * Vec3f(-camspeed[1], camspeed[2], 0f0))
+          end
+          return Consume(true)
         end
         return Consume(false)
     end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -160,6 +160,18 @@ function ScrollZoom(speed, reset_delay)
     return ScrollZoom(speed, RefValue{Union{Nothing, Timer}}(nothing), RefValue{Union{Automatic, Float64}}(0.0), RefValue{Union{Automatic, Float64}}(0.0), reset_delay)
 end
 
+struct ScrollPan
+  speed::Float32
+  reset_timer::RefValue{Union{Nothing, Timer}}
+  prev_xticklabelspace::RefValue{Union{Automatic, Float64}}
+  prev_yticklabelspace::RefValue{Union{Automatic, Float64}}
+  reset_delay::Float32
+end
+
+function ScrollPan(speed, reset_delay)
+  return ScrollPan(speed, RefValue{Union{Nothing, Timer}}(nothing), RefValue{Union{Automatic, Float64}}(0.0), RefValue{Union{Automatic, Float64}}(0.0), reset_delay)
+end
+
 struct DragPan
     reset_timer::RefValue{Union{Nothing, Timer}}
     prev_xticklabelspace::RefValue{Union{Automatic, Float64}}
@@ -413,6 +425,8 @@ end
         xzoomkey::Makie.Keyboard.Button = Makie.Keyboard.x
         "The key for limiting zooming to the y direction."
         yzoomkey::Makie.Keyboard.Button = Makie.Keyboard.y
+        "The button for zooming with scrolling"
+        scrollzoomkey = Or(Makie.Keyboard.left_shift | Makie.Keyboard.right_shift)
         "The position of the x axis (`:bottom` or `:top`)."
         xaxisposition::Symbol = :bottom
         "The position of the y axis (`:left` or `:right`)."


### PR DESCRIPTION
# Description

Adds the ability to pan by using inputs from the scroll wheel. For trackpads (on Mac anyway) this is a two-finger drag which is used across many applications and for some users will feel more natural than holding the right button (trackpad: holding two-finger press) and dragging.

The default behavior isn't changed. The API for enabling the feature isn't the greatest but at least it's fairly simple. I updated the docs for how to do this in 2D with `register_interaction!` but don't see an appropriate equivalent place for describing how to enable it for 3D, which is something like:

```
cc.attributes.scroll_mod = Or(Makie.Keyboard.right_shift, Makie.Keyboard.left_shift)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
