### PR TITLE
display fixes

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -106,7 +106,7 @@ mutable struct ScreenConfig
     end
 end
 
-const LAST_INLINE = Ref{Union{Makie.Automatic, Bool}}(Makie.automatic)
+const LAST_INLINE = Ref{Union{Makie.Automatic, Bool}}(false)
 
 """
     GLMakie.activate!(; screen_config...)

--- a/docs/documentation/fonts.md
+++ b/docs/documentation/fonts.md
@@ -42,7 +42,6 @@ Here's an example:
 ```julia
 using CairoMakie
 CairoMakie.activate!() # hide
-Makie.inline!(true) # hide
 
 f = Figure(fontsize = 24, fonts = (; regular = "Dejavu", weird = "Blackchancery"))
 Axis(f[1, 1], title = "A title", xlabel = "An x label", xlabelfont = :weird)

--- a/docs/examples/plotting_functions/text.md
+++ b/docs/examples/plotting_functions/text.md
@@ -184,7 +184,7 @@ ax3 = Axis(f[2, 1:2], limits = (9, 10, 11, 12))
 for (ax, label) in zip([ax1, ax2, ax3], ["A", "B", "C"])
     text!(
         ax, 0, 1,
-        text = label, 
+        text = label,
         font = :bold,
         align = (:left, :top),
         offset = (4, -2),
@@ -249,7 +249,6 @@ The top-level settings for font, color, etc. are taken from the `text` attribute
 ```julia
 using CairoMakie
 CairoMakie.activate!() # hide
-Makie.inline!(true) # hide
 
 f = Figure(fontsize = 30)
 Label(
@@ -284,7 +283,6 @@ You can use the `offset` value for rich text to shift glyphs by an amount propor
 ```julia
 using CairoMakie
 CairoMakie.activate!() # hide
-Makie.inline!(true) # hide
 
 f = Figure(fontsize = 30)
 Label(

--- a/src/display.jl
+++ b/src/display.jl
@@ -191,7 +191,9 @@ const MIME_TO_TRICK_VSCODE = MIME"application/vnd.julia-vscode.diagnostics"
 
 function _backend_showable(mime::MIME{SYM}) where SYM
     if ALWAYS_INLINE_PLOTS[] == false
-        return mime isa MIME_TO_TRICK_VSCODE
+        if mime isa MIME_TO_TRICK_VSCODE
+            return true
+        end
     end
     Backend = current_backend()
     if ismissing(Backend)

--- a/src/display.jl
+++ b/src/display.jl
@@ -110,7 +110,7 @@ end
 
 can_show_inline(::Missing) = false # no backend
 function can_show_inline(Backend)
-    for mime in [MIME"text/html"(), MIME"image/png"(), MIME"image/svg+xml"()]
+    for mime in [MIME"juliavscode/html"(), MIME"text/html"(), MIME"image/png"(), MIME"image/svg+xml"()]
         if backend_showable(Backend.Screen, mime)
             return has_mime_display(mime)
         end

--- a/src/display.jl
+++ b/src/display.jl
@@ -128,7 +128,8 @@ see `?Backend.Screen` or `Base.doc(Backend.Screen)` for applicable options.
 
 `backend` accepts Makie backend modules, e.g.: `backend = GLMakie`, `backend = CairoMakie`, etc.
 """
-function Base.display(figlike::FigureLike; backend=current_backend(), update=true, screen_config...)
+function Base.display(figlike::FigureLike; backend=current_backend(),
+                      inline=ALWAYS_INLINE_PLOTS[], update = true, screen_config...)
     if ismissing(backend)
         error("""
         No backend available!
@@ -138,7 +139,7 @@ function Base.display(figlike::FigureLike; backend=current_backend(), update=tru
         In that case, try `]build GLMakie` and watch out for any warnings.
         """)
     end
-    inline = ALWAYS_INLINE_PLOTS[]
+
     # We show inline if explicitely requested or if automatic and we can actually show something inline!
     if (inline === true || inline === automatic) && can_show_inline(backend)
         Core.invoke(display, Tuple{Any}, figlike)


### PR DESCRIPTION
So, GLMakie not opening a window with activated Plotpane really was not a great idea...
Lots of complaints, and I also tripped over this quite a bit.
This PR changes this back to opening a window by default for GLMakie!
But this means, that one now needs to call `GLMakie.activate!(inline=true)` to get GLMakie back into the plotpane.

This PR also changes a few other things:

* `can_show_inline(backend)` was weirdly buggy with VSCode, a.k.a most of the time it worked that e.g. WGLMakie would show in the plotpane if the plotpane is enabled, but sometimes it just stopped working...Not sure why, but looking at the VSCode code, it should never work the way `can_show_inline` is implemented (not checking for `MIME"juliavscode/html"`) - but it definitely worked correctly most of the time 🤷 
* now one can do `display(plot; inline=false)` to force a window even if inline is true. Of course this doesn't work the other way around, since VSCode somehow doesn't get into the show path anymore with calling `display(fig; inline=true)` directly... Not sure why...