### PR TITLE
[WIP] Allow colorbars to handle recipes which don't handle color

### DIFF
--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -67,7 +67,7 @@ macro Block(name::Symbol, body::Expr = Expr(:block))
 
         function Makie.default_attribute_values(::Type{$(name)}, scene::Union{Scene, Nothing})
             sceneattrs = scene === nothing ? Attributes() : theme(scene)
-            curdeftheme = deepcopy(CURRENT_DEFAULT_THEME)
+            curdeftheme = deepcopy(Makie.CURRENT_DEFAULT_THEME)
             $(make_attr_dict_expr(attrs, :sceneattrs, :curdeftheme))
         end
 
@@ -493,7 +493,7 @@ end
 
 function Base.delete!(block::Block)
     block.parent === nothing && return
-    
+
     # detach plots, cameras, transformations, px_area
     empty!(block.blockscene)
 

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -204,11 +204,11 @@ function process_interaction(r::RectangleZoom, event::KeysEvent, ax::Axis)
     return Consume(true)
 end
 
-function positivize(r::Rect2f)
+function positivize(r::Rect2)
     negwidths = r.widths .< 0
     newori = ifelse.(negwidths, r.origin .+ r.widths, r.origin)
     newwidths = ifelse.(negwidths, -r.widths, r.widths)
-    return Rect2f(newori, newwidths)
+    return Rect2(newori, newwidths)
 end
 
 function process_interaction(l::LimitReset, event::MouseEvent, ax::Axis)


### PR DESCRIPTION
# Description

If the plot given to`Colorbar(gp, plot)` does not have a colorrange attribute, this should recurse through the plot's children, and return the colormap of the first plot which does.  You can also extend this method for any recipe type.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
