### PR TITLE
MouseStateMachine order fixes

### DIFF
--- a/src/makielayout/mousestatemachine.jl
+++ b/src/makielayout/mousestatemachine.jl
@@ -318,8 +318,32 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
                         dt_last_click = t - t_last_click[]
                         t_last_click[] = t
 
+                        # up before click
+                        event = @match mouse_downed_button[] begin
+                            Mouse.left => MouseEventTypes.leftup
+                            Mouse.right => MouseEventTypes.rightup
+                            Mouse.middle => MouseEventTypes.middleup
+                            x => error("No recognized mouse button $x")
+                        end
+
+                        x = setindex!(mouseevent,
+                            MouseEvent(event, t, data, px, prev_t[], prev_data[], prev_px[])
+                        )
+
                         # guard against mouse coming in from outside, then mouse upping
                         if mouse_downed_inside[]
+
+                            event = @match mouse_downed_button[] begin
+                                Mouse.left => MouseEventTypes.leftclick
+                                Mouse.right => MouseEventTypes.rightclick
+                                Mouse.middle => MouseEventTypes.middleclick
+                                x => error("No recognized mouse button $x")
+                            end
+                            x = setindex!(mouseevent,
+                                MouseEvent(event, t, data, px, prev_t[], prev_data[], prev_px[])
+                            )
+                            consumed = consumed || x
+
                             if dt_last_click < dblclick_max_interval && !last_click_was_double[] &&
                                     mouse_downed_button[] == b_last_click[]
 
@@ -333,36 +357,16 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
                                     MouseEvent(event, t, data, px, prev_t[], prev_data[], prev_px[])
                                 )
                                 consumed = consumed || x
-                                last_click_was_double[] = true
+                                last_click_was_double[] = true                                
                             else
-                                event = @match mouse_downed_button[] begin
-                                    Mouse.left => MouseEventTypes.leftclick
-                                    Mouse.right => MouseEventTypes.rightclick
-                                    Mouse.middle => MouseEventTypes.middleclick
-                                    x => error("No recognized mouse button $x")
-                                end
-                                x = setindex!(mouseevent,
-                                    MouseEvent(event, t, data, px, prev_t[], prev_data[], prev_px[])
-                                )
-                                consumed = consumed || x
                                 last_click_was_double[] = false
                             end
+                            
                             # save what type the last downed button was
                             b_last_click[] = mouse_downed_button[]
                         end
                         mouse_downed_inside[] = false
 
-                        # up after click
-                        event = @match mouse_downed_button[] begin
-                            Mouse.left => MouseEventTypes.leftup
-                            Mouse.right => MouseEventTypes.rightup
-                            Mouse.middle => MouseEventTypes.middleup
-                            x => error("No recognized mouse button $x")
-                        end
-
-                        x = setindex!(mouseevent,
-                            MouseEvent(event, t, data, px, prev_t[], prev_data[], prev_px[])
-                        )
                         consumed = consumed || x
                     end
                 end


### PR DESCRIPTION
- move mouseup before click and trigger click before doubleclick, too
- add mouse state machine tests to glmakie tests

I've noticed that the canonical order in browsers is up -> click -> doubleclick so I've changed it to that on our side, too https://www.w3.org/TR/DOM-Level-3-Events/#events-mouseevent-event-order

Actually while doing all of this I've got a stronger feeling that we need to rework our interaction / event model. It's difficult to know what object will trigger first, will consume the event, etc. Maybe we can have a similar "bubbling-up" concept as the web with its DOM, just with our recipes. DataInspector already does something similar.