### PR TITLE
Fix struct uniforms

### DIFF
--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -423,8 +423,10 @@ function RenderObject(
         else
             k in (:indices, :visible, :ssao, :label, :cycle) && continue
             # structs are treated differently, since they have to be composed into their fields
+            # NOTE that merge!(data, ...) will break the iteration, so struct uniforms must
+            # be added after this iteration
             if isa_gl_struct(v)
-                merge!(data, gl_convert_struct(v, k))
+                merge!(passthrough, gl_convert_struct(v, k))
             elseif applicable(gl_convert, v) # if can't be converted to an OpenGL datatype,
                 try
                     data[k] = gl_convert(v)

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -441,11 +441,10 @@ function RenderObject(
         end
     end
     buffers = filter(((key, value),) -> isa(value, GLBuffer) || key === :indices, data)
-    uniforms = filter(((key, value),) -> !isa(value, GLBuffer) && key !== :indices, data)
     merge!(data, passthrough) # in the end, we insert back the non opengl data, to keep things simple
     program = gl_convert(to_value(program), data) # "compile" lazyshader
     vertexarray = GLVertexArray(Dict(buffers), program)
-    visible = pop!(uniforms, :visible, Observable(true))
+    visible = pop!(data, :visible, Observable(true))
     # remove all uniforms not occuring in shader
     # ssao, instances transparency are special for rendering passes. TODO do this more cleanly
     special = Set([:ssao, :transparency, :instances, :fxaa])

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -419,7 +419,7 @@ function RenderObject(
     observables = Observable[]
 
     # Overwriting data with break direct iteration over it
-    _keys = copy(keys(data))
+    _keys = collect(keys(data))
     for k in _keys
         v = data[k]
         v isa Observable && push!(observables, v)

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -438,8 +438,6 @@ function RenderObject(
                 merge!(data, gl_convert_struct(v, k))
                 delete!(data, k)
 
-            # TODO: gl vector handling
-
             # try direct conversion
             elseif applicable(gl_convert, v)
                 try

--- a/GLMakie/src/GLAbstraction/GLUniforms.jl
+++ b/GLMakie/src/GLAbstraction/GLUniforms.jl
@@ -213,7 +213,7 @@ function isa_gl_struct(x::T) where T
 end
 function gl_convert_struct(x::T, uniform_name::Symbol) where T
     if isa_gl_struct(x)
-        return Dict{Symbol, Any}(map(fieldnames(x)) do name
+        return Dict{Symbol, Any}(map(fieldnames(T)) do name
             (Symbol("$uniform_name.$name") => gl_convert(getfield(x, name)))
         end)
     else


### PR DESCRIPTION
# Description

I wanted to play around a bit with lighting and noticed struct uniforms are broken. (I think I ran into this before?) There were two issues here:
1. `fieldnames(obj)` needs to be `fieldnames(type)` now
2. Doing a `merge!(data, other)` when iterating `for (k, v) in data` breaks the iteration

The second problem may still cause issues here:

https://github.com/MakieOrg/Makie.jl/blob/d61d05f5cc2a6f5a2678b51c39ff1f2f6b05d537/GLMakie/src/GLAbstraction/GLTypes.jl#L435-L438

I don't know what input hits this branch so I don't know how to test it. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
