### PR TITLE
add option to flip x direction for bezier path

### DIFF
--- a/src/bezier.jl
+++ b/src/bezier.jl
@@ -240,11 +240,14 @@ function BezierPath(poly::Polygon)
     return BezierPath(commands)
 end
 
-function BezierPath(svg::AbstractString; fit = false, bbox = nothing, flipy = false, keep_aspect = true)
+function BezierPath(svg::AbstractString; fit = false, bbox = nothing, flipy = false, flipx=false, keep_aspect = true)
     commands = parse_bezier_commands(svg)
     p = BezierPath(commands)
     if flipy
         p = scale(p, Vec(1, -1))
+    end
+    if flipx
+        p = scale(p, Vec(-1,1)
     end
     if fit
         if bbox === nothing


### PR DESCRIPTION
# Description

I sometimes want to easily flip the direction of a marker I have the svg, this gives you that option

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
