### PR TITLE
Scatterjitter

### DIFF
--- a/docs/examples/plotting_functions/scatterjitter.md
+++ b/docs/examples/plotting_functions/scatterjitter.md
@@ -1,0 +1,29 @@
+# scatterlines
+
+{{doc scatterlines}}
+## Examples
+
+\begin{examplefigure}{svg = true}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+
+
+y = vcat([rand(k.*50).*5*k.+k for k = 1:5]...)
+
+f = Figure()
+	for (i,type) = enumerate([:uniform,:pseudorandom,:quasirandom])
+        for (j,clamp) = enumerate([0.,0.3])
+		ax = f[j,i] = Axis(f)
+	    scatterjitter!(ax,ones(length(y)).*1,y;jitter_type=type,jitter_width=1.0,clamped_portion=clamp)
+        scatterjitter!(ax,ones(length(y)).*2,y;jitter_type=type,jitter_width=0.2,clamped_portion=clamp)
+        scatterjitter!(ax,ones(length(y)).*2,y;jitter_type=type,jitter_width=1.5,clamped_portion=clamp)
+        end
+	end
+	
+	f
+
+
+f
+```
+\end{examplefigure}

--- a/docs/examples/plotting_functions/scatterjitter.md
+++ b/docs/examples/plotting_functions/scatterjitter.md
@@ -3,6 +3,7 @@
 {{doc scatterlines}}
 ## Examples
 
+Example demonstrating different jitter types in rows, with clamping and without in column, and different jitter widths in the rows.
 \begin{examplefigure}{svg = true}
 ```julia
 using CairoMakie
@@ -12,12 +13,12 @@ CairoMakie.activate!() # hide
 y = vcat([rand(k.*50).*5*k.+k for k = 1:5]...)
 
 f = Figure()
-	for (i,type) = enumerate([:uniform,:pseudorandom,:quasirandom])
-        for (j,clamp) = enumerate([0.,0.3])
+	for (j,type) = enumerate([:uniform,:pseudorandom,:quasirandom])
+        for (i,clamp) = enumerate([0.,0.3])
 		ax = f[j,i] = Axis(f)
 	    scatterjitter!(ax,ones(length(y)).*1,y;jitter_type=type,jitter_width=1.0,clamped_portion=clamp)
         scatterjitter!(ax,ones(length(y)).*2,y;jitter_type=type,jitter_width=0.2,clamped_portion=clamp)
-        scatterjitter!(ax,ones(length(y)).*2,y;jitter_type=type,jitter_width=1.5,clamped_portion=clamp)
+        scatterjitter!(ax,ones(length(y)).*3,y;jitter_type=type,jitter_width=1.5,clamped_portion=clamp)
         end
 	end
 	

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -319,6 +319,7 @@ include("makielayout/MakieLayout.jl")
 include("figureplotting.jl")
 include("basic_recipes/series.jl")
 include("basic_recipes/text.jl")
+include("basic_recipes/scatterjitter.jl")
 include("basic_recipes/raincloud.jl")
 include("deprecated.jl")
 

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -6,6 +6,13 @@ function cloud_plot_check_args(category_labels, data_array)
     return nothing
 end
 
