### PR TITLE
Set `Axis3` ticks to same default size as `Axis`

### DIFF
--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1506,11 +1506,11 @@ end
         "The z tick width"
         ztickwidth = 1
         "The size of the xtick marks."
-        xticksize::Float64 = 12f0
+        xticksize::Float64 = 6
         "The size of the ytick marks."
-        yticksize::Float64 = 12f0
+        yticksize::Float64 = 6
         "The size of the ztick marks."
-        zticksize::Float64 = 12f0
+        zticksize::Float64 = 6
         "The color of x spine 1 where the ticks are displayed"
         xspinecolor_1 = :black
         "The color of y spine 1 where the ticks are displayed"


### PR DESCRIPTION
This makes more intuitive sense I think.

Before

![image](https://github.com/MakieOrg/Makie.jl/assets/22495855/9a67d257-88ce-413c-bc9b-42e7492aa8c8)

After

![image](https://github.com/MakieOrg/Makie.jl/assets/22495855/c5fb2f40-4275-4699-8aef-3a05871392cb)
