### PR TITLE
[WIP] Clean up the recipe docs

### DIFF
--- a/docs/documentation/recipes.md
+++ b/docs/documentation/recipes.md
@@ -27,6 +27,10 @@ This is the sequential logic by which conversions in Makie are attempted:
 - Dispatch on `convert_arguments(::PlotType, converted_args...)`
 - Fail if no method was found
 
+There are two methods in the type recipe API: 
+- `convert_arguments(::Type{<: PlotType}, args...)`
+- `used_attributes(::Type{<: PlotType}, input_args...)::NTuple{Symbol}` which passes the returned keys as kwargs to `convert_arguments`.
+
 ### Multiple Argument Conversion with `convert_arguments`
 
 Plotting of a `Circle` for example can be defined via a conversion into a vector of points:


### PR DESCRIPTION
# Description

Adds a couple of cleanups, rephrasings, etc to the docs as well as documenting some previously unknown features.

e.g.: 
```julia
Makie.used_attributes(::Type{<:Choropleth}, v::AbstractVector) = (:transformation,)

function Makie.convert_arguments(::Type{<:Choropleth}, v::AbstractVector;
                                 transformation=trivialtransformation)
    geometries = map(Base.Fix1(to_geometry, transformation), v)
    return PlotSpec{Poly}(geometries)
end

```
(from AlgebraOfGraphics)
which I had no idea existed.
