### PR TITLE
Add nothing case for theme

### DIFF
--- a/src/theming.jl
+++ b/src/theming.jl
@@ -196,6 +196,7 @@ function with_theme(f, theme = Theme(); kwargs...)
     end
 end
 
+theme(::Nothing) = CURRENT_DEFAULT_THEME
 theme(::Nothing, key::Symbol) = theme(key)
 function theme(key::Symbol; default=nothing)
     if haskey(CURRENT_DEFAULT_THEME, key)


### PR DESCRIPTION
# Description

When calling `theme(scene, :key)` in a recipe, if scene is nothing it seems to look up the default theme.
But `theme(scene)` has no such fallback.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
