### PR TITLE
Fix the materials example in RPRMakie

### DIFF
--- a/RPRMakie/examples/materials.jl
+++ b/RPRMakie/examples/materials.jl
@@ -8,7 +8,7 @@ image = begin
               PointLight(Vec3f(10), RGBf(radiance, radiance, radiance * 1.1))]
     fig = Figure(; resolution=(1500, 700))
     ax = LScene(fig[1, 1]; show_axis=false, scenekw=(lights=lights,))
-    screen = Screen(ax.scene; plugin=RPR.Northstar, iterations=400)
+    screen = RPRMakie.Screen(ax.scene; plugin=RPR.Northstar)
 
     matsys = screen.matsys
     emissive = RPR.EmissiveMaterial(matsys)


### PR DESCRIPTION
- RPRMakie.Screen
- Don't set the number of iterations to 400 by default...it's a bit much for Mac users :(

# Description

Fixes # (issue)

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
