### PR TITLE
fix error bar range in recipes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fixed regression in determining axis limits [#3179](https://github.com/MakieOrg/Makie.jl/pull/3179)
+
 ## v0.19.8
 
 - Improved CairoMakie rendering of `lines` with repeating colors in an array [#3141](https://github.com/MakieOrg/Makie.jl/pull/3141).

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -54,7 +54,7 @@ function Makie.plot!(pl::Bracket)
         return to === automatic ? Float32.(0.75 .* fs) : Float32.(to)
     end
 
-    onany(pl, points, scene.camera.projectionview, pl.model, transform_func(pl), 
+    onany(pl, points, scene.camera.projectionview, pl.model, transform_func(pl),
           scene.px_area, pl.offset, pl.width, pl.orientation, realtextoffset,
           pl.style) do points, _, _, _, _, offset, width, orientation, textoff, style
 
@@ -108,7 +108,7 @@ function Makie.plot!(pl::Bracket)
     end
 
     # Avoid scale!() / translate!() / rotate!() to affect these
-    series!(pl, bp; space = :pixel, solid_color = pl.color, linewidth = pl.linewidth, 
+    series!(pl, bp; space = :pixel, solid_color = pl.color, linewidth = pl.linewidth,
         linestyle = pl.linestyle, transformation = Transformation())
     text!(pl, textpoints, text = texts, space = :pixel, align = pl.align, offset = textoffset_vec,
         fontsize = pl.fontsize, font = pl.font, rotation = autorotations, color = pl.textcolor,
@@ -116,8 +116,8 @@ function Makie.plot!(pl::Bracket)
     pl
 end
 
-data_limits(pl::Bracket) = mapreduce(union, pl[1][]) do points
-    Rect3f([points...])
+function point_iterator(pl::Bracket)
+    point_iterator(pl.plots[1])
 end
 
 bracket_bezierpath(style::Symbol, args...) = bracket_bezierpath(Val(style), args...)

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -239,7 +239,7 @@ end
 function plot_to_screen(plot, points::AbstractVector)
     cam = parent_scene(plot).camera
     space = to_value(get(plot, :space, :data))
-    spvm = clip_to_space(cam, :data) * space_to_clip(cam, space) * transformationmatrix(plot)[]
+    spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) * transformationmatrix(plot)[]
 
     return map(points) do p
         transformed = apply_transform(transform_func(plot), p, space)
@@ -280,6 +280,6 @@ function screen_to_plot(plot, p::VecTypes)
 end
 
 # ignore whiskers when determining data limits
-function data_limits(bars::Union{Errorbars, Rangebars})
-    data_limits(bars.plots[1])
+function point_iterator(bars::Union{Errorbars, Rangebars})
+    point_iterator(bars.plots[1])
 end

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -239,7 +239,7 @@ end
 function plot_to_screen(plot, points::AbstractVector)
     cam = parent_scene(plot).camera
     space = to_value(get(plot, :space, :data))
-    spvm = clip_to_space(cam, :pixel) * space_to_clip(cam, space) * transformationmatrix(plot)[]
+    spvm = clip_to_space(cam, :data) * space_to_clip(cam, space) * transformationmatrix(plot)[]
 
     return map(points) do p
         transformed = apply_transform(transform_func(plot), p, space)

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -62,7 +62,7 @@ end
 
 Makie.conversion_trait(::Type{<:Hexbin}) = PointBased()
 
-function data_limits(hb::Hexbin)
+function point_iterator(hb::Hexbin)
     bb = Rect3f(hb.plots[1][1][])
     fn(num::Real) = Float32(num)
     fn(tup::Union{Tuple,Vec2}) = Vec2f(tup...)
@@ -71,7 +71,7 @@ function data_limits(hb::Hexbin)
     nw = widths(bb) .+ (ms..., 0.0f0)
     no = bb.origin .- ((ms ./ 2.0f0)..., 0.0f0)
 
-    return Rect3f(no, nw)
+    return decompose(Point2f, Rect3f(no, nw))
 end
 
 get_weight(weights, i) = Float64(weights[i])


### PR DESCRIPTION
# Description

Fixes #3176

Moves to data space instead of pixel space.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] ~Added or changed relevant sections in the documentation~
- [ ] ~Added unit tests for new algorithms, conversion methods, etc.~
- [ ] ~Added reference image tests for new plotting functions, recipes, visual options, etc.~
