### PR TITLE
Improve Block deletion

### DIFF
--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -16,6 +16,7 @@ macro Block(name::Symbol, body::Expr = Expr(:block))
             parent::Union{Figure, Scene, Nothing}
             layoutobservables::Makie.LayoutObservables{GridLayout}
             blockscene::Scene
+            finalizers::Vector{Any}
         end
     end
 
@@ -358,18 +359,26 @@ function _block(T::Type{<:Block}, fig_or_scene::Union{Figure, Scene},
         suggestedbbox = bbox
     )
 
+    finalizers = []
+
+    px_area = Observable{Rect2i}()
+    obsfunc = on(topscene.px_area, update = true) do pxa
+        px_area[] = Makie.zero_origin(pxa)
+    end
+    push!(finalizers, offcaller(obsfunc))
+
     blockscene = Scene(
         topscene,
         # the block scene tracks the parent scene exactly
         # for this it seems to be necessary to zero-out a possible non-zero
         # origin of the parent
-        lift(Makie.zero_origin, topscene.px_area),
+        px_area,
         clear=false,
         camera = campixel!
     )
 
     # create base block with otherwise undefined fields
-    b = T(fig_or_scene, lobservables, blockscene)
+    b = T(fig_or_scene, lobservables, blockscene, finalizers)
 
     for (key, val) in attributes
         OT = fieldtype(T, key)
