### PR TITLE
Fix errorbar and bracket interaction with transform functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## master
 
+- Scale errorbar whiskers and bracket correctly with transformations [#3012](https://github.com/MakieOrg/Makie.jl/pull/3012)
+- Update bracket when the screen is resized or transformations change [#3012](https://github.com/MakieOrg/Makie.jl/pull/3012)
+
 ## v0.19.6
 
 - Fix broken AA for lines with strongly varying linewidth [#2953](https://github.com/MakieOrg/Makie.jl/pull/2953).

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -337,6 +337,15 @@ end
     fig
 end
 
+@reference_test "Errorbars log scale" begin
+    x = 1:5
+    y = sin.(x) .+ 5
+    fig = Figure()
+    errorbars(fig[1, 1], x, y, y .- 1, y .+ 1; linewidth = 3, whiskerwidth = 20, axis = (; yscale = log10, xscale = log10))
+    errorbars(fig[1, 2], y, x, y .- 1, y .+ 1; linewidth = 3, whiskerwidth = 20, direction = :x, axis = (; yscale = log10, xscale = log10))
+    fig
+end
+
 @reference_test "Rangebars x y low high" begin
     vals = -1:0.1:1
 

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -84,6 +84,7 @@ function Makie.plot!(pl::Bracket)
         end
 
         notify(bp)
+        notify(textpoints)
     end
 
     notify(points)

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -54,16 +54,17 @@ function Makie.plot!(pl::Bracket)
         return to === automatic ? Float32.(0.75 .* fs) : Float32.(to)
     end
 
-    onany(pl, points, scene.camera.projectionview, pl.offset, pl.width, pl.orientation, realtextoffset,
-          pl.style) do points, pv, offset, width, orientation, textoff, style
+    onany(pl, points, scene.camera.projectionview, pl.model, transform_func(pl), 
+          scene.px_area, pl.offset, pl.width, pl.orientation, realtextoffset,
+          pl.style) do points, _, _, _, _, offset, width, orientation, textoff, style
 
         empty!(bp[])
         empty!(textoffset_vec[])
         empty!(textpoints[])
 
         broadcast_foreach(points, offset, width, orientation, textoff, style) do (_p1, _p2), offset, width, orientation, textoff, style
-            p1 = scene_to_screen(_p1, scene)
-            p2 = scene_to_screen(_p2, scene)
+            p1 = plot_to_screen(pl, _p1)
+            p2 = plot_to_screen(pl, _p2)
 
             v = p2 - p1
             d1 = normalize(v)

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -107,10 +107,12 @@ function Makie.plot!(pl::Bracket)
         return text isa AbstractString ? [text] : text
     end
 
-    series!(pl, bp; space = :pixel, solid_color = pl.color, linewidth = pl.linewidth, linestyle = pl.linestyle)
+    # Avoid scale!() / translate!() / rotate!() to affect these
+    series!(pl, bp; space = :pixel, solid_color = pl.color, linewidth = pl.linewidth, 
+        linestyle = pl.linestyle, transformation = Transformation())
     text!(pl, textpoints, text = texts, space = :pixel, align = pl.align, offset = textoffset_vec,
         fontsize = pl.fontsize, font = pl.font, rotation = autorotations, color = pl.textcolor,
-        justification = pl.justification)
+        justification = pl.justification, model = Mat4f(I))
     pl
 end
 

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -235,10 +235,10 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
     plot
 end
 
-function plot_to_screen(plot::AbstractPlot, points::AbstractVector)
+function plot_to_screen(plot, points::AbstractVector)
     cam = parent_scene(plot).camera
     space = to_value(get(plot, :space, :data))
-    spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) * plot.model[]
+    spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) * transformationmatrix(plot)[]
 
     return map(points) do p
         transformed = apply_transform(transform_func(plot), p, space)
@@ -247,19 +247,19 @@ function plot_to_screen(plot::AbstractPlot, points::AbstractVector)
     end
 end
 
-function plot_to_screen(plot::AbstractPlot, p::VecTypes)
+function plot_to_screen(plot, p::VecTypes)
     cam = parent_scene(plot).camera
     space = to_value(get(plot, :space, :data))
-    spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) * plot.model[]
+    spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) * transformationmatrix(plot)[]
     transformed = apply_transform(transform_func(plot), p, space)
     p4d = spvm * to_ndim(Point4f, to_ndim(Point3f, transformed, 0), 1)
     return Point2f(p4d) / p4d[4]
 end
 
