### PR TITLE
Allow `nothing` to be passed to high/lowclip

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -16,10 +16,10 @@ function color_and_colormap!(plot, intensity = plot[:color])
     if intensity[] isa Union{Number, AbstractArray{<: Number}}
         @converted_attribute plot (colormap,)
         replace_automatic!(plot, :highclip) do
-            lift(last, plot, colormap)
+            map!(last, plot, Observable{Any}(), colormap)
         end
         replace_automatic!(plot, :lowclip) do
-            lift(first, plot, colormap)
+            map!(first, plot, Observable{Any}(), colormap)
         end
         get!(plot, :nan_color, RGBAf(0,0,0,0))
         if intensity[] isa Number


### PR DESCRIPTION
in `color_and_colormap!`

# Description

Loosens type constraints on high/lowclip.

Needs test.  This doesn't work with [W]/GLMakie, but works for eg Cairo.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
