### PR TITLE
fix for VSCode result type: both

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -99,6 +99,25 @@ end
 
 wait_for_display(screen) = nothing
 
+function has_mime_display(mime)
+    for display in Base.Multimedia.displays
+        # Ugh, why would textdisplay say it supports HTML??
+        display isa TextDisplay && continue
+        displayable(display, mime) && return true
+    end
+    return false
+end
+
+can_show_inline(::Missing) = false # no backend
+function can_show_inline(Backend)
+    for mime in [MIME"text/html"(), MIME"image/png"(), MIME"image/svg+xml"()]
+        if backend_showable(Backend.Screen, mime)
+            return has_mime_display(mime)
+        end
+    end
+    return false
+end
+
 """
     Base.display(figlike::FigureLike; backend=current_backend(), screen_config...)
 
@@ -119,8 +138,9 @@ function Base.display(figlike::FigureLike; backend=current_backend(), update=tru
         In that case, try `]build GLMakie` and watch out for any warnings.
         """)
     end
-
-    if ALWAYS_INLINE_PLOTS[] == true
+    inline = ALWAYS_INLINE_PLOTS[]
+    # We show inline if explicitely requested or if automatic and we can actually show something inline!
+    if inline === true || (inline === automatic && can_show_inline(backend))
         Core.invoke(display, Tuple{Any}, figlike)
         # In WGLMakie, we need to wait for the display being done
         screen = getscreen(get_scene(figlike))


### PR DESCRIPTION
Of course there are corner cases that I missed.
E.g. vscode set to result type: both:
![image](https://user-images.githubusercontent.com/1010467/237056726-5639a4c5-7c76-4f63-a319-a8298485f064.png)