### PR TITLE
fix error message

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -24,7 +24,7 @@ function color_and_colormap!(plot, intensity = plot[:color])
         get!(plot, :nan_color, RGBAf(0,0,0,0))
         if intensity[] isa Number
             plot[:colorrange][] isa Automatic &&
-                error("Cannot determine a colorrange automatically for single number color value $intens. Pass an explicit colorrange.")
+                error("Cannot determine a colorrange automatically for single number color value $intensity. Pass an explicit colorrange.")
             args = @converted_attribute plot (colorrange, lowclip, highclip, nan_color)
             plot[:color] = lift(numbers_to_colors, plot, intensity, colormap, args...)
             delete!(plot, :colorrange)


### PR DESCRIPTION
was getting this error:

```
ERROR: UndefVarError: `intens` not defined
Stacktrace:
  [1] color_and_colormap!(plot::Scatter{Tuple{Vector{Point{3, Float32}}}}, intensity::Observable{Any})
    @ Makie ~/.julia/packages/Makie/iECbF/src/interfaces.jl:26
```

# Description

Fixes # (issue)

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
