### PR TITLE
Resize screens as well when resizing scene

### DIFF
--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -311,3 +311,6 @@ end
 is_vector_backend(ctx::Cairo.CairoContext) = is_vector_backend(ctx.surface)
 is_vector_backend(surf::Cairo.CairoSurface) = is_vector_backend(get_render_type(surf))
 is_vector_backend(rt::RenderType) = rt in (PDF, EPS, SVG)
+
+# no need for resizing screen, since we need to redisplay anyways!
+Base.resize!(screen::Screen, w, h) = nothing

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -74,6 +74,9 @@ mutable struct Screen <: Makie.MakieScreen
     end
 end
 
+# Resizing the scene is enough for WGLMakie
+Base.resize!(::WGLMakie.Screen, w, h) = nothing
+
 function Base.isopen(screen::Screen)
     three = get_three(screen)
     return !isnothing(three) && isopen(three.session)

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -36,7 +36,7 @@ const CURRENT_FIGURE_LOCK = Base.ReentrantLock()
 """
     current_figure()
 
-Returns the current active figure (or the last figure created). 
+Returns the current active figure (or the last figure created).
 Returns `nothing` if there is no current active figure.
 """
 current_figure() = lock(()-> CURRENT_FIGURE[], CURRENT_FIGURE_LOCK)
@@ -202,4 +202,4 @@ end
 Resizes the given `Figure` to the resolution given by `width` and `height`.
 If you want to resize the figure to its current layout content, use `resize_to_layout!(fig)` instead.
 """
-Makie.resize!(figure::Figure, args...) = resize!(figure.scene, args...)
+Makie.resize!(figure::Figure, width::Integer, height::Integer) = resize!(figure.scene, width, height)

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -373,6 +373,11 @@ end
 Base.resize!(scene::Scene, x::Number, y::Number) = resize!(scene, (x, y))
 function Base.resize!(scene::Scene, rect::Rect2)
     pixelarea(scene)[] = rect
+    if isroot(scene)
+        for screen in scene.current_screens
+            resize!(screen, widths(rect)...)
+        end
+    end
 end
 
 # Just indexing into a scene gets you plot 1, plot 2 etc


### PR DESCRIPTION
We've been having `resize!(scene/fig, w, h)` for a long time, but they never actually resized the Screen.
With this PR, `resize!(fig, w, h)`  works finally as expected.