### PR TITLE
replace bgcolor with backgroundcolor in Legend

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ with_theme(palette = (; patchcolor = cgrad(cmap, alpha=0.45))) do
     band!(x, sin.(x), approx .+= x .^ 5 / 120; label = L"n = 2")
     band!(x, sin.(x), approx .+= -x .^ 7 / 5040; label = L"n = 3")
     limits!(-3.8, 3.8, -1.5, 1.5)
-    axislegend(; position = :ct, bgcolor = (:white, 0.75), framecolor = :orange)
+    axislegend(; position = :ct, backgroundcolor = (:white, 0.75), framecolor = :orange)
     save("./assets/approxsin.png", fig, resolution = (800, 600))
     fig
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -116,8 +116,8 @@ end
             lines!(ax,( 1:10) .* i, label = "$i")
         end
         # To verify that RGB values differ across entries
-        axislegend(ax, position = :lt, patchcolor = :red, patchsize = (100, 100), bgcolor = :gray50);
-        Legend(f[1, 2], ax, patchcolor = :gray80, patchsize = (100, 100), bgcolor = :gray50);
+        axislegend(ax, position = :lt, patchcolor = :red, patchsize = (100, 100), backgroundcolor = :gray50);
+        Legend(f[1, 2], ax, patchcolor = :gray80, patchsize = (100, 100), backgroundcolor = :gray50);
         f
     end
 end

--- a/docs/reference/plots/datashader.md
+++ b/docs/reference/plots/datashader.md
@@ -217,7 +217,7 @@ We can also re-use the previous NYC example for a categorical plot:
     hidedecorations!(ax)
     hidespines!(ax)
     # Create a styled legend
-    axislegend("Vendor ID"; titlecolor=:white, framecolor=:grey, polystrokewidth=2, polystrokecolor=(:white, 0.5), rowgap=10, bgcolor=:black, labelcolor=:white)
+    axislegend("Vendor ID"; titlecolor=:white, framecolor=:grey, polystrokewidth=2, polystrokecolor=(:white, 0.5), rowgap=10, backgroundcolor=:black, labelcolor=:white)
     display(f)
 end
 ```

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -19,7 +19,7 @@ function initialize_block!(leg::Legend,
         enlarge(la, -lm[1], -lm[2], -lm[3], -lm[4])
     end
 
-    backgroundcolor = if haskey(leg, :bgcolor)
+    backgroundcolor = if !isnothing(leg.bgcolor[])
         @warn("Keyword argument `bgcolor` is deprecated, use `backgroundcolor` instead.")
         leg.bgcolor
     else

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -21,7 +21,7 @@ function initialize_block!(leg::Legend,
 
     bg = poly!(scene,
         legendrect,
-        color = leg.bgcolor, strokewidth = leg.framewidth, visible = leg.framevisible,
+        color = leg.backgroundcolor, strokewidth = leg.framewidth, visible = leg.framevisible,
         strokecolor = leg.framecolor, inspectable = false)
     translate!(bg, 0, 0, -7) # bg behind patches but before content at 0 (legend is at +10)
 

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -19,9 +19,16 @@ function initialize_block!(leg::Legend,
         enlarge(la, -lm[1], -lm[2], -lm[3], -lm[4])
     end
 
+    backgroundcolor = if haskey(leg, :bgcolor)
+        @warn("Keyword argument `bgcolor` is deprecated, use `backgroundcolor` instead.")
+        leg.bgcolor
+    else
+        leg.backgroundcolor
+    end
+
     bg = poly!(scene,
         legendrect,
-        color = leg.backgroundcolor, strokewidth = leg.framewidth, visible = leg.framevisible,
+        color = backgroundcolor, strokewidth = leg.framewidth, visible = leg.framevisible,
         strokecolor = leg.framecolor, inspectable = false)
     translate!(bg, 0, 0, -7) # bg behind patches but before content at 0 (legend is at +10)
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1187,6 +1187,8 @@ const EntryGroup = Tuple{Any, Vector{LegendEntry}}
         padding = (10f0, 10f0, 8f0, 8f0)
         "The additional space between the legend and its suggested boundingbox."
         margin = (0f0, 0f0, 0f0, 0f0)
+        "The background color of the legend. DEPRECATED - use `backgroundcolor` instead."
+        bgcolor = nothing
         "The background color of the legend."
         backgroundcolor = :white
         "The color of the legend border."

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1188,7 +1188,7 @@ const EntryGroup = Tuple{Any, Vector{LegendEntry}}
         "The additional space between the legend and its suggested boundingbox."
         margin = (0f0, 0f0, 0f0, 0f0)
         "The background color of the legend."
-        bgcolor = :white
+        backgroundcolor = :white
         "The color of the legend border."
         framecolor = :black
         "The line width of the legend border."

--- a/src/themes/theme_black.jl
+++ b/src/themes/theme_black.jl
@@ -16,7 +16,7 @@ function theme_black()
         ),
         Legend = (
             framecolor = :white,
-            bgcolor = :black,
+            backgroundcolor = :black,
         ),
         Axis3 = (
             xgridcolor = RGBAf(1, 1, 1, 0.16),


### PR DESCRIPTION
# Description

Fixes #2101 

This PR renames the kwarg `bgcolor` in `Legend` to `backgroundcolor` to be consistent with usage in `Axis` and `Figure`.

## Type of change

- Breaking but with deprecation warning ?

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
