### PR TITLE
skip 0 width line segments

### DIFF
--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -519,7 +519,7 @@ void main(void)
     o_normal = vec3(0);
 
     // we generate very thin lines for linewidth 0, so we manually skip them:
-    if (g_thickness[0] == 0.0 && g_thickness[1] == 0.0 && g_thickness[2] == 0.0 && g_thickness[3] == 0.0) {
+    if (g_thickness[1] == 0.0 && g_thickness[2] == 0.0) {
         return;
     }
 

--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -518,6 +518,12 @@ void main(void)
     o_view_pos = vec3(0);
     o_normal = vec3(0);
 
+    // we generate very thin lines for linewidth 0, so we manually skip them:
+    if (g_thickness[0] == 0.0 && g_thickness[1] == 0.0 && g_thickness[2] == 0.0 && g_thickness[3] == 0.0) {
+        return;
+    }
+
+
     // We mark each of the four vertices as valid or not. Vertices can be
     // marked invalid on input (eg, if they contain NaN). We also mark them
     // invalid if they repeat in the index buffer. This allows us to render to
@@ -525,10 +531,10 @@ void main(void)
     // CPU side by repeating the first and last points via the index buffer. It
     // just requires a little care further down to avoid degenerate normals.
     bool isvalid[4] = bool[](
-        g_valid_vertex[0] == 1 && g_id[0].y != g_id[1].y, 
-        g_valid_vertex[1] == 1, 
-        g_valid_vertex[2] == 1, 
-        g_valid_vertex[3] == 1 && g_id[2].y != g_id[3].y 
+        g_valid_vertex[0] == 1 && g_id[0].y != g_id[1].y,
+        g_valid_vertex[1] == 1,
+        g_valid_vertex[2] == 1,
+        g_valid_vertex[3] == 1 && g_id[2].y != g_id[3].y
     );
 
     if(!isvalid[1] || !isvalid[2]){


### PR DESCRIPTION
To avoid these artifacts:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/1010467/226854812-08ea9dfa-c8b6-4d86-8ecd-39e5a120fbbe.png">
```julia
using GLMakie
begin 
    f = lines(Rect2f(0, 0, 1, 4), linewidth=0.0, depth_shift=-1.0f-5)
    lines!(Rect2f(0, 0, 1, 4), linewidth=10)
    f
end
```