### PR TITLE
Fix theta tick label update error in PolarAxis

### DIFF
--- a/src/makielayout/blocks/polaraxis.jl
+++ b/src/makielayout/blocks/polaraxis.jl
@@ -146,7 +146,7 @@ function draw_axis!(po::PolarAxis, axis_radius)
             pop!(_thetaticklabels)
         end
 
-        thetatick_align.val = map(_thetatickvalues) do angle
+        thetatick_align[] = map(_thetatickvalues) do angle
             s, c = sincos(angle + theta_0)
             scale = 1 / max(abs(s), abs(c)) # point on ellipse -> point on bbox
             Point2f(0.5 - 0.5scale * c, 0.5 - 0.5scale * s)
@@ -263,8 +263,13 @@ function draw_axis!(po::PolarAxis, axis_radius)
         color = po.thetaticklabelcolor,
         strokewidth = po.thetaticklabelstrokewidth,
         strokecolor = thetastrokecolor,
-        align = thetatick_align,
+        align = thetatick_align[]
     )
+
+    # Hack to deal with synchronous update problems
+    on(thetatick_align) do align
+        thetaticklabelplot.align.val = align
+    end
 
     # inner clip
     # scatter shouldn't interfere with lines and text in GLMakie, so this should


### PR DESCRIPTION
# Description

Fixes #3127

This is a synchronous update issue with text that I had trouble with in the original pr too. You can't cleanly update a text plot like it is used in the polar axis. Simplified example:

```julia
# Setup align and pos_lbl for manual updating
N = Observable(8)
align = Observable{Vector{Point2f}}()
on(N) do N
    align.val = [Point2f(0.5) for _ in 1:N]
end
pos_lbl = Observable{Vector{Tuple{String, Point2f}}}()
on(N) do N
    pos_lbl.val = [("$i", Point2f(i, 0)) for i in 1:N]
end
notify(N)

f, a, p = text(pos_lbl, align = align)

N[] = 4
```

Calling either of
```julia
notify(pos_lbl)
notify(align)
```
errors in this case, You need to call both once and then notify `pos_lbl` a second time for the update to actually get through. This is partially because `p.align !== align`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
