### PR TITLE
fix brack data_limits

### DIFF
--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -261,7 +261,7 @@ Creates a connected line plot for each element in `(x, y, z)`, `(x, y)` or `posi
 - `color=theme(scene, :linecolor)` sets the color of the line. If no color is set, multiple calls to `line!` will cycle through the axis color palette.
   Otherwise, one can set one color per line point by passing a `Vector{<:Colorant}`, or one colorant for the whole line. If color is a vector of numbers, the colormap args are used to map the numbers to colors.
 - `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
-- `linestyle::Union{Nothing, Symbol, Vector} = nothing` sets the pattern of the line (e.g. `:solid`, `:dot`, `:dashdot`)
+- `linestyle::Union{Nothing, Symbol, Linestyle} = nothing` sets the pattern of the line e.g. `:solid`, `:dot`, `:dashdot`. For custom patterns look at `Linestyle(Number[...])`.
 - `linewidth::Union{Real, Vector} = 1.5` sets the width of the line in pixel units.
 
 $(Base.Docs.doc(colormap_attributes!))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Deprecated `linestyle=vector_of_gaps` in favor of `linestyle=Linestyle(vector_of_gaps)` [3135](https://github.com/MakieOrg/Makie.jl/pull/3135), [3193](https://github.com/MakieOrg/Makie.jl/pull/3193).
 - Fixed some errors around dynamic changes of `ax.xscale` or `ax.yscale` [#3084](https://github.com/MakieOrg/Makie.jl/pull/3084)
 - Improved Barplot Label Alignment [#3160](https://github.com/MakieOrg/Makie.jl/issues/3160).
 - Fixed regression in determining axis limits [#3179](https://github.com/MakieOrg/Makie.jl/pull/3179)

--- a/docs/explanations/nodes.md
+++ b/docs/explanations/nodes.md
@@ -72,6 +72,9 @@ nothing # hide
 ```
 \show{code3}
 
+!!! note
+    If you updated the `Observable` using in-place syntax (e.g. `img[] .= colorant"red"`), you need to manually
+    `notify(img)` to trigger the function.
 
 !!! note
     All registered functions in a `Observable` are executed synchronously in the order of registration.

--- a/docs/reference/plots/lines.md
+++ b/docs/reference/plots/lines.md
@@ -45,7 +45,7 @@ for (i, lw) in enumerate([1, 2, 3])
     lines!(xs, ys .- i/6 .- 2, linestyle = :dot, linewidth = lw)
     lines!(xs, ys .- i/6 .- 3, linestyle = :dashdot, linewidth = lw)
     lines!(xs, ys .- i/6 .- 4, linestyle = :dashdotdot, linewidth = lw)
-    lines!(xs, ys .- i/6 .- 5, linestyle = [0.5, 1.0, 1.5, 2.5], linewidth = lw)
+    lines!(xs, ys .- i/6 .- 5, linestyle = Linestyle([0.5, 1.0, 1.5, 2.5]), linewidth = lw)
 end
 
 f

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -37,7 +37,7 @@ function Makie.convert_arguments(::Type{<:Bracket}, x1::AbstractVector{<:Real}, 
     points = broadcast(x1, y1, x2, y2) do x1, y1, x2, y2
         (Point2f(x1, y1), Point2f(x2, y2))
     end
-    (points,)
+    return (points,)
 end
 
 function Makie.plot!(pl::Bracket)
@@ -117,7 +117,7 @@ function Makie.plot!(pl::Bracket)
 end
 
 function point_iterator(pl::Bracket)
-    point_iterator(pl.plots[1])
+    return Point2f[tupl[i] for tupl in pl[1][] for i in 1:2]
 end
 
 bracket_bezierpath(style::Symbol, args...) = bracket_bezierpath(Val(style), args...)


### PR DESCRIPTION
#3179 introduced a regression in the `data_limits` for brackets, and since our reference images tests still have a way too high threshold, it didn't fail the tests.
@ffreyer, you think there are other places where this happened which are untested?
We should definitely look into the refimages this time before merging! 