### PR TITLE
Explicitly write out and stabilize point projection

### DIFF
--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -429,8 +429,7 @@ function project(cam::Camera, input_space::Symbol, output_space::Symbol, pos)
     input_space === output_space && return to_ndim(Point3f, pos, 0)
     clip_from_input = space_to_clip(cam, input_space)
     output_from_clip = clip_to_space(cam, output_space)
-    transformed = apply_matrix(output_from_clip * clip_from_input, pos)
-    return Point3f(transformed[Vec(1, 2, 3)] ./ transformed[4])
+    return apply_matrix(output_from_clip * clip_from_input, pos)
 end
 
 function project(cam::Camera, input_space::Symbol, output_space::Symbol, pos::AbstractArray{<: VecTypes{<: Number}})


### PR DESCRIPTION
This PR provides a function `apply_matrix(::Mat4, ::VecTypes)` which performs a non-allocating matrix multiplication of a 4d matrix with a 2d or 3d point, without ever actually converting the point to 4d. 

Earlier, we were actually converting to Point3f and padding with 0, then to Point4f and padding with 1.  This way gets rid of those conversions, and shows a 5x improvement when projecting a lot of values - useful in CairoMakie for large data / complex curves.