### PR TITLE
Refactor SurfaceLike trait

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -476,10 +476,9 @@ end
 function draw_atomic(screen::Screen, scene::Scene, x::Image)
     return cached_robj!(screen, scene, x) do gl_attributes
         position = lift(x, x[1], x[2]) do x, y
-            r = to_range(x, y)
-            x, y = minimum(r[1]), minimum(r[2])
-            xmax, ymax = maximum(r[1]), maximum(r[2])
-            rect =  Rect2f(x, y, xmax - x, ymax - y)
+            xmin, xmax = extrema(x)
+            ymin, ymax = extrema(y)
+            rect =  Rect2f(xmin, ymin, xmax - xmin, ymax - ymin)
             return decompose(Point2f, rect)
         end
         gl_attributes[:vertices] = apply_transform(transform_func_obs(x), position, x.space)

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -218,7 +218,7 @@ end
 Plots a surface, where `(x, y)`  define a grid whose heights are the entries in `z`.
 `x` and `y` may be `Vectors` which define a regular grid, **or** `Matrices` which define an irregular grid.
 
-`Surface` has the conversion trait `ContinuousSurface <: SurfaceLike`.
+`Surface` has the conversion trait `VertexBasedGrid <: GridBased`.
 
 ## Attributes
 

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -121,7 +121,7 @@ calculated_attributes!(plot::T) where T = calculated_attributes!(T, plot)
     image(x, y, image)
     image(image)
 
-Plots an image on range `x, y` (defaults to dimensions).
+Plots an image on a rectangle bounded by `x` and `y` (defaults to size of image).
 
 ## Attributes
 
@@ -146,7 +146,8 @@ end
     heatmap(x, y, values)
     heatmap(values)
 
-Plots a heatmap as an image on `x, y` (defaults to interpretation as dimensions).
+Plots a heatmap as a collection of rectangles centered at `x[i], y[j]` with
+colors derived from `values[i, j]`. (Defaults to `x, y = axes(values)`.)
 
 ## Attributes
 
@@ -215,10 +216,8 @@ end
     surface(x, y, z)
     surface(z)
 
-Plots a surface, where `(x, y)`  define a grid whose heights are the entries in `z`.
+Plots a surface, where `(x, y)` define a grid whose heights are the entries in `z`.
 `x` and `y` may be `Vectors` which define a regular grid, **or** `Matrices` which define an irregular grid.
-
-`Surface` has the conversion trait `VertexBasedGrid <: GridBased`.
 
 ## Attributes
 

--- a/MakieCore/src/conversion.jl
+++ b/MakieCore/src/conversion.jl
@@ -37,13 +37,26 @@ struct PointBased <: ConversionTrait end
 conversion_trait(::Type{<: XYBased}) = PointBased()
 conversion_trait(::Type{<: Text}) = PointBased()
 
-abstract type SurfaceLike <: ConversionTrait end
+abstract type GridBased <: ConversionTrait end
 
-struct ContinuousSurface <: SurfaceLike end
-conversion_trait(::Type{<: Union{Surface, Image}}) = ContinuousSurface()
+struct VertexBasedGrid <: GridBased end
+conversion_trait(::Type{<: Surface}) = VertexBasedGrid()
+# [Point3f(xs[i], ys[j], zs[i, j]) for i in axes(zs, 1), j in axes(zs, 2)]
 
