### PR TITLE
Add Dendrogram recipe

### DIFF
--- a/src/stats/dendrogram.jl
+++ b/src/stats/dendrogram.jl
@@ -70,7 +70,7 @@ function get_box_connectors(parent, child1, child2)
     return [(x1, child1.y), (x1, yp), (x2, yp), (x2, child2.y)]
 end
 
-function recurssive_draw!(ax, node, nodes; branch_shape=:tree)
+function recursive_draw_dendrogram!(ax, node, nodes; branch_shape=:tree)
     isnothing(node.children) && return nothing
     child1 = nodes[node.children[1]]
     child2 = nodes[node.children[2]]
@@ -80,8 +80,8 @@ function recurssive_draw!(ax, node, nodes; branch_shape=:tree)
     
     lines!(ax, l)
 
-    recurssive_draw!(ax, child1, nodes; branch_shape)
-    recurssive_draw!(ax, child2, nodes; branch_shape)
+    recursive_draw_dendrogram!(ax, child1, nodes; branch_shape)
+    recursive_draw_dendrogram!(ax, child2, nodes; branch_shape)
     return nothing
 end
 
@@ -101,7 +101,7 @@ end
 
 function dendrogram(nodes::Dict{Int, DNode}; branch_shape=:tree)
     ax = Axis(Figure()[1,1])    
-    recurssive_draw!(ax, nodes[maximum(keys(nodes))], nodes; branch_shape)
+    recursive_draw_dendrogram!(ax, nodes[maximum(keys(nodes))], nodes; branch_shape)
     current_figure()
 end
 

--- a/src/stats/dendrogram.jl
+++ b/src/stats/dendrogram.jl
@@ -1,0 +1,123 @@
+"""
+    dendrogram(x, y; kwargs...)
+
+Draw a [dendrogram](https://en.wikipedia.org/wiki/Dendrogram),
+with leaf nodes specified by `x` and `y` coordinates,
+and parent nodes identified by `merges`.
+
+# Arguments
+- `x`: x positions of leaf nodes
+- `y`: y positions of leaf nodes (default = 0)
+# Keywords
+- `merges`: specifies connections between nodes (see below)
+- `treestyle`: one of `:??`, `:??` 
+"""
+@recipe(Dendrogram, x, y) do scene
+    Theme(
+        weights = automatic,
+        color = theme(scene, :patchcolor),
+        colormap = theme(scene, :colormap),
+        colorrange = automatic,
+        orientation = :vertical,
+        strokecolor = theme(scene, :patchstrokecolor),
+        strokewidth = theme(scene, :patchstrokewidth),
+        cycle = [:color => :patchcolor],
+        inspectable = theme(scene, :inspectable)
+    )
+end
+
+conversion_trait(x::Type{<:Dendrogram}) = SampleBased() #??
+
+function Makie.plot!(plot::Dendrogram)
+    args = @extract plot (weights, width, range, show_outliers, whiskerwidth, show_notch, orientation, gap, dodge, n_dodge, dodge_gap)
+
+end
+
+##############
+# Playground #
+##############
+
+struct DNode
+    idx::Int
+    x::Float32
+    y::Float32
+    children::Union{Tuple{Int,Int}, Nothing}
+end
+
+function find_merge(n1, n2; height=1)
+    newx = min(n1[1], n2[1]) + abs((n1[1] - n2[1])) / 2
+    newy = max(n1[2], n2[2]) + height
+    return Point2f(newx, newy)
+end
+
+function find_merge(n1::DNode, n2::DNode; height=1, index=max(n1.idx, n2.idx)+1)
+    newx = min(n1.x, n2.x) + abs((n1.x - n2.x)) / 2
+    newy = max(n1.y, n2.y) + height
+
+    return DNode(index, Point2f(newx, newy)..., (n1.idx, n2.idx))
+end
+
+
+function get_tree_connectors(parent, child1, child2)
+    return [(child1.x, child1.y), (parent.x, parent.y), (child2.x, child2.y)]
+end
+
+function get_box_connectors(parent, child1, child2)
+    yp = parent.y
+    x1 = child1.x
+    x2 = child2.x
+
+    return [(x1, child1.y), (x1, yp), (x2, yp), (x2, child2.y)]
+end
+
+function recurssive_draw!(ax, node, nodes; branch_shape=:tree)
+    isnothing(node.children) && return nothing
+    child1 = nodes[node.children[1]]
+    child2 = nodes[node.children[2]]
+   
+    l = branch_shape == :tree ? get_tree_connectors(node, child1, child2) :
+        branch_shape == :box  ? get_box_connectors(node, child1, child2) : error()
+    
+    lines!(ax, l)
+
+    recurssive_draw!(ax, child1, nodes; branch_shape)
+    recurssive_draw!(ax, child2, nodes; branch_shape)
+    return nothing
+end
+
+
+function dendrogram(leaves, merges; branch_shape=:tree)
+    nodes = Dict(i => DNode(i, n[1], n[2], nothing) for (i,n) in enumerate(leaves))
+    nm = maximum(keys(nodes))
+
+    for m in merges
+        nm += 1
+        nodes[nm] = find_merge(nodes[m[1]], nodes[m[2]]; index = nm)
+    end
+
+    dendrogram(nodes; branch_shape)
+end
+
+
+function dendrogram(nodes::Dict{Int, DNode}; branch_shape=:tree)
+    ax = Axis(Figure()[1,1])    
+    recurssive_draw!(ax, nodes[maximum(keys(nodes))], nodes; branch_shape)
+    current_figure()
+end
+
+
+function hcl_nodes(hcl; useheight=false)
+    nleaves = length(hcl.order)
+    nodes = Dict(i => DNode(i, x, 0, nothing) for (i,x) in enumerate(invperm(hcl.order)))
+    nm = maximum(keys(nodes))
+
+    for (m1, m2) in eachrow(hcl.merges)
+        nm += 1
+        
+        m1 = m1 < 0 ? -m1 : m1 + nleaves
+        m2 = m2 < 0 ? -m2 : m2 + nleaves
+        nodes[nm] = find_merge(nodes[m1], nodes[m2]; index=nm)            
+    end
+
+    return nodes
+end


