### PR TITLE
Make scene.visible trigger render updates

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -435,6 +435,7 @@ function Makie.insertplots!(screen::Screen, scene::Scene)
     get!(screen.screen2scene, WeakRef(scene)) do
         id = length(screen.screens) + 1
         push!(screen.screens, (id, scene))
+        on(_ -> screen.requires_update = true, scene.visible)
         return id
     end
     for elem in scene.plots


### PR DESCRIPTION
# Description

Reported on discord.

We should probably also have `scene.visible` propagate to other child scenes because right now
```julia
f, a, p = scatter(rand(10))
a.blockscene.visible[] = false
a.scene.parent === a.blockscene
# true
```
results in

![Screenshot from 2023-03-28 14-18-25](https://user-images.githubusercontent.com/10947937/228233678-e271d10a-bcbe-4893-bc91-9d4597e37483.png)

I also noticed we're not using `Observables.inputs` (for map!/map at least)
https://github.com/JuliaGizmos/Observables.jl/blob/28bcea62fc74d34f132dd481804ba2a0ba0efcbe/src/Observables.jl#L515
Don't we want that for better bookkeeping?


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
