### PR TITLE
Add keyword docs to save

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -278,6 +278,10 @@ Save a `Scene` with the specified filename and format.
 ## All Backends
 
 - `resolution`: `(width::Int, height::Int)` of the scene in dimensionless units (equivalent to `px` for GLMakie and WGLMakie).
+- `update`: Whether the figure should be updated before saving. This resets the limits of all Axes in the figure. Defaults to `true`.
+- `backend`: Specify the `Makie` backend that should be used for saving. Defaults to the current backend.
+- Further keywords will be forwarded to the screen.
+
 
 ## CairoMakie
 


### PR DESCRIPTION
This adds short documentations about the keywords for the `save` function. Feel free to change the wording especially for the update keyword I am not so sure what it fully entails. 

Could the possibility to use update=false to keep the interactive changes of a figure added somewhere to the documentation apart from the changes to the docstring? 
I skimmed the docs but didn't find a good place to add this.
