### PR TITLE
Call normalize with qualified name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Fixed issue with scatterlines only accepting concrete color types as `markercolor` [#2691](https://github.com/MakieOrg/Makie.jl/pull/2691)
 - Fixed an accidental issue where `LaTeXStrings` were not typeset correctly in `Axis3`. [#2558](https://github.com/MakieOrg/Makie.jl/pull/2588)
 - Fixed a bug where line segments in `text(lstr::LaTeXString)` were ignoring offsets. [#2668](https://github.com/MakieOrg/Makie.jl/pull/2668)
+- Fixed a bug where the `arrows` recipe accidentally called a `Bool` when `normalize = true`. [#2740](https://github.com/MakieOrg/Makie.jl/pull/2740)
 - Re-exported the `@colorant_str` (`colorant"..."`) macro from Colors.jl. [#2726](https://github.com/MakieOrg/Makie.jl/pull/2726)
 
 ## v0.19.1

--- a/src/basic_recipes/arrows.jl
+++ b/src/basic_recipes/arrows.jl
@@ -125,7 +125,7 @@ function plot!(arrowplot::Arrows{<: Tuple{AbstractVector{<: Point{N}}, V}}) wher
         fxaa_bool = @lift($fxaa == automatic ? false : $fxaa)
         headstart = lift(points, directions, normalize, align, lengthscale) do points, dirs, n, align, s
             map(points, dirs) do p1, dir
-                dir = n ? normalize(dir) : dir
+                dir = n ? LinearAlgebra.normalize(dir) : dir
                 if align in (:head, :lineend, :tailend, :headstart, :center)
                     shift = s .* dir
                 else


### PR DESCRIPTION
# Description

Fixes #2738

Qualifies the call to `normalize` with `LinearAlgebra` to avoid name clash with the `@extract`ed parameter of the same name.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

In the past it was qualified with `StaticArrays`, however that is no longer a dependency of the library apparently which is probably why it was changed to break in the first place. The `StaticArrays` one is just a reexport of the `LinearAlgebra` one anyways as far as I can tell, so this should be identical to the old behavior.

Do you usually make tests for things like this? I'm not familiar enough with the internals of Makie yet to know how to verify programmatically that the data on the plot has actually been normalized, however I tested the fix on my use case and it works both in CairoMakie and GLMakie. If you want a test I can probably look into it with some help.