### PR TITLE
Fix bug in inspector for arrow plot

### DIFF
--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -942,7 +942,7 @@ function show_data(inspector::DataInspector, plot::Arrows, idx, ::LineSegments)
     return show_data(inspector, plot, div(idx+1, 2), nothing)
 end
 function show_data(inspector::DataInspector, plot::Arrows, idx, source)
-    a = inspector.plot.attributes
+    a = inspector.attributes
     tt = inspector.plot
     pos = plot[1][][idx]
     mpos = Point2f(mouseposition_px(inspector.root))


### PR DESCRIPTION
I think there was a small typo in the show_data method for the arrow plot

# Description

Fixes # (issue)

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