### PR DESCRIPTION
# Description

Fixes #398 

I've begun working on a [dendrogram](https://en.wikipedia.org/wiki/Dendrogram) recipe.
The primary goal is to be able to plot the output of hclust objects from Clustering.jl,
and I made a recipe for StatsPlots.jl that did that a few years ago, but here,
I thought I would try to make something a bit more generic.

## Design

My initial thought is that a dendrogram is essentially a graph structure - to represent it in a plot,
you need nodes with (x, y) coordinates, and links between them.
But a dendrogram is a special-case, since it is a directed acyclic graph with a single root node,
and nodes can have either 0 children (leaf nodes) or 2 children (all others).

This makes plotting relatively simple, since you can start with the root node,
and then recursively draw children until you get to the leaves.

This is still very much work-in-progress, its not even a recipe yet, but I just wanted to throw  it up to solicit feedback before I go too far down the path in the wrong direction.

My initial design is as follows:

- a struct `DNode` that has a node index, `x` and `y` coordinates, and a `Tuple` of child indexes (or `Nothing` if a leaf)
- a function `find_merge` that takes 2 `(x,y)` tuples or 2 `DNode`s, and finds the `x` and `y` coordinates where their parent node should be
- `get_tree_coordinates()` and `get_box_coordinates()` to get the shapes for lines connecting a series of nodes (see below). The idea here is that there may be different ways to connect nodes (in the future, one might one a radial tree for example, and hopefully this would be extensible)
- `recursive_draw_dendrogram!()` which takes a dictionary of nodes, and a starting node, and does the drawing

I also included an `hcl_nodes()` for a proof-of-concept on how one might pull the right structure from a `HClust` - I do not anticipate pulling in Clustering in as a dependency, but rather would add the recipe there, or else make a separate `MakieDendrograms` package or something.

### Showcase

<details>
<summary>Basic dendrograms</summary>

```julia
leaves = Point2f.([
    (1,0),
    (2,0.5),
    (3,1),
    (4,2),
    (5,0)
])

merges = [
    (1, 2), # 6
    (6, 3), # 7
    (4, 5), # 8
    (7, 8), # 9
]

dendrogram(leaves, merges)
dendrogram(leaves, merges; branch_shape = :box)
```

</details>

<img src="https://user-images.githubusercontent.com/3502975/224875878-cfef8d20-386c-484d-9bce-3e489b05c348.png" width=400> <img src="https://user-images.githubusercontent.com/3502975/224875975-377db23c-07ff-4c5c-a44b-449c77b73fdd.png" width=400>


<details>
<summary>Converting from HClust</summary>

```julia
using Clustering
using Distances

n = 20

mat = zeros(Int, n, n)

for i in 1:n
   last = minimum([i+Int(floor(n/5)), n])
   for j in i:last
       mat[i,j] = 1
   end
end

mat = mat[:, randperm(n)]

dm = pairwise(Euclidean(), mat; dims=2)
hcl = hclust(dm; linkage=:average, branchorder=:optimal)

heatmap(mat[:,hcl.order]) # see https://github.com/JuliaStats/Clustering.jl/pull/170

nodes = get_hcl(hcl)
dendrogram(nodes)
dendrogram(nodes; branch_shape=:box)
```

</details>

<img src="https://user-images.githubusercontent.com/3502975/224876397-2c2373b2-077a-46e3-93e1-31dda157b4a3.png" width=400> <img src="https://user-images.githubusercontent.com/3502975/224876528-6321e9d0-914e-43da-87ec-de4d58be9ea4.png" width=400>


## Planned features

- [ ] Specify heights of parent nodes. Right now, each parent is exactly 1 higher than the highest child
- [ ] Enable grouping. Because of the structure, it should be possible to specify color groups, and color branches if all leaves belong to the same group.

## Help / Feedback requested

- I think I need some guidance on how to plug into the recipe system. I started from the boxplot recipe because I thought I understood all of those components, but I really don't understand the internals here. I plan to do a bunch of reading this week to see if I can get a further handle on it, but any pointers would be appreciated.
- Does this make sense to people? A different idea I had was to do something like use the `z` coordinate as a node index, but this seems like abusing the idea of `z`, and one would need to specify connections separately anyway.
- Would it be better to just try a PR to `GraphMakie.jl` that provides a conversion from `HClust` to a `Graphs.jl` graph? Part of me things that a primitive representation would be useful, but another part is worried I'm inventing a chiseled-rock wheel when Firestone tires exist.


## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
