### PR TITLE
Docs tweaks

### DIFF
--- a/docs/buildutils/redirect_generation.jl
+++ b/docs/buildutils/redirect_generation.jl
@@ -44,6 +44,7 @@ function write_redirection_html(redirect_file, existing_file; dry_run)
                     <head>
                         <meta charset="UTF-8">
                         <meta http-equiv="refresh" content="0; url=$rel">
+                        <link rel="canonical" href="$rel" />
                         <script type="text/javascript">
                             window.location.href = "$rel"
                         </script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,10 +113,10 @@ To switch to a different backend, for example `CairoMakie`, call `CairoMakie.act
 
   @@box
     ~~~<a class="boxlink" href="reference/plots/">~~~
-    @@title Plot Examples @@
+    @@title Plot Reference @@
     @@box-content
       @@description
-      Have a look at this list of examples for the available plotting functions.
+      A visual reference of all available plotting functions and their attributes.
       @@
       ~~~
       <img src="/assets/reference/plots/heatmap/code/output/mandelbrot_heatmap.png">

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-@def title = "Interactive visualizations and powerful plotting in Julia"
+@def title = "Home"
 @def order = 0
 @def frontpage = true
 @def description = "Create impressive data visualizations with Makie, the plotting ecosystem for the Julia language. Build aesthetic plots with beautiful customizable themes, control every last detail of publication quality vector graphics, assemble complex layouts and quickly prototype interactive applications to explore your data live."


### PR DESCRIPTION
- change index.md title to Home (this was because I wanted that title in google results, but they didn't really pick this up anyway and mostly pick their own content)
- use rel=canonical to mark redirection sites as duplicates more clearly
- change example to reference
