### PR TITLE
strokecolormap keyword for  poly

### DIFF
--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -521,6 +521,7 @@ Plots polygons, which are defined by
    Vector or Matrices of numbers can be used as well, which will use the colormap arguments to map the numbers to colors.
    One can also use `Makie.LinePattern`, to cover the poly with a regular stroke pattern.
 - `strokecolor::Union{Symbol, <:Colorant} = :black` sets the color of the outline around a marker.
+- `strokecolormap`::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
 - `strokewidth::Real = 0` sets the width of the outline around a marker.
 - `linestyle::Union{Nothing, Symbol, Vector} = nothing` sets the pattern of the line (e.g. `:solid`, `:dot`, `:dashdot`)
 
@@ -533,6 +534,7 @@ $(Base.Docs.doc(MakieCore.generic_plot_attributes!))
         color = theme(scene, :patchcolor),
 
         strokecolor = theme(scene, :patchstrokecolor),
+        strokecolormap = theme(scene, :colormap),
         strokewidth = theme(scene, :patchstrokewidth),
         linestyle = nothing,
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Added `strokecolormap` to poly.
 - Added `xreversed`, `yreversed` and `zreversed` attributes to `Axis3` [#3138](https://github.com/MakieOrg/Makie.jl/pull/3138).
 - Fixed incorrect placement of contourlabels with transform functions [#3083](https://github.com/MakieOrg/Makie.jl/pull/3083)
 - Fixed automatic normal generation for meshes with shading and no normals [#3041](https://github.com/MakieOrg/Makie.jl/pull/3041).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- Added `strokecolormap` to poly.
+- Added `strokecolormap` to poly. [#3145](https://github.com/MakieOrg/Makie.jl/pull/3145)
 - Added `xreversed`, `yreversed` and `zreversed` attributes to `Axis3` [#3138](https://github.com/MakieOrg/Makie.jl/pull/3138).
 - Fixed incorrect placement of contourlabels with transform functions [#3083](https://github.com/MakieOrg/Makie.jl/pull/3083)
 - Fixed automatic normal generation for meshes with shading and no normals [#3041](https://github.com/MakieOrg/Makie.jl/pull/3041).

--- a/docs/examples/plotting_functions/poly.md
+++ b/docs/examples/plotting_functions/poly.md
@@ -99,3 +99,26 @@ poly!(ps, color = rand(RGBf, length(ps)))
 f
 ```
 \end{examplefigure}
+
+\begin{examplefigure}{}
+```julia
+using CairoMakie
+CairoMakie.activate!() # hide
+using Makie.GeometryBasics
+
+
+f = Figure()
+Axis(f[1, 1])
+
+# vector of shapes
+poly!(
+    [Rect(i, j, 0.75, 0.5) for i in 1:5 for j in 1:3],
+    color = :white,
+    strokewidth = 2,
+    strokecolor = 1:15,
+    strokecolormap=:plasma,
+)
+
+f
+```
+\end{examplefigure}

--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -30,7 +30,8 @@ function plot!(plot::Poly{<: Tuple{Union{GeometryBasics.Mesh, GeometryPrimitive}
         plot, plot[1],
         color = plot[:strokecolor], linestyle = plot[:linestyle], space = plot[:space],
         linewidth = plot[:strokewidth], visible = plot[:visible], overdraw = plot[:overdraw],
-        inspectable = plot[:inspectable], transparency = plot[:transparency]
+        inspectable = plot[:inspectable], transparency = plot[:transparency],
+        colormap = plot[:strokecolormap]
     )
 end
 
@@ -124,6 +125,7 @@ function plot!(plot::Poly{<: Tuple{<: Union{Polygon, AbstractVector{<: PolyEleme
     lines!(
         plot, outline, visible = plot.visible,
         color = stroke, linestyle = plot.linestyle, alpha = plot.alpha,
+        colormap = plot.strokecolormap,
         linewidth = plot.strokewidth, space = plot.space,
         overdraw = plot.overdraw, transparency = plot.transparency,
         inspectable = plot.inspectable, depth_shift = -1f-5


### PR DESCRIPTION
# Description
adds the keyword argument for poly, `strokecolormap`, useful when you want to change the colormap, currently it only applies the default `:viridis`, this allows to pass any other one.

Fixes (https://github.com/MakieOrg/Makie.jl/issues/1432)

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
