### PR TITLE
Allow indexing a figure with a CartesianIndex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Add `CartesianIndex`-based indexing of `Figure`s [#2964](https://github.com/MakieOrg/Makie.jl/pull/2964)
+
 ## v0.19.5
 
 - Add `loop` option for GIF outputs when recording videos with `record` [#2891](https://github.com/MakieOrg/Makie.jl/pull/2891).

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -99,6 +99,10 @@ function Base.getindex(fig::Figure, rows, cols, side = GridLayoutBase.Inner())
     fig.layout[rows, cols, side]
 end
 
+function Base.getindex(fig::Figure, index::CartesianIndex{2}, side = GridLayoutBase.Inner())
+    fig.layout[Tuple(index)[1], Tuple(index)[2], side]
+end
+
 function Base.setindex!(fig::Figure, obj, rows, cols, side = GridLayoutBase.Inner())
     fig.layout[rows, cols, side] = obj
     obj


### PR DESCRIPTION
# Description

I think it's rather convenient for creating a grid of plots to use a `CartesianIndex`, e.g.

```
for pos in setdiff(CartesianIndex(1,1):CartesianIndex(3,3), (CartesianIndex(2,2),))
    ax = Axis(fig[pos], ...)
    ...
end
```

One can currently use (in the above example) say `[(i,j) for i in 1:3, j in 1:3]` and then splat `pos`, but I think it's fair to call this less idiomatic.

It's also worth noting if somebody had a matrix of objects to be plotted, `CartesianIndicies(matrix)` would be a quite natural way of iterating through them.

## Type of change

A `getindex(::Figure, ::CartesianIndex{2})` method is added so the above example works.

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
