### PR TITLE
Skip limit reset on plot insertion when autolimits disabled

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -801,7 +801,10 @@ function Makie.plot!(
     # adjust the limit margins in those cases automatically.
     needs_tight_limits(plot) && tightlimits!(la)
 
-    if is_open_or_any_parent(la.scene)
+    xauto = to_value(get(allattrs, :xautolimits, true))
+    yauto = to_value(get(allattrs, :yautolimits, true))
+
+    if is_open_or_any_parent(la.scene) && (xauto || yauto)
         reset_limits!(la)
     end
     plot


### PR DESCRIPTION
# Description

Currently when a plot is added to an axis the limit resetting machinery always runs. This means that if you either set limits yourself (xlims!, ylims!) or any one of the inserted plots has valid limits, axis limits will reset. If you are dynamically inserting plots this can be rather annoying. (E.g. if you insert plots on click you'll end up resetting limits with every click.)

I adjusted things to skip limit resets when `xautolimits = false, yautolimits = false` in the inserted plot. Alternatively we could also add a new attribute for this. (Maybe one that is removed before the plot is constructed?)

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
