### PR TITLE
Let the "glyphcollection" observable be a Vector{Any} in text

### DIFF
--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -1,7 +1,7 @@
 function plot!(plot::Text)
     positions = plot[1]
     # attach a function to any text that calculates the glyph layout and stores it
-    glyphcollections = Observable(GlyphCollection[])
+    glyphcollections = Observable(Any[])
     linesegs = Observable(Point2f[])
     linewidths = Observable(Float32[])
     linecolors = Observable(RGBAf[])
@@ -18,7 +18,7 @@ function plot!(plot::Text)
         scol = to_color(scol)
         offs = to_offset(offs)
 
-        gcs = GlyphCollection[]
+        gcs = Any[]
         lsegs = Point2f[]
         lwidths = Float32[]
         lcolors = RGBAf[]

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -1,7 +1,7 @@
 function plot!(plot::Text)
     positions = plot[1]
     # attach a function to any text that calculates the glyph layout and stores it
-    glyphcollections = Observable(Any[])
+    glyphcollections = Observable([])
     linesegs = Observable(Point2f[])
     linewidths = Observable(Float32[])
     linecolors = Observable(RGBAf[])
@@ -18,7 +18,7 @@ function plot!(plot::Text)
         scol = to_color(scol)
         offs = to_offset(offs)
 
-        gcs = Any[]
+        gcs = []
         lsegs = Point2f[]
         lwidths = Float32[]
         lcolors = RGBAf[]


### PR DESCRIPTION

# Description

Allows arbitrary text input types to be dispatched on.
With this, I should be able to re-integrate MakieTeX, with the caveat (as before) that texts have to be initialized as LaTeXStrings or a TeX type in order to work with MakieTeX.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
