### PR TITLE
Minor fixes to documentation

### DIFF
--- a/docs/documentation/events.md
+++ b/docs/documentation/events.md
@@ -378,7 +378,7 @@ Furthermore you can wrap any of the above in `Exclusively` to discard matches wh
 
 ## Interactive Widgets
 
-Makie has a couple of useful interactive widgets like sliders, buttons and menus, which you can read about in the \myreflink{Blocks} section.
+Makie has a couple of useful interactive widgets like sliders, buttons and menus, which you can learn about in the [blocks and widgets](https://docs.makie.org/stable/examples/blocks/) section.
 
 ## Recording Animations with Interactions
 

--- a/docs/documentation/events.md
+++ b/docs/documentation/events.md
@@ -378,7 +378,7 @@ Furthermore you can wrap any of the above in `Exclusively` to discard matches wh
 
 ## Interactive Widgets
 
-Makie has a couple of useful interactive widgets like sliders, buttons and menus, which you can learn about in the [blocks and widgets](https://docs.makie.org/stable/examples/blocks/) section.
+Makie has a couple of useful interactive widgets like sliders, buttons and menus, which you can learn about in the \myreflink{Blocks} section.
 
 ## Recording Animations with Interactions
 

--- a/docs/documentation/fonts.md
+++ b/docs/documentation/fonts.md
@@ -56,6 +56,6 @@ f
 Currently, Makie does not have the ability to draw emoji.
 This is due to the implementation of text drawing in GLMakie and WGLMakie, which relies on signed distance fields that can only be used to render monochrome glyphs, but not arbitrary bitmaps.
 
-Multicolored fonts such as those in the context of the [color fonts](https://www.colorfonts.wtf/) project are currently not supported.
+Multicolored _fonts_, like those in the [color fonts](https://www.colorfonts.wtf/) project, are currently not supported.
 Colored text is supported with the [rich text](https://docs.makie.org/stable/examples/plotting_functions/text/index.html#rich_text) functionality.
 If you want to use emoji as scatter markers, consider using images (you will need to find suitable images separately, you cannot easily extract emoji from fonts with Makie).

--- a/docs/documentation/fonts.md
+++ b/docs/documentation/fonts.md
@@ -53,6 +53,8 @@ f
 
 ## Emoji and color fonts
 
-Currently, Makie does not have the ability to draw emoji or other color fonts.
+Currently, Makie does not have the ability to draw emoji.
 This is due to the implementation of text drawing in GLMakie and WGLMakie, which relies on signed distance fields that can only be used to render monochrome glyphs, but not arbitrary bitmaps.
+
+Other color fonts are supported with the [rich text](https://docs.makie.org/stable/examples/plotting_functions/text/index.html#rich_text) functionality.
 If you want to use emoji as scatter markers, consider using images (you will need to find suitable images separately, you cannot easily extract emoji from fonts with Makie).

--- a/docs/documentation/fonts.md
+++ b/docs/documentation/fonts.md
@@ -56,5 +56,6 @@ f
 Currently, Makie does not have the ability to draw emoji.
 This is due to the implementation of text drawing in GLMakie and WGLMakie, which relies on signed distance fields that can only be used to render monochrome glyphs, but not arbitrary bitmaps.
 
-Other color fonts are supported with the [rich text](https://docs.makie.org/stable/examples/plotting_functions/text/index.html#rich_text) functionality.
+Multicolored fonts such as those in the context of the [color fonts](https://www.colorfonts.wtf/) project are currently not supported.
+Colored text is supported with the [rich text](https://docs.makie.org/stable/examples/plotting_functions/text/index.html#rich_text) functionality.
 If you want to use emoji as scatter markers, consider using images (you will need to find suitable images separately, you cannot easily extract emoji from fonts with Makie).

--- a/src/basic_recipes/convenience_functions.jl
+++ b/src/basic_recipes/convenience_functions.jl
@@ -1,9 +1,9 @@
 """
     showlibrary(lib::Symbol)::Scene
 
-Shows all colour gradients in the given library.
-Returns a Scene with these colour gradients arranged
-as horizontal colourbars.
+Shows all color gradients in the given library.
+Returns a Scene with these color gradients arranged
+as horizontal colorbars.
 """
 function showlibrary(lib::Symbol)::Scene
     cgrads = sort(PlotUtils.cgradients(lib))


### PR DESCRIPTION
# Description

Minor fixes to documentation, previously stated that coloured text is not possible, which is no longer true, now points to rich text functionality. Also standardised some use of the British spelling of colour to American (unfortunately).

## Type of change

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
