### PR TITLE
Let some kwargs vary with k_ideal in WilkinsonTicks

### DIFF
--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -1,4 +1,4 @@
-function WilkinsonTicks(k_ideal::Int; k_min = 2, k_max = 10,
+function WilkinsonTicks(k_ideal::Int = 6; k_min::Int = k_ideal - 4, k_max::Int = k_ideal + 4,
         Q = [(1.0,1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
         granularity_weight = 1/4,
         simplicity_weight = 1/6,
@@ -7,7 +7,7 @@ function WilkinsonTicks(k_ideal::Int; k_min = 2, k_max = 10,
         min_px_dist = 50.0)
 
     if !(0 < k_min <= k_ideal <= k_max)
-        error("Invalid tick number specifications k_ideal $k_ideal, k_min $k_min, k_max $k_max")
+        error("Invalid tick number specifications `k_ideal` $k_ideal, `k_min` $k_min, `k_max` $k_max.  `k_ideal` must be between `k_min` and `k_max`!")
     end
 
     WilkinsonTicks(k_ideal, k_min, k_max, Q, granularity_weight, simplicity_weight,


### PR DESCRIPTION
# Description

Specifically, `k_min = k_ideal - 4`, `k_max = k_ideal + 4`.  Users can still override this as necessary.

## Type of change

Arguably a bug fix in the UX for WilkinsonTicks.

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