-function screen_to_plot(plot::AbstractPlot, points::AbstractVector)
+function screen_to_plot(plot, points::AbstractVector)
     cam = parent_scene(plot).camera
     space = to_value(get(plot, :space, :data))
-    mvps = inv(plot.model[]) * clip_to_space(cam, space) * space_to_clip(cam, :pixel)
+    mvps = inv(transformationmatrix(plot)[]) * clip_to_space(cam, space) * space_to_clip(cam, :pixel)
     itf = inverse_transform(transform_func(plot))
 
     return map(points) do p
@@ -269,10 +269,10 @@ function screen_to_plot(plot::AbstractPlot, points::AbstractVector)
     end
 end
 
-function screen_to_plot(plot::AbstractPlot, p::VecTypes)
+function screen_to_plot(plot, p::VecTypes)
     cam = parent_scene(plot).camera
     space = to_value(get(plot, :space, :data))
-    mvps = inv(plot.model[]) * clip_to_space(cam, space) * space_to_clip(cam, :pixel)
+    mvps = inv(transformationmatrix(plot)[]) * clip_to_space(cam, space) * space_to_clip(cam, :pixel)
     pre_transform = mvps * to_ndim(Vec4f, to_ndim(Vec3f, p, 0.0), 1.0)
     p3 = Point3f(pre_transform) / pre_transform[4]
     return apply_transform(itf, p3, space)

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -187,8 +187,8 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
 
     scene = parent_scene(plot)
 
-    whiskers = lift(plot, linesegpairs, scene.camera.projectionview,
-        scene.camera.pixel_space, whiskerwidth) do pairs, _, _, whiskerwidth
+    whiskers = lift(plot, linesegpairs, scene.camera.projectionview, plot.model,
+        scene.camera.pixel_space, transform_func(plot), whiskerwidth) do pairs, _, _, _, _, whiskerwidth
 
         endpoints = [p for pair in pairs for p in pair]
 

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -193,7 +193,6 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
         endpoints = [p for pair in pairs for p in pair]
 
         screenendpoints = plot_to_screen(plot, endpoints)
-        @info screenendpoints
 
         screenendpoints_shifted_pairs = map(screenendpoints) do sep
             (sep .+ f_if(is_in_y_direction[], reverse, Point(0, -whiskerwidth/2)),

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -188,10 +188,9 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
     scene = parent_scene(plot)
 
     whiskers = lift(plot, linesegpairs, scene.camera.projectionview, plot.model,
-        scene.camera.pixel_space, transform_func(plot), whiskerwidth) do pairs, _, _, _, _, whiskerwidth
+        scene.px_area, transform_func(plot), whiskerwidth) do pairs, _, _, _, _, whiskerwidth
 
         endpoints = [p for pair in pairs for p in pair]
-
         screenendpoints = plot_to_screen(plot, endpoints)
 
         screenendpoints_shifted_pairs = map(screenendpoints) do sep
@@ -229,7 +228,8 @@ function _plot_bars!(plot, linesegpairs, is_in_y_direction)
     linesegments!(
         plot, whiskers, color = whiskercolors, linewidth = whiskerlinewidths,
         visible = visible, colormap = colormap, colorrange = colorrange,
-        inspectable = inspectable, transparency = transparency, space = :pixel
+        inspectable = inspectable, transparency = transparency, space = :pixel,
+        model = Mat4f(I) # overwrite scale!() / translate!() / rotate!()
     )
     plot
 end

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -57,7 +57,7 @@ function plot!(plot::Text)
 
     onany(linesegs, positions, sc.camera.projectionview, sc.px_area, 
             transform_func_obs(sc), get(plot, :space, :data)) do segs, pos, _, _, transf, space
-        pos_transf = scene_to_screen(apply_transform(transf, pos, space), sc)
+        pos_transf = plot_to_screen(plot, pos)
         linesegs_shifted[] = map(segs, lineindices[]) do seg, index
             seg + attr_broadcast_getindex(pos_transf, index)
         end


### PR DESCRIPTION
# Description

Fixes #3005 and #1455

I replaced `scene_to_screen` and `screen_to_scene` with `plot_to_screen` and `screen_to_plot` here, which includes applying the model matrix, transform function and considers `plot.space`. I changed the name because these functions are more closely related to what a plot is doing, and a plot can have different transformations (and coordinate space) than a scene.I'm also hoping it trips up CI if I missed some calls to the old functions.

This now also fixes some issues with bracket. On master it doesn't react to window resizing and it doesn't include transformations when calculating its positions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
