### PR TITLE
Fix WGLMakie's README code snippet for JSServe

### DIFF
--- a/WGLMakie/README.md
+++ b/WGLMakie/README.md
@@ -15,7 +15,7 @@ You can also embed plots in a JSServe webpage:
 
 ```julia
 using JSServe
-app = App(session, request)
+app = App() do session, request
     return DOM.div(
         DOM.h1("Some Makie Plots:"),
         meshscatter(1:4, color=1:4),
@@ -23,7 +23,7 @@ app = App(session, request)
         meshscatter(1:4, color=rand(RGBf, 4)),
         meshscatter(1:4, color=:red),
         meshscatter(rand(Point3f, 10), color=rand(RGBf, 10)),
-        meshscatter(rand(Point3f, 10), marker=Pyramid(Point3f(0), 1f0, 1f0)),
+        meshscatter(rand(Point3f, 10), marker=WGLMakie.Pyramid(Point3f(0), 1f0, 1f0)),
     )
 end
 isdefined(Main, :server) && close(server)


### PR DESCRIPTION
It didn't work before. Needed to add the missing `do`, and `Pyramid` is not exported so it required `WGLMakie.Pyramid`.