### PR TITLE
Don't move scenes to the origin (fix #2814)

### DIFF
--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -326,7 +326,7 @@ function Scene(
         kw...
     )
     if isnothing(px_area)
-        map!(zero_origin, child, child_px_area, parent.px_area)
+        map!(identity, child, child_px_area, parent.px_area)
     elseif !(px_area isa Observable) # observables are assumed to be already corrected against the parent to avoid double updates
         a = Rect2i(px_area)
         on(child, pixelarea(parent)) do p


### PR DESCRIPTION
# Description

This has been in Makie since day 1 and I don't know why. Setting the origin to zero means moving the scene to the bottom left corner. Why?

I checked 

```julia
fig = Figure()
Axis(fig[1, 1])
p = scatter!(rand(10))
Axis3(fig[1, 2])
LScene(fig[1, 3])
Box(fig[2, 1])
Button(fig[2, 2])
Colorbar(fig[2, 3], tellwidth=false)
IntervalSlider(fig[3, 1])
Label(fig[3, 2])
Slider(fig[3, 3])
Legend(fig[4, 1], [p], ["test"])
Menu(fig[4, 2], options = string.(1:3))
Textbox(fig[5, 1])
Toggle(fig[5, 2])
Menu(fig[1, 4][1, 1])
fig
```

And everything seems fine here. Same with the example from https://docs.makie.org/stable/tutorials/layout-tutorial/

I may have intentionally removed this in MakieLayout in #1818 which caused a similar problem with #1907. I think this was before `blockscene` which probably resulted in less consistent scene sizes. Maybe there `zero_origin` made sure to place a full size scene at the origin and not an offset. But I don't think this is a problem anymore, and if it is I think it should be handled in makielayout.

## Type of change

Bug fix if we consider this internal, breaking if not.

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
