### PR TITLE
Default `fig` to `current_figure()` for `resize!` and `resize_to_layo…

### DIFF
--- a/src/figures.jl
+++ b/src/figures.jl
@@ -130,6 +130,7 @@ end
 
 """
     resize_to_layout!(fig::Figure)
+    resize_to_layout!()
 
 Resize `fig` so that it fits the current contents of its top `GridLayout`.
 If a `GridLayout` contains fixed-size content or aspect-constrained
@@ -138,6 +139,8 @@ differs from the size of the `Figure`. This can result in superfluous
 whitespace at the borders, or content clipping at the figure edges.
 Once resized, all content should fit the available space, including
 the `Figure`'s outer padding.
+
+If no figure is provided, `fig` defaults to `current_figure()`.
 """
 function resize_to_layout!(fig::Figure)
     # it is assumed that all plot objects have been added at this point,
@@ -150,7 +153,9 @@ function resize_to_layout!(fig::Figure)
     resize!(fig.scene, widths(bbox)...)
     new_size
 end
+resize_to_layout!() = resize_to_layout!(current_figure())
 
+# No default to `current_figure()` added, as `Base` owns this function
 function Base.empty!(fig::Figure)
     empty!(fig.scene)
     empty!(fig.scene.events)
@@ -165,7 +170,12 @@ end
 # Layouts are already hooked up to this, so it's very simple.
 """
     resize!(fig::Figure, width, height)
+    resize!(width, height)
+
 Resizes the given `Figure` to the resolution given by `width` and `height`.
 If you want to resize the figure to its current layout content, use `resize_to_layout!(fig)` instead.
+
+If no figure is provided, `fig` defaults to `current_figure()`.
 """
 Makie.resize!(figure::Figure, args...) = resize!(figure.scene, args...)
+Makie.resize!(args...) = resize!(current_figure().scene, args...)  # Less specific type, so definition above is used if figure is passed.


### PR DESCRIPTION
# Description

What it says on the box.

## Type of change

Delete options that do not apply:
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
