### PR TITLE
cycle color for error and range bars

### DIFF
--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -28,7 +28,8 @@ $(ATTRIBUTES)
         colorscale = identity,
         colorrange = automatic,
         inspectable = theme(scene, :inspectable),
-        transparency = false
+        transparency = false,
+        cycle = [:color]
     )
 end
 
@@ -57,7 +58,8 @@ $(ATTRIBUTES)
         colorscale = identity,
         colorrange = automatic,
         inspectable = theme(scene, :inspectable),
-        transparency = false
+        transparency = false,
+        cycle = [:color]
     )
 end
 


### PR DESCRIPTION
# Description

Currently error and range bars do not cycle colors. This PR simply allows to cycle colors when using error and range bars.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
