### PR TITLE
Bar label alignment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Improved Barplot Label Alignment [#3160](https://github.com/MakieOrg/Makie.jl/issues/3160).
+
 ## v0.19.8
 
 - Improved CairoMakie rendering of `lines` with repeating colors in an array [#3141](https://github.com/MakieOrg/Makie.jl/pull/3141).

--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -162,14 +162,9 @@ function stack_grouped_from_to(i_stack, y, grp)
 end
 
 function calculate_bar_label_align(label_align, label_rotation::Real, in_y_direction::Bool, flip::Bool)
-    is_align_type(::Any) = false
-    is_align_type(::Vec2f) = true
-    is_align_type(::Point2f) = true
-    is_align_type(::NTuple{2, <:Real}) = true
-    is_align_type(::Tuple{<:Real, <:Real}) = true
-    is_align_type(::NTuple{2, Symbol}) = true
-    make_align(a) = Vec2f(a)
+    make_align(a::VecTypes{2, <:Real}) = Vec2f(a)
     make_align(a::NTuple{2, Symbol}) = to_align(a)
+    make_align(a) = error("`label_align` needs to be of type NTuple{2, <:Real}, not of type $(typeof(a))")
     if label_align == automatic
         if flip
             label_rotation += π
@@ -181,10 +176,8 @@ function calculate_bar_label_align(label_align, label_rotation::Real, in_y_direc
         scale = 1 / max(abs(s), abs(c))
         align = Vec2f(0.5 - 0.5scale * s, 0.5 - 0.5scale * c)
         return align
-    elseif is_align_type(label_align)
-        return make_align(label_align)
     else
-        error("`label_align` needs to be of type NTuple{2, <:Real}, not of type $(typeof(label_align))")
+        return make_align(label_align)
     end
 end
 

--- a/test/barplot_labels.jl
+++ b/test/barplot_labels.jl
@@ -1,0 +1,53 @@
+@testset "Barplot label align" begin
+    @testset "automatic" begin
+        # for more info see https://github.com/MakieOrg/Makie.jl/issues/3160
+        # below is the best square angles behavior for bar labels
+
+        al = Makie.automatic
+
+        y_dir, flip = false, false
+        @test Makie.calculate_bar_label_align(al, 0.0, y_dir, flip) ≈ Vec2f(0.0, 0.5)
+        @test Makie.calculate_bar_label_align(al, π, y_dir, flip) ≈ Vec2f(1.0, 0.5)
+        @test Makie.calculate_bar_label_align(al, π/2, y_dir, flip) ≈ Vec2f(0.5, 1.0)
+        @test Makie.calculate_bar_label_align(al, -π/2, y_dir, flip) ≈ Vec2f(0.5, 0.0)
+
+        y_dir, flip = true, false
+        @test Makie.calculate_bar_label_align(al, 0.0, y_dir, flip) ≈ Vec2f(0.5, 0.0)
+        @test Makie.calculate_bar_label_align(al, π, y_dir, flip) ≈ Vec2f(0.5, 1.0)
+        @test Makie.calculate_bar_label_align(al, π/2, y_dir, flip) ≈ Vec2f(0.0, 0.5)
+        @test Makie.calculate_bar_label_align(al, -π/2, y_dir, flip) ≈ Vec2f(1.0, 0.5)
+
+        y_dir, flip = false, true
+        @test Makie.calculate_bar_label_align(al, 0.0, y_dir, flip) ≈ Vec2f(1.0, 0.5)
+        @test Makie.calculate_bar_label_align(al, π, y_dir, flip) ≈ Vec2f(0.0, 0.5)
+        @test Makie.calculate_bar_label_align(al, π/2, y_dir, flip) ≈ Vec2f(0.5, 0.0)
+        @test Makie.calculate_bar_label_align(al, -π/2, y_dir, flip) ≈ Vec2f(0.5, 1.0)
+
+        y_dir, flip = true, true
+        @test Makie.calculate_bar_label_align(al, 0.0, y_dir, flip) ≈ Vec2f(0.5, 1.0)
+        @test Makie.calculate_bar_label_align(al, π, y_dir, flip) ≈ Vec2f(0.5, 0.0)
+        @test Makie.calculate_bar_label_align(al, π/2, y_dir, flip) ≈ Vec2f(1.0, 0.5)
+        @test Makie.calculate_bar_label_align(al, -π/2, y_dir, flip) ≈ Vec2f(0.0, 0.5)
+    end
+
+    @testset "manual" begin
+        input = 0.0, false, false
+        for align in (Vec2f(1.0, 0.5), Point2f(1.0, 0.5), (1.0, 0.5), (1, 0), (1.0, 0))
+            @test Makie.calculate_bar_label_align(align, input...) ≈ Vec2f(align)
+        end
+    end
+
+    @testset "symbols" begin
+        input = 0.0, false, false
+        @test Makie.calculate_bar_label_align((:center, :center), input...) ≈ Makie.calculate_bar_label_align((0.5, 0.5), input...)
+    end
+
+    @testset "error" begin
+        input = 0.0, false, false
+        for align in ("center", 0.5, ("center", "center"), (0.5, :center))
+            msg = "`label_align` needs to be of type NTuple{2, <:Real}, not of type $(typeof(align))"
+            @test_throws ErrorException(msg) Makie.calculate_bar_label_align(align, input...)
+        end
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,4 +33,5 @@ using Makie: volume
     include("text.jl")
     include("boundingboxes.jl")
     include("ray_casting.jl")
+    include("barplot_labels.jl")
 end


### PR DESCRIPTION
# Description

Fixes #3160

Improved the automatic barplot label alignment and added the attribute `label_align` for custom placement.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

Done: 
- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.

Not done:
- [x] Added or changed relevant sections in the documentation
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.

I assume the documentation will automatically show the new attribute.
I considered adding a new reference image, but I think the unit tests cover the behavior well.

So I assume these two items do not need to be checked.