### PR TITLE
Setup automatic colorbars for `volumeslices`

### DIFF
--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -220,7 +220,10 @@ end
 
     # TO not make this fail in CairoMakie, we dont actually plot the volume
     _f, ax, cp = contour(x, y, z, values; levels=10, colormap=:viridis)
-    Colorbar(fig[2, :], cp; size=300)
+    Colorbar(fig[2, 1], cp; size=300)
+
+    _f, ax, vs = volumeslices(x, y, z, values, colormap=:bluesreds)
+    Colorbar(fig[2, 2], vs)
 
     # horizontal colorbars
     Colorbar(fig[1, 3][2, 1]; limits=(0, 10), colormap=:viridis,

--- a/src/makielayout/blocks/colorbar.jl
+++ b/src/makielayout/blocks/colorbar.jl
@@ -47,6 +47,10 @@ function extract_colormap(plot::StreamPlot)
     return extract_colormap(plot.plots[1])
 end
 
+function extract_colormap(plot::Combined{volumeslices})
+    return extract_colormap(plot.plots[1])
+end
+
 function extract_colormap(plot::Union{Contourf,Tricontourf})
     levels = plot._computed_levels
     limits = lift(l -> (l[1], l[end]), levels)

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -180,6 +180,13 @@ end
         f, ax, pl = barplot(1:3; color=1:3)
         cbar = Colorbar(f[1, 2], pl)
         @test cbar.limits[] == Vec(1.0, 3.0)
+
+        let data = fill(1.0, 2,2,2)
+            data[1] = 3.0
+            f, ax, pl = volumeslices(1:2, 1:2, 1:2, data)
+            cbar = Colorbar(f[1,2], pl)
+            @test cbar.limits[] == Vec(1.0, 3.0)
+        end
     end
 end
 


### PR DESCRIPTION
# Description

Fixes #3251

This PR introduces a specialized `extract_colormap(plot::Combined{volumeslices})` method, in an attempt to fix #3251.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.

I'm not sure how to test this. I added
- a call to `volumeslices`+`Colorbar` in `ReferenceTests/src/tests/figures_and_makielayout.jl`, taking `contour` as a model; 
- a small check in `test/makielayout.jl`, this time taking `barplot` as a model.

Is that enough?