### PR TITLE
GLMakie: ignore mouse buttons beyond the first three

### DIFF
--- a/GLMakie/src/events.jl
+++ b/GLMakie/src/events.jl
@@ -99,9 +99,7 @@ function Makie.mouse_buttons(scene::Scene, window::GLFW.Window)
     event = scene.events.mousebutton
     function mousebuttons(window, button, action, mods)
         @print_error begin
-            if Int(button) < 3  # ignore mouse buttons beyond 3
-                event[] = MouseButtonEvent(Mouse.Button(Int(button)), Mouse.Action(Int(action)))
-            end
+            event[] = MouseButtonEvent(Mouse.Button(Int(button)), Mouse.Action(Int(action)))
         end
     end
     disconnect!(window, mouse_buttons)

--- a/GLMakie/src/events.jl
+++ b/GLMakie/src/events.jl
@@ -99,7 +99,9 @@ function Makie.mouse_buttons(scene::Scene, window::GLFW.Window)
     event = scene.events.mousebutton
     function mousebuttons(window, button, action, mods)
         @print_error begin
-            event[] = MouseButtonEvent(Mouse.Button(Int(button)), Mouse.Action(Int(action)))
+            if Int(button) < 3  # ignore mouse buttons beyond 3
+                event[] = MouseButtonEvent(Mouse.Button(Int(button)), Mouse.Action(Int(action)))
+            end
         end
     end
     disconnect!(window, mouse_buttons)

--- a/src/interaction/iodevices.jl
+++ b/src/interaction/iodevices.jl
@@ -170,6 +170,11 @@ module Mouse
         middle = 2
         right = 1 # Conform to GLFW
         none = -1 # for convenience
+        button_4 = 3
+        button_5 = 4
+        button_6 = 5
+        button_7 = 6
+        button_8 = 7
     end
 
     """

--- a/src/makielayout/mousestatemachine.jl
+++ b/src/makielayout/mousestatemachine.jl
@@ -122,6 +122,9 @@ function addmouseevents!(scene, bbox::Observables.AbstractObservable{<: Rect2}; 
 end
 
 
+# don't react to buttons beyond the first three
+_isstandardmousebutton(b) = (b == Mouse.left || b == Mouse.middle || b == Mouse.right)
+
 function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
     Mouse = Makie.Mouse
     dblclick_max_interval = 0.2
@@ -156,7 +159,7 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
         # this can mean a new drag started, or a drag continues if it is ongoing.
         # it can also mean that a drag that started outside and isn't related to this
         # object is going across it and should be ignored here
-        if last_mouseevent[] == Mouse.press
+        if last_mouseevent[] == Mouse.press && _isstandardmousebutton(mouse_downed_button[])
 
             if drag_ongoing[]
                 # continue the drag
@@ -241,7 +244,7 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
 
         # mouse went down, this can either happen inside or outside the objects of interest
         # we also only react if one button is pressed, because otherwise things go crazy (pressed left button plus clicks from other buttons in between are not allowed, e.g.)
-        if event.action == Mouse.press
+        if event.action == Mouse.press && _isstandardmousebutton(first(pressed_buttons))
             if length(pressed_buttons) == 1
                 button = first(pressed_buttons)
                 mouse_downed_button[] = button
@@ -267,7 +270,7 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
                 end
             end
             last_mouseevent[] = Mouse.press
-        elseif event.action == Mouse.release
+        elseif event.action == Mouse.release && _isstandardmousebutton(mouse_downed_button[])
             # only register up events and clicks if the upped button matches
             # the recorded downed one
             # and it can't be nothing (if the first up event comes from outside)


### PR DESCRIPTION
# Description

Fixes #3125

Prevents an error from being thrown when you press an exotic mouse button. Allowing those buttons to be used would require additions to mousestatemachine.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
