### PR TITLE
allow modifier key for rectzoom

### DIFF
--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -212,6 +212,7 @@ given `scene`.
 By default uses the `scene` that the mouse is currently hovering over.
 """
 mouseposition(x) = mouseposition(get_scene(x))
+
 function mouseposition(scene::Scene = hovered_scene())
     return to_world(scene, mouseposition_px(scene))
 end

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -108,7 +108,6 @@ end
 ############################################################################
 
 function _chosen_limits(rz, ax)
-
     r = positivize(Rect2f(rz.from, rz.to .- rz.from))
     lims = ax.finallimits[]
     # restrict to y change
@@ -144,7 +143,8 @@ function _selection_vertices(ax_scene, outer, inner)
 end
 
 function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)
-
+    # only rectangle zoom if modifier is pressed (defaults to true)
+    ispressed(ax.scene, r.modifier) || return Consume(false)
     # TODO: actually, the data from the mouse event should be transformed already
     # but the problem is that these mouse events are generated all the time
     # and outside of log axes, you would quickly run into domain errors

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -141,11 +141,12 @@ mutable struct RectangleZoom
     from::Union{Nothing, Point2f}
     to::Union{Nothing, Point2f}
     rectnode::Observable{Rect2f}
+    modifier::Any # e.g. Keyboard.left_alt, or some other button that needs to be pressed to start rectangle... Defaults to `true`, which means no modifier needed
 end
 
-function RectangleZoom(callback::Function; restrict_x=false, restrict_y=false)
+function RectangleZoom(callback::Function; restrict_x=false, restrict_y=false, modifier=true)
     return RectangleZoom(callback, Observable(false), restrict_x, restrict_y,
-                         nothing, nothing, Observable(Rect2f(0, 0, 1, 1)))
+                         nothing, nothing, Observable(Rect2f(0, 0, 1, 1)), modifier)
 end
 
 struct ScrollZoom


### PR DESCRIPTION
Can't set this via the theme yet, but at least when constructing directly: `RectangleZoom(f, axis; modifier=(Keyboard.left_control & Keyboard.left_alt))`.
