### PR TITLE
tweak bibtex to preserve capitalisation

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -7,6 +7,6 @@
   number = {65},
   pages = {3349},
   author = {Simon Danisch and Julius Krumbiegel},
-  title = {Makie.jl: Flexible high-performance data visualization for Julia},
+  title = {{Makie.jl}: Flexible high-performance data visualization for {Julia}},
   journal = {Journal of Open Source Software}
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ BibTeX entry:
   number = {65},
   pages = {3349},
   author = {Simon Danisch and Julius Krumbiegel},
-  title = {Makie.jl: Flexible high-performance data visualization for Julia},
+  title = {{Makie.jl}: Flexible high-performance data visualization for {Julia}},
   journal = {Journal of Open Source Software}
 }
 ```

--- a/assets/DanischKrumbiegel2021.bibtex
+++ b/assets/DanischKrumbiegel2021.bibtex
@@ -7,6 +7,6 @@
   number = {65},
   pages = {3349},
   author = {Simon Danisch and Julius Krumbiegel},
-  title = {Makie.jl: Flexible high-performance data visualization for Julia},
+  title = {{Makie.jl}: Flexible high-performance data visualization for {Julia}},
   journal = {Journal of Open Source Software}
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -268,7 +268,7 @@ You can use the following BibTeX entry:
   number = {65},
   pages = {3349},
   author = {Simon Danisch and Julius Krumbiegel},
-  title = {Makie.jl: Flexible high-performance data visualization for Julia},
+  title = {{Makie.jl}: Flexible high-performance data visualization for {Julia}},
   journal = {Journal of Open Source Software}
 }
 ```


### PR DESCRIPTION
# Description

Makie.jl includes bibtex snippets for convenience when citing Makie.jl.

Many bibtex styles change titles to sentence case, removing the capitalisation on "Julia".

Enclose individual words instead of only the offending letters to avoid uppercase styles capitalising the name of the package and to issues with kerning (e.g.
https://tex.stackexchange.com/a/140071/77508).


## Type of change

Docs

## Checklist

None of these apply here

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
