### PR TITLE
Fix AA with large linewidth differences

### DIFF
--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -639,9 +639,8 @@ void draw_solid_line(bool isvalid[4])
     vec2 n2 = vec2(-v2.y, v2.x);
 
     // determine stretching of AA border due to linewidth change
-    vec2 edge_v = segment_length * v1.xy + (g_thickness[2] - g_thickness[1]) * n1;
-    vec2 edge_n = vec2(-edge_v.y, edge_v.x);
-    float edge_scale = length(edge_n) / dot(edge_n, n1);
+    float temp = (g_thickness[2] - g_thickness[1]) / segment_length;
+    float edge_scale = sqrt(1 + temp * temp);
 
     // linewidth with padding for anti aliasing (used for geometry)
     float thickness_aa1 = g_thickness[1] + edge_scale * AA_THICKNESS;

--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -55,7 +55,8 @@ void emit_vertex(vec3 position, vec2 uv, int index)
     f_color     = g_color[index];
     gl_Position = vec4((position.xy / resolution), position.z, 1.0);
     f_id        = g_id[index];
-    f_thickness = g_thickness[index];
+    // linewidth scaling may shrink the effective linewidth
+    f_thickness = abs(uv.y) - AA_THICKNESS; 
     EmitVertex();
 }
 
@@ -77,7 +78,7 @@ void emit_vertex(vec3 position, vec2 uv, int index, vec4 color)
     f_color     = color;
     gl_Position = vec4((position.xy / resolution), position.z, 1.0);
     f_id        = g_id[index];
-    f_thickness = g_thickness[index];
+    f_thickness = abs(uv.y) - AA_THICKNESS;
     EmitVertex();
 }
 void emit_vertex(vec3 position, vec2 uv, vec4 color)
@@ -618,10 +619,6 @@ void draw_solid_line(bool isvalid[4])
     vec3 p2 = screen_space(gl_in[2].gl_Position); // end of current segment, start of next segment
     vec3 p3 = screen_space(gl_in[3].gl_Position); // end of next segment
 
-    // linewidth with padding for anti aliasing
-    float thickness_aa1 = g_thickness[1] + AA_THICKNESS;
-    float thickness_aa2 = g_thickness[2] + AA_THICKNESS;
-
     // determine the direction of each of the 3 segments (previous, current, next)
     vec3 v1 = p2 - p1;
     float segment_length = length(v1.xy);
@@ -640,6 +637,15 @@ void draw_solid_line(bool isvalid[4])
     vec2 n0 = vec2(-v0.y, v0.x);
     vec2 n1 = vec2(-v1.y, v1.x);
     vec2 n2 = vec2(-v2.y, v2.x);
+
+    // determine stretching of AA border due to linewidth change
+    vec2 edge_v = segment_length * v1.xy + (g_thickness[2] - g_thickness[1]) * n1;
+    vec2 edge_n = vec2(-edge_v.y, edge_v.x);
+    float edge_scale = length(edge_n) / dot(edge_n, n1);
+
+    // linewidth with padding for anti aliasing (used for geometry)
+    float thickness_aa1 = g_thickness[1] + edge_scale * AA_THICKNESS;
+    float thickness_aa2 = g_thickness[2] + edge_scale * AA_THICKNESS;
 
     // Setup for sharp corners (see above)
     vec2 miter_a = normalize(n0 + n1);
@@ -717,6 +723,10 @@ void draw_solid_line(bool isvalid[4])
         segment_length += corner_offset;
     }
 
+    // scaling of uv.y due to different linewidths
+    // the padding for AA_THICKNESS should always have AA_THICKNESS width in uv
+    thickness_aa1 = g_thickness[1] / edge_scale + AA_THICKNESS;
+    thickness_aa2 = g_thickness[2] / edge_scale + AA_THICKNESS;
 
     // Generate line segment
     u1 *= px2uv;

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix broken AA for lines with strongly varying linewidth [#2953](https://github.com/MakieOrg/Makie.jl/pull/2953)
+
 ## v0.19.5
 
 - Add `loop` option for GIF outputs when recording videos with `record` [#2891](https://github.com/MakieOrg/Makie.jl/pull/2891).


### PR DESCRIPTION
# Description

This is another fix coming out of #2944. I added per position linewidths with the fixes for line patterns but I didn't think carefully enough about the padding for those cases. Thus we find no anti-aliasing when the change in linewidth from one point to the next is (much) larger than the distance between those points:

```julia
scene = Scene(resolution = (400, 400))
campixel!(scene)
lines!(scene, fill(200, 4), [0, 190, 210, 400], linewidth = [2, 2, 202, 202], color = :black)
scene
```

![Screenshot from 2023-05-14 19-56-47](https://github.com/MakieOrg/Makie.jl/assets/10947937/a0950a6d-b10e-497f-acad-4a811e50729e)

The pr adds scaling so that this is fixed:

![Screenshot from 2023-05-14 19-58-38](https://github.com/MakieOrg/Makie.jl/assets/10947937/21773ca2-9e4d-489e-910c-499b67502df1)

I didn't bother with patterned lines since, well, they do their own weird thing....
![Screenshot from 2023-05-14 19-49-19](https://github.com/MakieOrg/Makie.jl/assets/10947937/73af175f-84c9-4392-81e4-5c8fa4dce7f2)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
