### PR TITLE
test JSServe#sd/static-export

### DIFF
--- a/.github/workflows/wglmakie.yaml
+++ b/.github/workflows/wglmakie.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           using Pkg;
           # dev mono repo versions
-          pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests"
+          pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests; add JSServe#sd/static-export"
       - name: Run the tests
         continue-on-error: true
         run: >

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -2,7 +2,7 @@ using Pkg
 cd(@__DIR__)
 Pkg.activate(".")
 pkg"dev .. ../MakieCore ../CairoMakie ../GLMakie ../WGLMakie ../RPRMakie"
-pkg"add MeshIO GeometryBasics JSServe"
+pkg"add MeshIO GeometryBasics JSServe#sd/static-export"
 Pkg.instantiate()
 Pkg.precompile()
 


### PR DESCRIPTION
Since tests are still a bit leight in JSServe, I want to run the tests here before I tag a non breaking patch release in JSServe