-struct DiscreteSurface <: SurfaceLike end
-conversion_trait(::Type{<: Heatmap}) = DiscreteSurface()
+struct CellBasedGrid <: GridBased end
+conversion_trait(::Type{<: Heatmap}) = CellBasedGrid()
+# [Rect2f(xs[i], ys[j], xs[i+1], ys[j+1]) for i in axes(zs, 1), j in axes(zs, 2)]
+
+struct ImageLike end
+conversion_trait(::Type{<: Image}) = ImageLike()
+# Rect2f(xmin, ymin, xmax, ymax)
+
+# Deprecations
+function ContinuousSurface()
+    error("ContinuousSurface has been deprecated. Use `ImageLike()` or `VertexBasedGrid()`")
+end
+
+@deprecate DiscreteSurface CellLike()
 
 struct VolumeLike <: ConversionTrait end
 conversion_trait(::Type{<: Volume}) = VolumeLike()

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,11 +7,12 @@
   [#2544](https://github.com/MakieOrg/Makie.jl/pull/2544)
 - Fixed an issue where NaN was interpreted as zero when rendering `surface` through CairoMakie. [#2598](https://github.com/MakieOrg/Makie.jl/pull/2598)
 - Improved 3D camera handling, hotkeys and functionality [#2746](https://github.com/MakieOrg/Makie.jl/pull/2746)
+- Refactored the `SurfaceLike` family of traits into `VertexBasedGrid`, `CellBasedGrid` and `ImageLike`. [#3106](https://github.com/MakieOrg/Makie.jl/pull/3106)
 
 ## master
 
 - Fixed incorrect placement of contourlabels with transform functions [#3083](https://github.com/MakieOrg/Makie.jl/pull/3083)
-- Fix automatic normal generation for meshes with shading and no normals [#3041](https://github.com/MakieOrg/Makie.jl/pull/3041).
+- Fixed automatic normal generation for meshes with shading and no normals [#3041](https://github.com/MakieOrg/Makie.jl/pull/3041).
 
 ## v0.19.7
 

--- a/docs/tutorials/basic-tutorial.md
+++ b/docs/tutorials/basic-tutorial.md
@@ -221,7 +221,7 @@ lines([Point(0, 0), Point(5, 10), Point(10, 5)])
 
 The input arguments you can use with `lines` and `scatter` are mostly the same because they have the same conversion trait `PointBased`.
 Other plotting functions have different conversion traits, \myreflink{heatmap} for example expects two-dimensional grid data.
-The respective trait is called `DiscreteSurface`.
+The respective trait is called `CellBasedGrid`.
 
 ## Layering multiple plots
 

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -73,7 +73,7 @@ using Observables: listeners, to_value, notify
 
 using MakieCore: SceneLike, MakieScreen, ScenePlot, AbstractScene, AbstractPlot, Transformable, Attributes, Combined, Theme, Plot
 using MakieCore: Arrows, Heatmap, Image, Lines, LineSegments, Mesh, MeshScatter, Poly, Scatter, Surface, Text, Volume, Wireframe
-using MakieCore: ConversionTrait, NoConversion, PointBased, SurfaceLike, ContinuousSurface, DiscreteSurface, VolumeLike
+using MakieCore: ConversionTrait, NoConversion, PointBased, GridBased, VertexBasedGrid, CellBasedGrid, ImageLike, VolumeLike
 using MakieCore: Key, @key_str, Automatic, automatic, @recipe
 using MakieCore: Pixel, px, Unit, Billboard
 using MakieCore: not_implemented_for
@@ -85,7 +85,7 @@ import MakieCore: arrows!, heatmap!, image!, lines!, linesegments!, mesh!, meshs
 import MakieCore: convert_arguments, convert_attribute, default_theme, conversion_trait
 
 export @L_str, @colorant_str
-export ConversionTrait, NoConversion, PointBased, SurfaceLike, ContinuousSurface, DiscreteSurface, VolumeLike
+export ConversionTrait, NoConversion, PointBased, GridBased, VertexBasedGrid, CellBasedGrid, ImageLike, VolumeLike
 export Pixel, px, Unit, plotkey, attributes, used_attributes
 
 const RealVector{T} = AbstractVector{T} where T <: Number

--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -58,7 +58,7 @@ function _get_isoband_levels(levels::AbstractVector{<:Real}, mi, ma)
     edges
 end
 
-conversion_trait(::Type{<:Contourf}) = ContinuousSurface()
+conversion_trait(::Type{<:Contourf}) = VertexBasedGrid()
 
 function _get_isoband_levels(::Val{:normal}, levels, values)
     _get_isoband_levels(levels, extrema_nan(values)...)

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -112,8 +112,8 @@ end
 
 conversion_trait(::Type{<: Contour3d}) = VertexBasedGrid()
 conversion_trait(::Type{<: Contour}) = VertexBasedGrid()
-conversion_trait(::Type{<: Contour{<: Tuple{X, Y, Z, Vol}}}) where {X, Y, Z, Vol} = VolumeLike()
-conversion_trait(::Type{<: Contour{<: Tuple{<: AbstractArray{T, 3}}}}) where T = VolumeLike()
+conversion_trait(::Type{<:Contour}, x, y, z, ::Union{Function, AbstractArray{<: Number, 3}}) = VolumeLike()
+conversion_trait(::Type{<: Contour}, ::AbstractArray{<: Number, 3}) = VolumeLike()
 
 function plot!(plot::Contour{<: Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
     x, y, z, volume = plot[1:4]

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -110,10 +110,10 @@ function to_levels(n::Integer, cnorm)
     range(zmin + dz; step = dz, length = n)
 end
 
-conversion_trait(::Type{<: Contour3d}) = ContinuousSurface()
-conversion_trait(::Type{<: Contour}) = ContinuousSurface()
-conversion_trait(::Type{<:Contour}, x, y, z, ::Union{Function, AbstractArray{<: Number, 3}}) = VolumeLike()
-conversion_trait(::Type{<: Contour}, ::AbstractArray{<: Number, 3}) = VolumeLike()
+conversion_trait(::Type{<: Contour3d}) = VertexBasedGrid()
+conversion_trait(::Type{<: Contour}) = VertexBasedGrid()
+conversion_trait(::Type{<: Contour{<: Tuple{X, Y, Z, Vol}}}) where {X, Y, Z, Vol} = VolumeLike()
+conversion_trait(::Type{<: Contour{<: Tuple{<: AbstractArray{T, 3}}}}) where T = VolumeLike()
 
 function plot!(plot::Contour{<: Tuple{X, Y, Z, Vol}}) where {X, Y, Z, Vol}
     x, y, z, volume = plot[1:4]

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -302,7 +302,7 @@ end
 
 
 ################################################################################
-#                                 SurfaceLike                                  #
+#                                  GridBased                                   #
 ################################################################################
 
 function edges(v::AbstractVector)
@@ -320,31 +320,31 @@ function edges(v::AbstractVector)
     end
 end
 
-function adjust_axes(::DiscreteSurface, x::AbstractVector{<:Number}, y::AbstractVector{<:Number}, z::AbstractMatrix)
+function adjust_axes(::CellBasedGrid, x::AbstractVector{<:Number}, y::AbstractVector{<:Number}, z::AbstractMatrix)
     x̂, ŷ = map((x, y), size(z)) do v, sz
         return length(v) == sz ? edges(v) : v
     end
     return x̂, ŷ, z
 end
 
-adjust_axes(::SurfaceLike, x, y, z) = x, y, z
+adjust_axes(::VertexBasedGrid, x, y, z) = x, y, z
 
 """
-    convert_arguments(SL::SurfaceLike, x::VecOrMat, y::VecOrMat, z::Matrix)
+    convert_arguments(SL::GridBased, x::VecOrMat, y::VecOrMat, z::Matrix)
 
 If `SL` is `Heatmap` and `x` and `y` are vectors, infer from length of `x` and `y`
 whether they represent edges or centers of the heatmap bins.
 If they are centers, convert to edges. Convert eltypes to `Float32` and return
 outputs as a `Tuple`.
 """
-function convert_arguments(SL::SurfaceLike, x::AbstractVecOrMat{<: Number}, y::AbstractVecOrMat{<: Number}, z::AbstractMatrix{<: Union{Number, Colorant}})
+function convert_arguments(SL::GridBased, x::AbstractVecOrMat{<: Number}, y::AbstractVecOrMat{<: Number}, z::AbstractMatrix{<: Union{Number, Colorant}})
     return map(el32convert, adjust_axes(SL, x, y, z))
 end
-function convert_arguments(SL::SurfaceLike, x::AbstractVecOrMat{<: Number}, y::AbstractVecOrMat{<: Number}, z::AbstractMatrix{<:Number})
+function convert_arguments(SL::GridBased, x::AbstractVecOrMat{<: Number}, y::AbstractVecOrMat{<: Number}, z::AbstractMatrix{<:Number})
     return map(el32convert, adjust_axes(SL, x, y, z))
 end
 
-convert_arguments(sl::SurfaceLike, x::AbstractMatrix, y::AbstractMatrix) = convert_arguments(sl, x, y, zeros(size(y)))
+convert_arguments(sl::GridBased, x::AbstractMatrix, y::AbstractMatrix) = convert_arguments(sl, x, y, zeros(size(y)))
 
 """
     convert_arguments(P, x, y, z)::Tuple{ClosedInterval, ClosedInterval, Matrix}
@@ -353,7 +353,7 @@ Takes 2 ClosedIntervals's `x`, `y`, and an AbstractMatrix `z`, and converts the 
 linspaces with size(z, 1/2)
 `P` is the plot Type (it is optional).
 """
-function convert_arguments(P::SurfaceLike, x::ClosedInterval, y::ClosedInterval, z::AbstractMatrix)
+function convert_arguments(P::GridBased, x::ClosedInterval, y::ClosedInterval, z::AbstractMatrix)
     convert_arguments(P, to_linspace(x, size(z, 1)), to_linspace(y, size(z, 2)), z)
 end
 
@@ -365,17 +365,20 @@ and stores the `ClosedInterval` to `n` and `m`, plus the original matrix in a Tu
 
 `P` is the plot Type (it is optional).
 """
-function convert_arguments(sl::SurfaceLike, data::AbstractMatrix)
+function convert_arguments(il::ImageLike, data::AbstractMatrix)
     n, m = Float32.(size(data))
-    convert_arguments(sl, 0f0 .. n, 0f0 .. m, el32convert(data))
+    return (0f0 .. n, 0f0 .. m, el32convert(data))
+end
+function convert_arguments(il::ImageLike, xs::RangeLike, ys::RangeLike, data::AbstractMatrix)
+    return (minimum(xs) .. maximum(xs), minimum(ys) .. maximum(ys), el32convert(data))
 end
 
-function convert_arguments(ds::DiscreteSurface, data::AbstractMatrix)
+function convert_arguments(CT::GridBased, data::AbstractMatrix)
     n, m = Float32.(size(data))
-    convert_arguments(ds, edges(1:n), edges(1:m), el32convert(data))
+    convert_arguments(CT, 1f0 .. n, 1f0 .. m, el32convert(data))
 end
 
-function convert_arguments(SL::SurfaceLike, x::AbstractVector{<:Number}, y::AbstractVector{<:Number}, z::AbstractVector{<:Number})
+function convert_arguments(CT::GridBased, x::AbstractVector{<:Number}, y::AbstractVector{<:Number}, z::AbstractVector{<:Number})
     if !(length(x) == length(y) == length(z))
         error("x, y and z need to have the same length. Lengths are $(length.((x, y, z)))")
     end
@@ -397,9 +400,26 @@ function convert_arguments(SL::SurfaceLike, x::AbstractVector{<:Number}, y::Abst
         j = searchsortedfirst(y_centers, yi)
         @inbounds zs[i, j] = zi
     end
-    convert_arguments(SL, x_centers, y_centers, zs)
+    convert_arguments(CT, x_centers, y_centers, zs)
 end
 
+
+"""
+    convert_arguments(P, x, y, f)::(Vector, Vector, Matrix)
+
+Takes vectors `x` and `y` and the function `f`, and applies `f` on the grid that `x` and `y` span.
+This is equivalent to `f.(x, y')`.
+`P` is the plot Type (it is optional).
+"""
+function convert_arguments(CT::Union{GridBased, ImageLike}, x::AbstractVector{T1}, y::AbstractVector{T2}, f::Function) where {T1, T2}
+    if !applicable(f, x[1], y[1])
+        error("You need to pass a function with signature f(x::$T1, y::$T2). Found: $f")
+    end
+    T = typeof(f(x[1], y[1]))
+    z = similar(x, T, (length(x), length(y)))
+    z .= f.(x, y')
+    return convert_arguments(CT, x, y, z)
+end
 
 ################################################################################
 #                                  VolumeLike                                  #
@@ -618,21 +638,6 @@ function convert_arguments(::VolumeLike, x::AbstractVector, y::AbstractVector, z
     return (x, y, z, el32convert.(f.(_x, _y, _z)))
 end
 
-"""
-    convert_arguments(P, x, y, f)::(Vector, Vector, Matrix)
-
-Takes vectors `x` and `y` and the function `f`, and applies `f` on the grid that `x` and `y` span.
-This is equivalent to `f.(x, y')`.
-`P` is the plot Type (it is optional).
-"""
-function convert_arguments(sl::SurfaceLike, x::AbstractVector{T1}, y::AbstractVector{T2},
-                           f::Function) where {T1,T2}
-    if !applicable(f, x[1], y[1])
-        error("You need to pass a function with signature f(x::$T1, y::$T2). Found: $f")
-    end
-    return convert_arguments(sl, x, y, f.(x, y'))
-end
-
 function convert_arguments(P::PlotFunc, r::AbstractVector, f::Function)
     return convert_arguments(P, r, map(f, r))
 end
@@ -668,7 +673,7 @@ end
 
 
 # OffsetArrays conversions
-function convert_arguments(sl::SurfaceLike, wm::OffsetArray)
+function convert_arguments(sl::GridBased, wm::OffsetArray)
   x1, y1 = wm.offsets .+ 1
   nx, ny = size(wm)
   x = range(x1, length = nx)

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -10,8 +10,8 @@
 
     fig, ax, p = surface([x*y for x in 1:10, y in 1:10])
     bb = boundingbox(p)
-    @test bb.origin ≈ Point3f(0.0, 0.0, 1.0)
-    @test bb.widths ≈ Vec3f(10.0, 10.0, 99.0)
+    @test bb.origin ≈ Point3f(1.0, 1.0, 1.0)
+    @test bb.widths ≈ Vec3f(9.0, 9.0, 99.0)
 
     fig, ax, p = meshscatter([Point3f(x, y, z) for x in 1:5 for y in 1:5 for z in 1:5])
     bb = boundingbox(p)
@@ -42,7 +42,7 @@
     bb = boundingbox(p)
     @test bb.origin ≈ Point3f(0.5, 0.5, 0)
     @test bb.widths ≈ Vec3f(10.0, 10.0, 0)
-    
+
     fig, ax, p = image(rand(10, 10))
     bb = boundingbox(p)
     @test bb.origin ≈ Point3f(0)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -283,3 +283,66 @@ end
     pl[1] = [points]
     @test pl.plots[1][1][] == Makie.poly_convert(points)
 end
+
+
+@testset "GridBased and ImageLike conversions" begin
+    # type tree
+    @test GridBased <: ConversionTrait
+    @test CellBasedGrid <: GridBased
+    @test VertexBasedGrid <: GridBased
+    @test ImageLike <: ConversionTrait
+
+    # Plot to trait
+    @test conversion_trait(Image) === ImageLike()
+    @test conversion_trait(Heatmap) === CellBasedGrid()
+    @test conversion_trait(Surface) === VertexBasedGrid()
+    @test conversion_trait(Contour) === VertexBasedGrid()
+    @test conversion_trait(Contourf) === VertexBasedGrid()
+
+    m1 = [x for x in 1:10, y in 1:6]
+    m2 = [y for x in 1:10, y in 1:6]
+    m3 = rand(10, 6)
+
+    r1 = 1:10
+    r2 = 1:6
+
+    v1 = collect(1:10)
+    v2 = collect(1:6)
+
+    i1 = 1..10
+    i2 = 1..6
+
+    o3 = Float32.(m3)
+
+    # Conversions
+    @testset "ImageLike conversion" begin
+        @test convert_arguments(Image, m3)         == (0f0..10f0, 0f0..6f0, o3)
+        @test convert_arguments(Image, v1, r2, m3) == (1f0..10f0, 1f0..6f0, o3)
+        @test convert_arguments(Image, i1, v2, m3) == (1f0..10f0, 1f0..6f0, o3)
+        @test_throws ErrorException convert_arguments(Image, m1, m2, m3)
+        @test_throws ErrorException convert_arguments(Heatmap, m1, m2)
+    end
+
+    @testset "VertexBasedGrid conversion" begin
+        vo1 = Float32.(v1)
+        vo2 = Float32.(v2)
+        mo1 = Float32.(m1)
+        mo2 = Float32.(m2)
+        @test convert_arguments(Surface, m3)          == (vo1, vo2, o3)
+        @test convert_arguments(Contour, i1, v2, m3)  == (vo1, vo2, o3)
+        @test convert_arguments(Contourf, v1, r2, m3) == (vo1, vo2, o3)
+        @test convert_arguments(Surface, m1, m2, m3)  == (mo1, mo2, o3)
+        @test convert_arguments(Surface, m1, m2)      == (mo1, mo2, zeros(Float32, size(o3)))
+    end
+
+    @testset "CellBasedGrid conversion" begin
+        o1 = Float32.(0.5:1:10.5)
+        o2 = Float32.(0.5:1:6.5)
+        @test convert_arguments(Heatmap, m3)         == (o1, o2, o3)
+        @test convert_arguments(Heatmap, r1, i2, m3) == (o1, o2, o3)
+        @test convert_arguments(Heatmap, v1, r2, m3) == (o1, o2, o3)
+        @test convert_arguments(Heatmap, 0:10, v2, m3) == (collect(0f0:10f0), o2, o3)
+        @test_throws ErrorException convert_arguments(Heatmap, m1, m2, m3)
+        @test_throws ErrorException convert_arguments(Heatmap, m1, m2)
+    end
+end


### PR DESCRIPTION
# Description

This pr breaks up the `SurfaceLike` trait and its children `ContinuousSurface` and `DiscreteSurface` into 3 (4) new traits:
- `GridBased` which more or less replaces SurfaceLike. The name change is meant to remove the association with Surface plots which is misleading imo.
    - `CellBasedGrid <: GridBased` which replaces `DiscreteSurface` with no changes
    - `VertexBasedGrid <: GridBased` which replaces `ContinuousSurface` for surface, contour and contourf plots. The only change here is to default to a `1:size(zs, dim)` instead of `0:size(zs, dim)`. This fixes the alignment issue noted in #3060 and a similar issue noted for surface in #2598.
- `ImageLike` which replaces ContinuousSurface specifically for image plots. This no longer produces arrays in the conversion pipeline, but instead just an interval. In backends an image plot is treated as a single quad so I don't think this removes anything

In #2598 there is a picture which shows how vertices are aligned for surface plots:

![](https://user-images.githubusercontent.com/10947937/228682689-1f80ec7d-565c-4976-a67d-c9059bad1290.png)

After this pr they would be aligned to integer x and y values instead, starting at (1, 1).

Example after pr: (should only change placement and scale)

```julia
begin
    f = Figure()
    img = [sin(i + 2 * cos(j)) for i in 1:10, j in 1:10]
    heatmap(f[1, 1], img)
    image(f[1, 2], img)
    a = Axis(f[2, 1])
    surface!(a, img, shading = false)
    xlims!(a, 1, 10); ylims!(a, 1, 10)
    contourf(f[2, 2], img)
    a, p = contour(f[2, 3], img)
    tightlimits!(a)
    f
end
```
![Screenshot from 2023-07-28 18-34-27](https://github.com/MakieOrg/Makie.jl/assets/10947937/2b2c13af-0eab-4091-b92e-65071121d2f2)

With this and #3102 adding `voronoiplot`, maybe we can consider #748 done?

TODO:
- [x] Check if CairoMakie surface discoloration comes from this pr

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Changes placements of some plots and may break some `convert_arguments` methods.

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