@@ -432,6 +441,9 @@ function _block(T::Type{<:Block}, fig_or_scene::Union{Figure, Scene},
     b
 end
 
+offcaller(o::ObserverFunction) = () -> off(o) || error("Failed to deregister ObserverFunction $o")
+offcaller(o::AbstractObservable, func) = () -> off(o, func) || error("Failed to deregister function $func from observable $o")
+
 
 """
 Get the scene which blocks need from their parent to plot stuff into
@@ -492,6 +504,10 @@ function Base.show(io::IO, ::T) where T <: Block
 end
 
 function Base.delete!(block::Block)
+    for finalizer in block.finalizers
+        finalizer()
+    end
+    
     block.parent === nothing && return
     
     # detach plots, cameras, transformations, px_area
@@ -505,9 +521,9 @@ function Base.delete!(block::Block)
     # TODO: what about the lift of the parent scene's
     # `px_area`, should this be cleaned up as well?
 
-    GridLayoutBase.remove_from_gridlayout!(GridLayoutBase.gridcontent(block))
+    gc = GridLayoutBase.gridcontent(block)
+    gc === nothing || GridLayoutBase.remove_from_gridlayout!()
 
-    on_delete(block)
     delete_from_parent!(block.parent, block)
     block.parent = nothing
 
@@ -524,13 +540,6 @@ function delete_from_parent!(figure::Figure, block::Block)
         current_axis!(figure, nothing)
     end
     nothing
-end
-
-"""
-Overload to execute cleanup actions for specific blocks that go beyond
-deleting elements and removing from gridlayout
-"""
-function on_delete(block)
 end
 
 function remove_element(x)

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -522,7 +522,7 @@ function Base.delete!(block::Block)
     # `px_area`, should this be cleaned up as well?
 
     gc = GridLayoutBase.gridcontent(block)
-    gc === nothing || GridLayoutBase.remove_from_gridlayout!()
+    gc === nothing || GridLayoutBase.remove_from_gridlayout!(gc)
 
     delete_from_parent!(block.parent, block)
     block.parent = nothing

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -166,9 +166,9 @@ function make_attr_dict_expr(attrs, sceneattrsym, curthemesym)
             # then default value
             d = quote
                 if haskey($sceneattrsym, $key)
-                    $sceneattrsym[$key]
+                    $sceneattrsym[$key][] # only use value of theme entry
                 elseif haskey($curthemesym, $key)
-                    $curthemesym[$key]
+                    $curthemesym[$key][] # only use value of theme entry
                 else
                     $default
                 end
@@ -507,7 +507,7 @@ function Base.delete!(block::Block)
     for finalizer in block.finalizers
         finalizer()
     end
-    
+
     block.parent === nothing && return
     
     # detach plots, cameras, transformations, px_area

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -55,10 +55,11 @@ function register_events!(ax, scene)
     end
 
     # TODO this should probably just forward KeyEvent from Makie
-    on(evs.keyboardbutton) do e
+    obsfunc = on(evs.keyboardbutton) do e
         keysevents[] = KeysEvent(evs.keyboardstate)
         return Consume(false)
     end
+    push!(ax.finalizers, offcaller(obsfunc))
 
     interactions = Dict{Symbol, Tuple{Bool, Any}}()
     setfield!(ax, :interactions, interactions)

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -40,20 +40,25 @@ end
 function register_events!(ax, scene)
 
     mouseeventhandle = addmouseevents!(scene)
+    for obsfunc in mouseeventhandle.observerfuncs
+        push!(ax.finalizers, offcaller(obsfunc))
+    end
     setfield!(ax, :mouseeventhandle, mouseeventhandle)
     scrollevents = Observable(ScrollEvent(0, 0))
     setfield!(ax, :scrollevents, scrollevents)
     keysevents = Observable(KeysEvent(Set()))
     setfield!(ax, :keysevents, keysevents)
     evs = events(scene)
-    on(evs.scroll) do s
+
+    obsfunc = on(evs.scroll) do s
         if is_mouseinside(scene)
             scrollevents[] = ScrollEvent(s[1], s[2])
             return Consume(true)
         end
         return Consume(false)
     end
-
+    push!(ax.finalizers, offcaller(obsfunc))
+    
     # TODO this should probably just forward KeyEvent from Makie
     obsfunc = on(evs.keyboardbutton) do e
         keysevents[] = KeysEvent(evs.keyboardstate)

--- a/src/makielayout/blocks/button.jl
+++ b/src/makielayout/blocks/button.jl
@@ -47,6 +47,9 @@ function initialize_block!(b::Button)
     end
 
     mouseevents = addmouseevents!(scene, b.layoutobservables.computedbbox)
+    for obsfunc in mouseevents.observerfuncs
+        push!(b.finalizers, offcaller(obsfunc))
+    end
 
     onmouseover(mouseevents) do _
         mousestate[] = :hover

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -220,7 +220,7 @@ function initialize_block!(m::Menu; default = 1)
         return false
     end
 
-    onany(e.mouseposition, e.mousebutton, priority=64) do position, butt
+    obsfuncs = onany(e.mouseposition, e.mousebutton, priority=64) do position, butt
         mp = screen_relative(menuscene, position)
         # track if we have been inside menu/options to clean up if we haven't been
         is_over_options = false
@@ -288,8 +288,11 @@ function initialize_block!(m::Menu; default = 1)
         end
         return Consume(false)
     end
+    for obsfunc in obsfuncs
+        push!(m.finalizers, offcaller(obsfunc))
+    end
 
-    on(menuscene.events.scroll, priority=61) do (x, y)
+    obsfunc = on(menuscene.events.scroll, priority=61) do (x, y)
         if is_mouseinside(menuscene)
             t = translation(menuscene)[]
             new_y = max(min(t[2] - y, 0), height(menuscene.px_area[]) - listheight[])
@@ -299,6 +302,7 @@ function initialize_block!(m::Menu; default = 1)
             return Consume(false)
         end
     end
+    push!(m.finalizers, offcaller(obsfunc))
 
     on(m.options) do options
         # Make sure i_selected is on a valid index when the contentgrid updates

--- a/src/makielayout/blocks/slider.jl
+++ b/src/makielayout/blocks/slider.jl
@@ -90,6 +90,9 @@ function initialize_block!(sl::Slider)
         markersize = buttonsize, inspectable = false, marker=Circle)
 
     mouseevents = addmouseevents!(topscene, sl.layoutobservables.computedbbox)
+    for obsfunc in mouseevents.observerfuncs
+        push!(sl.finalizers, offcaller(obsfunc))
+    end
 
     onmouseleftdrag(mouseevents) do event
         dragging[] = true

--- a/src/makielayout/blocks/slidergrid.jl
+++ b/src/makielayout/blocks/slidergrid.jl
@@ -46,6 +46,12 @@ function initialize_block!(sg::SliderGrid, nts::NamedTuple...)
     sg.valuelabels = Label[]
     sg.labels = Label[]
 
+    push!(sg.finalizers, function()
+        delete!.(sg.sliders)
+        delete!.(sg.valuelabels)
+        delete!.(sg.labels)
+    end)
+
     extract_label_range_format(pair::Pair) = pair[1], extract_range_format(pair[2])...
     extract_range_format(p::Pair) = (p...,)
     extract_range_format(x) = (x, default_format)

--- a/src/makielayout/blocks/toggle.jl
+++ b/src/makielayout/blocks/toggle.jl
@@ -45,6 +45,9 @@ function initialize_block!(t::Toggle)
         color = t.buttoncolor, strokewidth = 0, inspectable = false, marker = Circle)
 
     mouseevents = addmouseevents!(topscene, t.layoutobservables.computedbbox)
+    for obsfunc in mouseevents.observerfuncs
+        push!(t.finalizers, offcaller(obsfunc))
+    end
 
     onmouseleftdown(mouseevents) do event
         if animating[]

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -279,7 +279,7 @@ function Scene(
     )
     if isnothing(px_area)
         px_area = lift(zero_origin, parent.px_area; ignore_equal_values=true)
-    else
+    elseif !(px_area isa Observable) # observables are assumed to be already corrected against the parent to avoid double updates
         px_area = lift(pixelarea(parent), convert(Observable, px_area); ignore_equal_values=true) do p, a
             # make coordinates relative to parent
             rect = Rect2i(minimum(p) .+ minimum(a), widths(a))

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -348,4 +348,14 @@ end
         end
         @test isempty(d)
     end
+    @testset "Legend" begin
+        d = get_difference_dict() do scene
+            Legend(s, [
+                MarkerElement(marker = :cross),
+                LineElement(),
+                PolyElement(),
+            ], ["Label 1", "Label 2", "Label 3"])
+        end
+        @test isempty(d)
+    end
 end

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -350,7 +350,7 @@ end
     end
     @testset "Legend" begin
         d = get_difference_dict() do scene
-            Legend(s, [
+            Legend(scene, [
                 MarkerElement(marker = :cross),
                 LineElement(),
                 PolyElement(),

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -271,3 +271,81 @@ end
     @test Set(ax2.yaxislinks) == Set([ax1, ax3])
     @test Set(ax3.yaxislinks) == Set([ax1, ax2])
 end
+
+copy_listeners(obs::Observable) = copy(obs.listeners)
+function iterate_observable_fields(f, x::T) where T
+    for (fieldname, fieldtype) in zip(fieldnames(T), fieldtypes(T))
+        fieldtype <: Observable || continue
+        f(fieldname, getfield(x, fieldname))
+    end
+    return
+end
+
+function iterate_attributes(f, a::Attributes, prefix = "")
+    for (key, value) in a
+        if value isa Attributes
+            iterate_attributes(f, value, "$prefix:$key")
+        else
+            f("$prefix:$key", value)
+        end
+    end
+end
+
+function listener_dict(s::Scene)
+    d = Dict{String,Vector}()
+    iterate_observable_fields(s) do fieldname, field
+        d["$fieldname"] = copy_listeners(field)
+    end
+    iterate_observable_fields(s.events) do fieldname, field
+        d["events:$fieldname"] = copy_listeners(field)
+    end
+    iterate_observable_fields(s.camera) do fieldname, field
+        d["camera:$fieldname"] = copy_listeners(field)
+    end
+    iterate_attributes(s.theme) do prefix, obs
+        d["theme:$prefix"] = copy_listeners(obs)
+    end
+    return d
+end
+
+function dictdiff(before, after)
+    kd = setdiff(keys(before), keys(after))
+    isempty(kd) || error("Mismatching keys: $kd")
+    d = Dict{String,Vector}()
+    for key in keys(after)
+        befset = Set(last.(before[key]))
+        v = filter(after[key]) do (prio,func)
+            func ∉ befset
+        end
+        isempty(v) || (d[key] = v)
+    end
+    return d
+end
+
+function get_difference_dict(blockfunc)
+    s = Scene(camera = campixel!);
+    before = listener_dict(s)
+    block = blockfunc(s)
+    delete!(block)
+    after = listener_dict(s)
+    return dictdiff(before, after)
+end
+
+@testset "Deletion of Blocks" begin
+    blocks = [Axis, Axis3, Slider, Toggle, Label, Button, Menu, Textbox, Box]
+    @testset "$block" for block in blocks
+        d = get_difference_dict(block)
+        @test isempty(d)
+    end
+    @testset "Slidergrid" begin
+        d = get_difference_dict() do scene
+            SliderGrid(scene,
+                (label = "Amplitude", range = 0:0.1:10, startvalue = 5),
+                (label = "Frequency", range = 0:0.5:50, format = "{:.1f}Hz", startvalue = 10),
+                (label = "Phase", range = 0:0.01:2pi,
+                    format = x -> string(round(x/pi, digits = 2), "π"))
+            ) 
+        end
+        @test isempty(d)
+    end
+end


### PR DESCRIPTION
I tried to just compare the listeners of most (all?) relevant observables that a fresh `Scene` has with those after a `Block` object has been added and `delete!`d. This way I found all observables that needed to be cleaned up for each `Block`.

While it seems that this correctly cleans up such that new objects in the place of deleted ones work correctly, I have the feeling it has also introduced some instability. Or maybe just uncovered previously existing instability that didn't show because nobody `delete!`d stuff and continued interacting with the `Scene` after.

Fixes ...

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
