### PR TITLE
fix #2767 and #1881 (slow data_limits for recipes)

### DIFF
--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -65,7 +65,9 @@ function point_iterator(list::AbstractVector)
     else
         points = Point3f[]
         for elem in list
-            append!(points, point_iterator(elem))
+            for point in point_iterator(elem)
+                push!(points, to_ndim(Point3f, point, 0))
+            end
         end
         return points
     end

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -59,7 +59,16 @@ end
 point_iterator(mesh::GeometryBasics.Mesh) = decompose(Point, mesh)
 
 function point_iterator(list::AbstractVector)
-    Iterators.flatten((point_iterator(elem) for elem in list))
+    if length(list) == 1
+        # save a copy!
+        return point_iterator(list[1])
+    else
+        points = Point3f[]
+        for elem in list
+            append!(points, point_iterator(elem))
+        end
+        return points
+    end
 end
 
 point_iterator(plot::Combined) = point_iterator(plot.plots)
@@ -74,45 +83,9 @@ function br_getindex(matrix::AbstractMatrix, idx::CartesianIndex, dim::Int)
     return matrix[idx]
 end
 
-function get_point_xyz(linear_indx::Int, indices, X, Y, Z)
-    idx = indices[linear_indx]
-    x = br_getindex(X, idx, 1)
-    y = br_getindex(Y, idx, 2)
-    z = Z[linear_indx]
-    return Point(x, y, z)
-end
-
-function get_point_xyz(linear_indx::Int, indices, X, Y)
-    idx = indices[linear_indx]
-    x = br_getindex(X, idx, 1)
-    y = br_getindex(Y, idx, 2)
-    return Point(x, y, 0.0)
-end
-
-function point_iterator(plot::Surface)
-    X = plot.x[]
-    Y = plot.y[]
-    Z = plot.z[]
-    indices = CartesianIndices(Z)
-    return (get_point_xyz(idx, indices, X, Y, Z) for idx in 1:length(Z))
-end
-
-function point_iterator(plot::Heatmap)
-    X = plot.x[]
-    Y = plot.y[]
-    Z = plot[3][]
-    zsize = size(Z) .+ 1
-    indices = CartesianIndices(zsize)
-    return (get_point_xyz(idx, indices, X, Y) for idx in 1:prod(zsize))
-end
-
-function point_iterator(plot::Image)
-    X = plot.x[]
-    Y = plot.y[]
-    Z = plot[3][]
-    zsize = size(Z)
-    indices = CartesianIndices(zsize)
-    return (get_point_xyz(idx, indices, X, Y) for idx in 1:prod(zsize))
+function point_iterator(plot::Union{Image, Heatmap, Surface})
+    rect = data_limits(plot)
+    return unique(decompose(Point3f, rect))
 end
 
 function point_iterator(x::Volume)


### PR DESCRIPTION
So, turns out we've been using a slow path for recipes, because we overloaded `data_limits` directly for Surface, Image and Heatmap, to avoid that slow path. Recipes would use my earlier, slow implementation of `point_iterator`, which hasn't been used anymore outside recipes...