### PR TITLE
Set visible=true for interactive record

### DIFF
--- a/src/recording.jl
+++ b/src/recording.jl
@@ -139,7 +139,7 @@ end
 """
 function record(func, figlike::FigureLike, path::AbstractString; kw_args...)
     format = lstrip(splitext(path)[2], '.')
-    io = Record(func, figlike; format=format, kw_args...)
+    io = Record(func, figlike; format=format, visible=true, kw_args...)
     save(path, io)
 end
 


### PR DESCRIPTION
# Description

Fixes #2879 

Sets default figure  behavior  to `visible=true` for interactive record

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
