### PR TITLE
Allow `[x/y/z]scale = Base.Fix1(log, base::Number)`

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1366,7 +1366,7 @@ defaultlimits(::typeof(Makie.pseudolog10)) = (0.0, 100.0)
 defaultlimits(::Makie.Symlog10) = (0.0, 100.0)
 
 defined_interval(::typeof(identity)) = OpenInterval(-Inf, Inf)
-defined_interval(::Union{typeof(log2), typeof(log10), typeof(log), Base.Fix1{typeof(log), <: Number}) = OpenInterval(0.0, Inf)
+defined_interval(::Union{typeof(log2), typeof(log10), typeof(log), Base.Fix1{typeof(log), <: Number}}) = OpenInterval(0.0, Inf)
 defined_interval(::typeof(sqrt)) = Interval{:closed,:open}(0, Inf)
 defined_interval(::typeof(Makie.logit)) = OpenInterval(0.0, 1.0)
 defined_interval(::typeof(Makie.pseudolog10)) = OpenInterval(-Inf, Inf)

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1355,7 +1355,7 @@ defaultlimits(limits::Tuple{Real, Nothing}, scale) = (limits[1], defaultlimits(s
 defaultlimits(limits::Tuple{Nothing, Real}, scale) = (defaultlimits(scale)[1], limits[2])
 defaultlimits(limits::Tuple{Nothing, Nothing}, scale) = defaultlimits(scale)
 
-
+defaultlimits(f::Base.Fix1{typeof(log), <: Number}) = (1.0, f.x ^ 3)
 defaultlimits(::typeof(log10)) = (1.0, 1000.0)
 defaultlimits(::typeof(log2)) = (1.0, 8.0)
 defaultlimits(::typeof(log)) = (1.0, exp(3.0))
@@ -1366,7 +1366,7 @@ defaultlimits(::typeof(Makie.pseudolog10)) = (0.0, 100.0)
 defaultlimits(::Makie.Symlog10) = (0.0, 100.0)
 
 defined_interval(::typeof(identity)) = OpenInterval(-Inf, Inf)
-defined_interval(::Union{typeof(log2), typeof(log10), typeof(log)}) = OpenInterval(0.0, Inf)
+defined_interval(::Union{typeof(log2), typeof(log10), typeof(log), Base.Fix1{typeof(log), <: Number}) = OpenInterval(0.0, Inf)
 defined_interval(::typeof(sqrt)) = Interval{:closed,:open}(0, Inf)
 defined_interval(::typeof(Makie.logit)) = OpenInterval(0.0, 1.0)
 defined_interval(::typeof(Makie.pseudolog10)) = OpenInterval(-Inf, Inf)


### PR DESCRIPTION
simply hooks up `Base.Fix1{typeof(log), <: Number}` to the Axis transform api.

# Description

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