+const RAINCLOUD_RNG = Ref{Random.AbstractRNG}(Random.GLOBAL_RNG)
+
+# quick custom function for jitter
+rand_localized(min, max) = rand_localized(RAINCLOUD_RNG[], min, max)
+rand_localized(RNG::Random.AbstractRNG, min, max) = rand(RNG) * (max - min) .+ min
+
+
 """
     rainclouds!(ax, category_labels, data_array; plot_boxplots=true, plot_clouds=true, kwargs...)
 
@@ -228,7 +235,7 @@ function plot!(plot::RainClouds)
     width_ratio = width / full_width
 
     jitter = create_jitter_array(data_array;
-                                    jitter_width = jitter_width*width_ratio,clamped_proportion=0.2,jitter_type=:uniform)
+                                    jitter_width = jitter_width*width_ratio,clamped_portion=0.2,jitter_type=:uniform)
 
     if !isnothing(clouds)
         if clouds === violin

--- a/src/basic_recipes/scatterjitter.jl
+++ b/src/basic_recipes/scatterjitter.jl
@@ -71,7 +71,7 @@ function create_jitter_array(data_array; jitter_type = :uniform,jitter_width = 1
 		pdf_x = pdf_x ./ maximum(pdf_x)
 		jitter = pdf_x .* jitter
 	end
-	@show maximum(jitter),minimum(jitter)
+
 	
     # created clamp_min, and clamp_max to clamp a portion of the data
     @assert (base_max - base_min) == 1.0

--- a/src/basic_recipes/scatterjitter.jl
+++ b/src/basic_recipes/scatterjitter.jl
@@ -1,0 +1,88 @@
+"""
+scatterjitter(x,y; jitter_type=true, jitter_width=1, clamped_portion,kwargs...)
+Plot a scatter plot, but jitter points along the x-axis.
+
+# Arguments
+- `x/y`, same as for `Scatter`
+# Keywords
+- `jitter_type=:pseudorandom`: Type of jitter. Available are `:pseudorandom` (follows the deterministic VanDerCorput series, weighted by the kernel-estimated-density), `:quasirandom` (uniform jitter, but weighted by the kernel-estimated-density density) or `:uniform`
+- `jitter_width=1`: How much to jitter left/right
+- `clamped_proportion=0`: Optionally clamp the values left/right by a certain amount of jitter_width
+
+"""
+@recipe(ScatterJitter,x,y) do scene
+        return Attributes(
+            jitter_type=:pseudorandom,
+            jitter_width = 1,
+            clamped_portion = 0.;
+            default_theme(scene, Scatter)...
+        )
+end
+
+function plot!(plt::ScatterJitter)    
+    jitter = map(x->create_jitter_array(x; 	jitter_type=to_value(plt.jitter_type),jitter_width=to_value(plt.jitter_width),clamped_portion=to_value(plt.clamped_portion)), plt.y)
+    
+    scatter_x = map(+,plt.x,jitter)
+    
+    scatter!(plt,Attributes(plt),scatter_x,plt.y,)
+    return plt
+end
+# Allow to globally set jitter RNG for testing
+# A bit of a lazy solution, but it doesn't seem to be desirably to
+# pass the RNG through the plotting command
+const JITTER_RNG = Ref{Random.AbstractRNG}(Random.GLOBAL_RNG)
+
+# quick custom function for jitter
+jitter_uniform(n) = jitter_uniform(JITTER_RNG[],n)
+jitter_uniform(RNG::Random.AbstractRNG, n) = rand(RNG,n)
+
+function create_jitter_array(data_array; jitter_type = :uniform,jitter_width = 1, clamped_portion = 0.0)
+    jitter_width < 0 && ArgumentError("`jitter_width` should be positive.")
+    !(0 <= clamped_portion <= 1) || ArgumentError("`clamped_portion` should be between 0.0 to 1.0")
+
+    # Make base jitter, note base jitter minimum-to-maximum span is 1.0
+    base_min, base_max = (-0.5, 0.5)
+
+	
+	if jitter_type == :uniform
+		#pdf_x = ones(length(data_array))
+		jitter = jitter_uniform(length(data_array))
+		
+	elseif jitter_type == :pseudorandom
+		jitter = jitter_uniform(length(data_array))
+		
+	elseif jitter_type ==:quasirandom
+		jitter = vandercorput.(1:length(data_array))
+	else
+	
+		error("jitter_type not implemented")
+	
+	end
+	jitter = jitter.*(base_max-base_min).+base_min
+	
+	# weight it
+	if jitter_type == :pseudorandom || jitter_type == :quasirandom
+	
+		k = KernelDensity.kde(data_array,npoints=200)	
+		ik = InterpKDE(k)
+		pdf_x = pdf(ik, data_array)
+		pdf_x = pdf_x ./ maximum(pdf_x)
+		jitter = pdf_x .* jitter
+	end
+	@show maximum(jitter),minimum(jitter)
+	
+    # created clamp_min, and clamp_max to clamp a portion of the data
+    @assert (base_max - base_min) == 1.0
+    @assert (base_max + base_min) / 2.0 == 0
+    clamp_min = base_min + (clamped_portion / 2.0)
+    clamp_max = base_max - (clamped_portion / 2.0)
+
+    # clamp if need be
+    clamp!(jitter, clamp_min, clamp_max)
+
+    # Based on assumptions of clamp_min and clamp_max above
+    jitter = jitter * (0.5jitter_width / clamp_max)
+	
+    return jitter
+end
+

--- a/src/basic_recipes/scatterjitter.jl
+++ b/src/basic_recipes/scatterjitter.jl
@@ -9,6 +9,8 @@ Plot a scatter plot, but jitter points along the x-axis.
 - `jitter_width=1`: How much to jitter left/right
 - `clamped_proportion=0`: Optionally clamp the values left/right by a certain amount of jitter_width
 
+
+Benedikt Ehinger & Vladimir Mikheev
 """
 @recipe(ScatterJitter,x,y) do scene
         return Attributes(


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/AlgebraOfGraphics.jl/issues/253

Adds weighted-jitter along the density of the distribution

## Type of change
![image](https://user-images.githubusercontent.com/10183650/233134380-5321d9c0-8f97-4e90-a3ca-8a9de0183834.png)

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
