### PR TITLE
data_limits dispatch for Mesh to omit slow iteration over buffer

### DIFF
--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -209,6 +209,12 @@ function data_limits(plot::Surface)
     return Rect3f(mini, maxi .- mini)
 end
 
+function data_limits(plot::Mesh)
+    xyz = plot.mesh[].position
+    mini,maxi = extrema(xyz)
+    return Rect3f(mini, maxi .- mini)
+end
+
 function data_limits(plot::Heatmap)
     mini_maxi = extrema_nan.((plot.x[], plot.y[]))
     mini = Vec3f(first.(mini_maxi)..., 0)


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/Makie.jl/issues/2864

This PR changes the performance of the following:

```
julia> begin
           fig = GLMakie.Figure()
           ax = GLMakie.LScene(fig[1, 1])
           @time meshplot =GLMakie.mesh!(ax, plotter.mesh)
           fig
       end
  0.637678 seconds (15.12 k allocations: 566.358 MiB)
```
to
```
julia> begin
           fig = GLMakie.Figure()
           ax = GLMakie.LScene(fig[1, 1])
           @time meshplot =GLMakie.mesh!(ax, plotter.mesh)
           fig
       end
0.186790 seconds (15.13 k allocations: 1.111 MiB)
```

by using `extrema` in `data_limits` instead of computing the `bbox` by iterating over `mesh.position` which is still expensive. I'm not sure tho what `extrema` uses under the hood the avoid the performance issues. I looked up the source code at 
```
julia> @which extrema(plotter.physical_coords_mesh)
extrema(a::AbstractArray; dims, kw...) in Base at reducedim.jl:994
```
but I don't understand anything that's going on there :D 

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
