### PR TITLE
rename CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
-      - name: Install Julia dependencies
+      - name: Develop and test Makie
         shell: julia --project=monorepo {0}
         run: |
-          using Pkg;
+          using Pkg
           # dev mono repo versions
           pkg"dev . ./MakieCore"
           Pkg.test("Makie"; coverage=true)


### PR DESCRIPTION
Small consistency PR (the `Install Julia dependencies` message in CI is misleading since it also runs the tests).