### PR TITLE
Remove offset in `show_data` for `scatter`

### DIFF
--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -509,8 +509,8 @@ function show_data(inspector::DataInspector, plot::Scatter, idx)
         tt.text[] = position2string(plot[1][][idx])
     end
     tt.offset[] = ifelse(
-        a.apply_tooltip_offset[], 
-        0.5 * sv_getindex(plot.markersize[], idx) + 2, 
+        a.apply_tooltip_offset[],
+        0.5 * maximum(sv_getindex(plot.markersize[], idx)) + 2,
         a.offset[]
     )
     tt.visible[] = true

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -314,6 +314,8 @@ returning a label. See Makie documentation for more detail.
 - `enable_indicators = true)`: Enables or disables indicators
 - `depth = 9e3`: Depth value of the tooltip. This should be high so that the
     tooltip is always in front.
+- `apply_tooltip_offset = true`: Enables or disables offsetting tooltips based 
+    on, for example, markersize.
 - and all attributes from `Tooltip`
 """
 function DataInspector(fig_or_block; kwargs...)
@@ -332,6 +334,7 @@ function DataInspector(scene::Scene; priority = 100, kwargs...)
         depth = pop!(attrib_dict, :depth, 9e3),
         enable_indicators = pop!(attrib_dict, :show_bbox_indicators, true),
         offset = get(attrib_dict, :offset, 10f0),
+        apply_tooltip_offset = pop!(attrib_dict, :apply_tooltip_offset, true),
 
         # Settings for indicators (plots that highlight the current selection)
         indicator_color = pop!(attrib_dict, :indicator_color, :red),
@@ -505,6 +508,11 @@ function show_data(inspector::DataInspector, plot::Scatter, idx)
     else
         tt.text[] = position2string(plot[1][][idx])
     end
+    tt.offset[] = ifelse(
+        a.apply_tooltip_offset[], 
+        0.5 * sv_getindex(plot.markersize[], idx) + 2, 
+        a.offset[]
+    )
     tt.visible[] = true
     a.indicator_visible[] && (a.indicator_visible[] = false)
 
@@ -581,12 +589,16 @@ function show_data(inspector::DataInspector, plot::Union{Lines, LineSegments}, i
     p0, p1 = plot[1][][idx-1:idx]
     origin, dir = view_ray(scene)
     pos = closest_point_on_line(p0, p1, origin, dir)
-    lw = plot.linewidth[] isa Vector ? plot.linewidth[][idx] : plot.linewidth[]
 
     proj_pos = shift_project(scene, plot, to_ndim(Point3f, pos, 0))
     update_tooltip_alignment!(inspector, proj_pos)
 
-    tt.offset[] = lw + 2
+    tt.offset[] = ifelse(
+        a.apply_tooltip_offset[], 
+        sv_getindex(plot.linewidth[], idx) + 2, 
+        a.offset[]
+    )
+
     if haskey(plot, :inspector_label)
         tt.text[] = plot[:inspector_label][](plot, idx, typeof(p0)(pos))
     else

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -499,9 +499,7 @@ function show_data(inspector::DataInspector, plot::Scatter, idx)
 
     proj_pos = shift_project(scene, plot, to_ndim(Point3f, plot[1][][idx], 0))
     update_tooltip_alignment!(inspector, proj_pos)
-    ms = plot.markersize[]
 
-    tt.offset[] = 0.5ms + 2
     if haskey(plot, :inspector_label)
         tt.text[] = plot[:inspector_label][](plot, idx, plot[1][][idx])
     else

--- a/src/layouting/layouting.jl
+++ b/src/layouting/layouting.jl
@@ -299,8 +299,6 @@ end
 
 _offset_to_vec(o::VecTypes) = to_ndim(Vec3f, o, 0)
 _offset_to_vec(o::Vector) = to_ndim.(Vec3f, o, 0)
-_offset_at(o::Vec3f, i) = o
-_offset_at(o::Vector, i) = o[i]
 Base.getindex(x::ScalarOrVector, i) = x.sv isa Vector ? x.sv[i] : x.sv
 Base.lastindex(x::ScalarOrVector) = x.sv isa Vector ? length(x.sv) : 1
 
@@ -322,7 +320,7 @@ function text_quads(atlas::TextureAtlas, position::VecTypes, gc::GlyphCollection
         )
         uvs[i] = glyph_uv_width!(atlas, gc.glyphs[i], gc.fonts[i])
         scales[i] = widths(glyph_bb) .+ gc.scales[i] .* 2pad
-        char_offsets[i] = gc.origins[i] .+ _offset_at(off, i)
+        char_offsets[i] = gc.origins[i] .+ sv_getindex(off, i)
         quad_offsets[i] = minimum(glyph_bb) .- gc.scales[i] .* pad
     end
 
@@ -364,7 +362,7 @@ function text_quads(atlas::TextureAtlas, position::Vector, gcs::Vector{<: GlyphC
             )
             uvs[k] = glyph_uv_width!(atlas, gc.glyphs[i], gc.fonts[i])
             scales[k] = widths(glyph_bb) .+ gc.scales[i] * 2pad
-            char_offsets[k] = gc.origins[i] .+ _offset_at(off, j)
+            char_offsets[k] = gc.origins[i] .+ sv_getindex(off, j)
             quad_offsets[k] = minimum(glyph_bb) .- gc.scales[i] .* pad
             k += 1
         end

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -346,3 +346,7 @@ function extract_keys(attributes, keys)
     end
     return attr
 end
+
+# Scalar - Vector getindex
+sv_getindex(v::Vector, i::Integer) = v[i]
+sv_getindex(x, i::Integer) = x


### PR DESCRIPTION
# Description

Fixes #2724 

The tooltip offset in the `show_data` method for `scatter` plots (relevant when using `DataInspector`) is removed.
As it is in master, the offset assumes all markers to be of the same size, so it errors when that is not the case.
In contrast `meshscatter` uses no tooltip offset, and hence does not suffer from this issue. This PR brings `scatter` behavior in line with `meshscatter`. Arguably, the offset only makes the tooltip less precise spatially in busy plots, so this is also an improvement in tooltip clarity in my opinion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

As a bugfix with no significant change in behavior, no additional actions apply, correct?
