### PR TITLE
Change "x-limits" to "$(dimsym)-limits".

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -967,7 +967,7 @@ function autolimits(ax::Axis, dim::Integer)
     margin = getproperty(ax, Symbol(dimsym, :autolimitmargin))[]
     if !isnothing(lims)
         if !validate_limits_for_scale(lims, scale)
-            error("Found invalid x-limits $lims for scale $(scale) which is defined on the interval $(defined_interval(scale))")
+            error("Found invalid $(dimsym)-limits $lims for scale $(scale) which is defined on the interval $(defined_interval(scale))")
         end
         lims = expandlimits(lims, margin[1], margin[2], scale)
     end


### PR DESCRIPTION
# Description
I quite often get the error `Found invalid x-limits (0.0f0, 1.331f0) for scale log10 which is defined on the interval 0.0..Inf (open)` when setting the **y-scale** of plots. Below is the plot which produced that message when doing `ax.yscale=log10`, despite having run `ylims!(1e-100, nothing)`. Note that the limits in the error are in fact y-limits.
![image](https://user-images.githubusercontent.com/61620837/232422741-6ac98dc2-2bac-4f12-9815-770a47fb49b2.png)

I believe this should fix the erroneous text (warning about x-axis). However, no error should be raised, as I explicitly set legal y-limits. I do not know what needs to be changed to fix that.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
