### PR TITLE
Fix color conversion in scatterlines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Fixed an issue where `poly` plots with `Vector{<: MultiPolygon}` inputs with per-polygon color were mistakenly rendered as meshes using CairoMakie. [#2590](https://github.com/MakieOrg/Makie.jl/pulls/2478)
 - Fixed a small typo which caused an error in the `Stepper` constructor. [#2600](https://github.com/MakieOrg/Makie.jl/pulls/2478)
 - Fixed rectangle zoom for nonlinear axes [#2674](https://github.com/MakieOrg/Makie.jl/pull/2674)
+- Fixed issue with scatterlines only accepting concrete color types as `markercolor` [#2691](https://github.com/MakieOrg/Makie.jl/pull/2691)
 
 ## v0.19.1
 

--- a/src/basic_recipes/scatterlines.jl
+++ b/src/basic_recipes/scatterlines.jl
@@ -31,8 +31,7 @@ end
 function plot!(p::Combined{scatterlines, <:NTuple{N, Any}}) where N
 
     # markercolor is the same as linecolor if left automatic
-    real_markercolor = Observable{Union{Vector{RGBAf}, RGBAf}}()
-    map!(real_markercolor, p.color, p.markercolor) do col, mcol
+    real_markercolor = map(p.color, p.markercolor) do col, mcol
         if mcol === automatic
             return to_color(col)
         else

--- a/src/basic_recipes/scatterlines.jl
+++ b/src/basic_recipes/scatterlines.jl
@@ -31,7 +31,9 @@ end
 function plot!(p::Combined{scatterlines, <:NTuple{N, Any}}) where N
 
     # markercolor is the same as linecolor if left automatic
-    real_markercolor = map(p.color, p.markercolor) do col, mcol
+    # RGBColors -> union of all colortypes that `to_color` accepts + returns
+    real_markercolor = Observable{RGBColors}() 
+    map!(real_markercolor, p.color, p.markercolor) do col, mcol
         if mcol === automatic
             return to_color(col)
         else


### PR DESCRIPTION
# Description

Fixes https://discourse.julialang.org/t/makie-markercolor-magic/94760

Just removes the strict typing to colortypes so we can also use numeric vectors or whatever else here. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
