### PR TITLE
DataInspector: fix an attribute extraction bug for heatmaps & images

### DIFF
--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -662,7 +662,7 @@ function show_imagelike(inspector, plot, name, edge_based)
     a._color[] = if z isa AbstractFloat
         interpolated_getindex(
             to_colormap(plot.colormap[]), z,
-            to_value(get(plot.attributes, :colorrange, (0, 1)))
+            extract_colorrange(plot)
         )
     else
         z

--- a/src/makielayout/blocks/colorbar.jl
+++ b/src/makielayout/blocks/colorbar.jl
@@ -25,6 +25,16 @@ function colorbar_check(keys, kwargs_keys)
     end
 end
 
+function extract_colorrange(@nospecialize(plot::AbstractPlot))::Vec2{Float64}
+    if haskey(plot, :calculated_colors) && plot.calculated_colors[] isa Makie.ColorMapping
+        return plot.calculated_colors[].colorrange[]
+    elseif haskey(plot, :colorrange) && !(plot.colorrange[] isa Makie.Automatic)
+        return plot.colorrange[]
+    else
+        error("colorrange not found and calculated_colors for the plot is missing or is not a proper color map. Heatmaps and images should always contain calculated_colors[].colorrange")
+    end
+end
+
 function extract_colormap(@nospecialize(plot::AbstractPlot))
     has_colorrange = haskey(plot, :colorrange) && !(plot.colorrange[] isa Makie.Automatic)
     if haskey(plot, :calculated_colors) && plot.calculated_colors[] isa Makie.ColorMapping


### PR DESCRIPTION
# Description

Fixes #3101

If the `colorrange` attribute is left at default it returns `MakieCore.Automatic`; the method for [`get`](https://github.com/MakieOrg/Makie.jl/blob/2b8b8a1472f2fd8692a64a554f3b85669c297e90/MakieCore/src/attributes.jl#L169) that was called at `show_imagelike` does not check for this type so the ensuing call to `interpolated_getindex` would fail.

The colorrange is now generically extracted and `calculated_colors[].colorrange[]` is preferred as it contains the actual range.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

