### PR TITLE
Provide helpful warning and round instead of cryptic error

### DIFF
--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -42,9 +42,14 @@ struct VideoStreamOptions
     rawvideo::Bool
 
     function VideoStreamOptions(
-            format::AbstractString, framerate::Integer, compression, profile,
+            format::AbstractString, framerate::Real, compression, profile,
             pixel_format, loglevel::String, input::String, rawvideo::Bool=true)
-
+        
+        if !isa(framerate, Integer)
+            @warn "The given framefrate is not a subtype of `Integer`, and will be rounded to the nearest integer. To supress this warning, provide an integer as the framerate."
+            framerate = round(Int, framerate)
+        end
+        
         if format == "mp4"
             (profile === nothing) && (profile = "high422")
             (pixel_format === nothing) && (pixel_format = (profile == "high444" ? "yuv444p" : "yuv420p"))


### PR DESCRIPTION
The current error message if framerate is not an integer is quite bad, only showing up several calls away from the original call to `record`:
```
ERROR: MethodError: no method matching Makie.VideoStreamOptions(::SubString{String}, ::Float64, ::Nothing, ::Nothing, ::Nothing, ::String, ::String, ::Bool)

Some of the types have been truncated in the stacktrace for improved reading. To emit complete information
in the stack trace, evaluate `TruncatedStacktraces.VERBOSE[] = true` and re-run the code.


Closest candidates are:
  Makie.VideoStreamOptions(::AbstractString, ::Integer, ::Any, ::Any, ::Any, ::String, ::String, ::Bool)
   @ Makie ~/.julia/packages/Makie/gAmAB/src/ffmpeg-util.jl:44
  Makie.VideoStreamOptions(::AbstractString, ::Integer, ::Any, ::Any, ::Any, ::String, ::String)
   @ Makie ~/.julia/packages/Makie/gAmAB/src/ffmpeg-util.jl:44

Stacktrace:
 [1] VideoStream(fig::Figure; format::SubString{String}, framerate::Float64, compression::Nothing, profile::Nothing, pixel_format::Nothing, loglevel::String, visible::Bool, connect::Bool, backend::Module, screen_config::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Makie ~/.julia/packages/Makie/gAmAB/src/ffmpeg-util.jl:215
 [2] kwcall(::NamedTuple{(:format, :framerate), Tuple{SubString{String}, Float64}}, ::Type{VideoStream}, fig::Figure)
   @ Makie ~/.julia/packages/Makie/gAmAB/src/ffmpeg-util.jl:201
 [3] Record(func::var"#233#234", figlike::Figure, iter::UnitRange{Int64}; kw_args::Base.Pairs{Symbol, Any, Tuple{Symbol, Symbol}, NamedTuple{(:format, :framerate), Tuple{SubString{String}, Float64}}})
   @ Makie ~/.julia/packages/Makie/gAmAB/src/recording.jl:165
 [4] kwcall(::NamedTuple{(:format, :framerate), Tuple{SubString{String}, Float64}}, ::typeof(Record), func::Function, figlike::Figure, iter::UnitRange{Int64})
   @ Makie ~/.julia/packages/Makie/gAmAB/src/recording.jl:164
 [5] record(func::Function, figlike::Figure, path::String, iter::UnitRange{Int64}; kw_args::Base.Pairs{Symbol, Float64, Tuple{Symbol}, NamedTuple{(:framerate,), Tuple{Float64}}})
   @ Makie ~/.julia/packages/Makie/gAmAB/src/recording.jl:148
 [6] kwcall(::NamedTuple{(:framerate,), Tuple{Float64}}, ::typeof(record), func::Function, figlike::Figure, path::String, iter::UnitRange{Int64})
   @ Makie ~/.julia/packages/Makie/gAmAB/src/recording.jl:146
 [7] top-level scope
   @ ~/Uni/Semester/8. Sem/Computational Physics/BathroomTeamGithub/Homework/Dennis_6.jl:81
```

This PR changes the behavior to a warning and automatic rounding, which is a lot more useful and friendly.