### PR TITLE
fix lines on nvidia

### DIFF
--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -525,10 +525,10 @@ void main(void)
     // CPU side by repeating the first and last points via the index buffer. It
     // just requires a little care further down to avoid degenerate normals.
     bool isvalid[4] = bool[](
-        g_valid_vertex[0] == 1 && g_id[0].y != g_id[1].y,
+        g_valid_vertex[0] == 1,
         g_valid_vertex[1] == 1,
         g_valid_vertex[2] == 1,
-        g_valid_vertex[3] == 1 && g_id[2].y != g_id[3].y
+        g_valid_vertex[3] == 1
     );
 
     if(!isvalid[1] || !isvalid[2]){

--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -482,12 +482,12 @@ void draw_solid_line(bool isvalid[4])
     // direction and enforce an AA border at the original start/end position
     // with f_uv_minmax.
     float is_start = float(!isvalid[0]);
-    f_uv_minmax.x = ifelse(is_start, px2uv * u1, f_uv_minmax.x);
+    if (!isvalid[0]) f_uv_minmax.x = px2uv * u1;
     p1 -= is_start * AA_THICKNESS * v1;
     u1 -= is_start * AA_THICKNESS;
 
     float is_end = float(!isvalid[3]);
-    f_uv_minmax.y = ifelse(is_end, px2uv * u2, f_uv_minmax.y);
+    if (!isvalid[3]) f_uv_minmax.y = px2uv * u2;
     u2 += is_end * AA_THICKNESS;
     p2 += is_end * AA_THICKNESS * v1;
 
@@ -525,10 +525,10 @@ void main(void)
     // CPU side by repeating the first and last points via the index buffer. It
     // just requires a little care further down to avoid degenerate normals.
     bool isvalid[4] = bool[](
-        g_valid_vertex[0] == 1,
-        g_valid_vertex[1] == 1,
-        g_valid_vertex[2] == 1,
-        g_valid_vertex[3] == 1
+        g_valid_vertex[0] == 1 && g_id[0].y != g_id[1].y, 
+        g_valid_vertex[1] == 1, 
+        g_valid_vertex[2] == 1, 
+        g_valid_vertex[3] == 1 && g_id[2].y != g_id[3].y 
     );
 
     if(!isvalid[1] || !isvalid[2]){

--- a/GLMakie/src/glshaders/lines.jl
+++ b/GLMakie/src/glshaders/lines.jl
@@ -45,10 +45,10 @@ function gappy(x, ps)
     return last(ps) - x
 end
 function ticks(points, resolution)
-    # This is used to map a vector of `points` to a signed distance field. The 
+    # This is used to map a vector of `points` to a signed distance field. The
     # points mark transition between "on" and "off" section of the pattern.
 
-    # The output should be periodic so the signed distance field value 
+    # The output should be periodic so the signed distance field value
     # representing points[1] should be equal to the one representing points[end].
     # => range(..., length = resolution+1)[1:end-1]
 
@@ -104,7 +104,6 @@ function draw_lines(screen, position::Union{VectorTypes{T}, MatTypes{T}}, data::
         lastlen             = const_lift(sumlengths, p_vec) => GLBuffer
         pattern_length      = 1f0 # we divide by pattern_length a lot.
     end
-
     if pattern !== nothing
         if !isa(pattern, Texture)
             if !isa(pattern, Vector)
@@ -118,7 +117,7 @@ function draw_lines(screen, position::Union{VectorTypes{T}, MatTypes{T}}, data::
             maxlength = const_lift(last, lastlen)
         end
     end
-    
+
     data[:intensity] = intensity_convert(intensity, vertex)
     return assemble_shader(data)
 end


### PR DESCRIPTION
I'm not 100% sure if this is the correct fix! I think @ffreyer was intending this to be used differently.
But we do need to repeat first and last indices with `lines_adjecency`, see comment:
https://github.com/MakieOrg/Makie.jl/blob/master/GLMakie/src/glshaders/lines.jl#L82-L84
```
       # Duplicate the vertex indices on the ends of the line, as our geometry
       # shader in `layout(lines_adjacency)` mode requires each rendered
       # segment to have neighbouring vertices.
```
Not sure I understand the comment correctly in the shader, since we still do duplicate these indices, and from memory I do think that was necessary, since `lines_adjecency` needs to be always multiple of 4... 
I'm surprised though, that this seems to be an nvidia only problem, so there still seems to be more to it...