### PR TITLE
Move recursion to data_limits

### DIFF
--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -116,9 +116,7 @@ function Makie.plot!(pl::Bracket)
     pl
 end
 
-function point_iterator(pl::Bracket)
-    return Point2f[tupl[i] for tupl in pl[1][] for i in 1:2]
-end
+data_limits(pl::Bracket) = mapreduce(ps -> Rect3f([ps...]), union, pl[1][])
 
 bracket_bezierpath(style::Symbol, args...) = bracket_bezierpath(Val(style), args...)
 

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -287,6 +287,6 @@ function screen_to_plot(plot, p::VecTypes)
 end
 
 # ignore whiskers when determining data limits
-function point_iterator(bars::Union{Errorbars, Rangebars})
-    point_iterator(bars.plots[1])
+function data_limits(bars::Union{Errorbars, Rangebars})
+    data_limits(bars.plots[1])
 end

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -40,20 +40,21 @@ function point_iterator(plot::Union{Scatter, MeshScatter, Lines, LineSegments})
 end
 
 # TODO?
-function point_iterator(text::Text{<: Tuple{<: Union{GlyphCollection, AbstractVector{GlyphCollection}}}})
+function data_limits(text::Text{<: Tuple{<: Union{GlyphCollection, AbstractVector{GlyphCollection}}}})
     if is_data_space(text.markerspace[])
-        return decompose(Point, boundingbox(text))
+        return boundingbox(text)
     else
         if text.position[] isa VecTypes
-            return [to_ndim(Point3f, text.position[], 0.0)]
+            return Rect3f(text.position[])
         else
-            return convert_arguments(PointBased(), text.position[])[1]
+            # TODO: is this branch necessary?
+            return Rect3f(convert_arguments(PointBased(), text.position[])[1])
         end
     end
 end
 
-function point_iterator(text::Text)
-    return point_iterator(text.plots[1])
+function data_limits(text::Text)
+    return data_limits(text.plots[1])
 end
 
 point_iterator(mesh::GeometryBasics.Mesh) = decompose(Point, mesh)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -73,8 +73,6 @@ function point_iterator(list::AbstractVector)
     end
 end
 
-point_iterator(plot::Combined) = point_iterator(plot.plots)
-
 point_iterator(plot::Mesh) = point_iterator(plot.mesh[])
 
 function br_getindex(vector::AbstractVector, idx::CartesianIndex, dim::Int)
@@ -168,7 +166,14 @@ function update_boundingbox!(bb_ref, bb::Rect)
 end
 
 function data_limits(plot::AbstractPlot)
-    limits_from_transformed_points(iterate_transformed(plot))
+    isempty(plot.plots) && return Rect3f()
+
+    bb_ref = Ref(data_limits(plot.plots[1]))
+    for i in 2:length(plot.plots)
+        update_boundingbox!(bb_ref, data_limits(plot.plots[i]))
+    end
+
+    return bb_ref[]
 end
 
 function _update_rect(rect::Rect{N, T}, point::Point{N, T}) where {N, T}

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -166,9 +166,13 @@ function update_boundingbox!(bb_ref, bb::Rect)
 end
 
 function data_limits(plot::AbstractPlot)
-    isempty(plot.plots) && return Rect3f()
+    # Assume primitive plot
+    if isempty(plot.plots)
+        return limits_from_transformed_points(iterate_transformed(plot))
+    end
 
-    bb_ref = Ref(data_limits(plot.plots[1]))
+    # Assume Combined Plot
+    bb_ref = Base.RefValue(data_limits(plot.plots[1]))
     for i in 2:length(plot.plots)
         update_boundingbox!(bb_ref, data_limits(plot.plots[i]))
     end

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -62,7 +62,7 @@ end
 
 Makie.conversion_trait(::Type{<:Hexbin}) = PointBased()
 
-function point_iterator(hb::Hexbin)
+function data_limits(hb::Hexbin)
     bb = Rect3f(hb.plots[1][1][])
     fn(num::Real) = Float32(num)
     fn(tup::Union{Tuple,Vec2}) = Vec2f(tup...)
@@ -71,7 +71,7 @@ function point_iterator(hb::Hexbin)
     nw = widths(bb) .+ (ms..., 0.0f0)
     no = bb.origin .- ((ms ./ 2.0f0)..., 0.0f0)
 
-    return decompose(Point2f, Rect3f(no, nw))
+    return Rect3f(no, nw)
 end
 
 get_weight(weights, i) = Float64(weights[i])

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -1,3 +1,22 @@
+function Base.isapprox(r1::Rect{D}, r2::Rect{D}; kwargs...) where D
+    return isapprox(minimum(r1), minimum(r2); kwargs...) &&
+            isapprox(widths(r1), widths(r2); kwargs...)
+end
+
+@testset "data_limits(plot)" begin
+    ps = Point2f[(0, 0), (1, 1)]
+
+    fig, ax, p = hexbin(ps)
+    ms = to_ndim(Vec3f, Vec2f(p.plots[1].markersize[]), 0)
+    @test data_limits(p) ≈ Rect3f(-ms, Vec3f(1, 1, 0) .+ 2ms)
+
+    fig, ax, p = errorbars(ps, [0.5, 0.5])
+    @test data_limits(p) ≈ Rect3f(-Point3f(0, 0.5, 0), Vec3f(1, 2, 0))
+
+    fig, ax, p = bracket(ps...)
+    @test data_limits(p) ≈ Rect3f(Point3f(0), Vec3f(1, 1, 0))
+end
+
 @testset "boundingbox(plot)" begin
     cat = FileIO.load(Makie.assetpath("cat.obj"))
 
@@ -42,7 +61,7 @@
     bb = boundingbox(p)
     @test bb.origin ≈ Point3f(0.5, 0.5, 0)
     @test bb.widths ≈ Vec3f(10.0, 10.0, 0)
-    
+
     fig, ax, p = image(rand(10, 10))
     bb = boundingbox(p)
     @test bb.origin ≈ Point3f(0)


### PR DESCRIPTION
# Description

I thought about the changes in #3179 some more and came to the conclusion that moving the recursion to `data_limits` instead of `point_iterator` isn't something we need or should hold back. It's just a simple internal change that is pretty isolated from other bounding box and transformation changes.

This rolls back the data_limits -> point_iterator changes from #3179 and instead updates bbox recursion.

TODO:
- [x] check errorbars, i.e. #3179
- [x] check bracket
- [x] check hexbin

## Type of change

- Internal clean up

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
