### PR TITLE
Fix depwarn for cairomakie lines

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -4,7 +4,6 @@
 
 function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Union{Lines, LineSegments}))
     fields = @get_attribute(primitive, (color, linewidth, linestyle))
-    linestyle = Makie.convert_attribute(linestyle, Makie.key"linestyle"())
     ctx = screen.context
     model = primitive[:model][]
     positions = primitive[1][]
@@ -245,7 +244,7 @@ function draw_multi(primitive::Lines, ctx, positions, colors::AbstractArray, lin
                     this_linewidth != prev_linewidth && error("Encountered two different linewidth values $prev_linewidth and $this_linewidth in `lines` at index $(i-1). Different linewidths in one line are only permitted in CairoMakie when separated by a NaN point.")
                     Cairo.line_to(ctx, this_position...)
                     prev_continued = true
-                    
+
                     if i == lastindex(positions)
                         # this is the last element so stroke this
                         Cairo.set_line_width(ctx, this_linewidth)
@@ -691,7 +690,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Unio
     t = Makie.transform_func(primitive)
     identity_transform = (t === identity || t isa Tuple && all(x-> x === identity, t)) && (abs(model[1, 2]) < 1e-15)
     regular_grid = xs isa AbstractRange && ys isa AbstractRange
-    xy_aligned = let 
+    xy_aligned = let
         # Only allow scaling and translation
         pv = scene.camera.projectionview[]
         M = Mat4f(
@@ -720,7 +719,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Unio
     xymax = project_position(scene, space, Point2f(last.(imsize)), model)
     w, h = xymax .- xy
 
-    can_use_fast_path = !(is_vector && !interpolate) && regular_grid && identity_transform && 
+    can_use_fast_path = !(is_vector && !interpolate) && regular_grid && identity_transform &&
         (interpolate || xy_aligned)
     use_fast_path = can_use_fast_path && !disable_fast_path
 

--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -235,7 +235,12 @@ function get_attribute(dict, key, default=nothing)
     if haskey(dict, key)
         value = to_value(dict[key])
         value isa Automatic && return default
-        return convert_attribute(to_value(dict[key]), Key{key}())
+        plot_k = plotkey(dict)
+        if isnothing(plot_k)
+            return convert_attribute(value, Key{key}())
+        else
+            return convert_attribute(value, Key{key}(), Key{plot_k}())
+        end
     else
         return default
     end

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -21,6 +21,7 @@ func2type(f::Function) = Combined{f}
 plotkey(::Type{<: AbstractPlot{Typ}}) where Typ = Symbol(lowercase(func2string(Typ)))
 plotkey(::T) where T <: AbstractPlot = plotkey(T)
 plotkey(::Nothing) = :scatter
+plotkey(any) = nothing
 
 """
      default_plot_signatures(funcname, funcname!, PlotType)

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -5,7 +5,7 @@
     points = Point2f[(1, 1), (1, 2), (2, 3), (2, 1)]
     linestyles = [
         :solid, :dash, :dot, :dashdot, :dashdotdot,
-        [1, 2, 3], [1, 2, 4, 5]
+        Linestyle([1, 2, 3]), Linestyle([1, 2, 4, 5])
     ]
     for linewidth in 1:10
         for (i, linestyle) in enumerate(linestyles)
@@ -270,13 +270,13 @@ end
 
     # Same as above
     markers = [
-        :rect, :circle, :cross, :x, :utriangle, :rtriangle, :dtriangle, :ltriangle, :pentagon, 
+        :rect, :circle, :cross, :x, :utriangle, :rtriangle, :dtriangle, :ltriangle, :pentagon,
         :hexagon, :octagon, :star4, :star5, :star6, :star8, :vline, :hline, 'x', 'X'
     ]
 
     for (i, marker) in enumerate(markers)
         scatter!(
-            Point2f.(1:5, i), marker = marker, 
+            Point2f.(1:5, i), marker = marker,
             markersize = range(10, 30, length = 5), color = :orange,
             strokewidth = 2, strokecolor = :black
         )
@@ -451,7 +451,7 @@ end
     lab1 = L"\int f(x) dx"
     lab2 = lab1
     # lab2 = L"\frac{a}{b} - \sqrt{b}" # this will not work until #2667 is fixed
-    
+
     barplot(fig[1,1], [1, 2], [0.5, 0.2], bar_labels = [lab1, lab2], flip_labels_at = 0.3, direction=:x)
     barplot(fig[1,2], [1, 2], [0.5, 0.2], bar_labels = [lab1, lab2], flip_labels_at = 0.3)
 

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -169,20 +169,20 @@ end
 
 attr_broadcast_length(x::NativeFont) = 1
 attr_broadcast_length(x::VecTypes) = 1 # these are our rules, and for what we do, Vecs are usually scalars
-attr_broadcast_length(x::AbstractArray) = length(x)
+attr_broadcast_length(x::AbstractVector) = length(x)
 attr_broadcast_length(x::AbstractPattern) = 1
 attr_broadcast_length(x) = 1
 attr_broadcast_length(x::ScalarOrVector) = x.sv isa Vector ? length(x.sv) : 1
 
 attr_broadcast_getindex(x::NativeFont, i) = x
 attr_broadcast_getindex(x::VecTypes, i) = x # these are our rules, and for what we do, Vecs are usually scalars
-attr_broadcast_getindex(x::AbstractArray, i) = x[i]
+attr_broadcast_getindex(x::AbstractVector, i) = x[i]
 attr_broadcast_getindex(x::AbstractPattern, i) = x
 attr_broadcast_getindex(x, i) = x
 attr_broadcast_getindex(x::Ref, i) = x[] # unwrap Refs just like in normal broadcasting, for protecting iterables
 attr_broadcast_getindex(x::ScalarOrVector, i) = x.sv isa Vector ? x.sv[i] : x.sv
 
-is_vector_attribute(x::AbstractArray) = true
+is_vector_attribute(x::AbstractVector) = true
 is_vector_attribute(x::NativeFont) = false
 is_vector_attribute(x::Quaternion) = false
 is_vector_attribute(x::VecTypes) = false


### PR DESCRIPTION
CairoMakie was double converting the linestyle (`@get_attribute` already applies `attribute_conversion`), so it was running into the depwarn for any linestyle...