### PR TITLE
Fix legendelements when children have no elements

### DIFF
--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -370,3 +370,9 @@ end
         [rich("some", subscript("entry"))],
         rich("title", color = :red, font = :bold_italic))
 end
+
+@testset "Legend for hist with labels" begin
+    f, ax, h = hist(randn(100), bar_labels = :y, label = "My histogram")
+    @test_nowarn axislegend()
+    f
+end


### PR DESCRIPTION
# Description

Making a legend for a labeled histogram would fail because the text plot inside the hist would not return a legend element. Now that function is allowed to return an empty vector, it only fails afterwards if the combination of all subplots is still emtpy.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
 
## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.
