### PR TITLE
correctly construct Attributes in get_axis

### DIFF
--- a/src/figureplotting.jl
+++ b/src/figureplotting.jl
@@ -40,7 +40,7 @@ function get_axis(fig, P, axis_kw::Dict, plot_attr, plot_args)
         delete!(plot_attr, :show_axis)
         delete!(plot_attr, :limits)
         delete!(plot_attr, :color) # Color may contain Cycled(1), which needs the axis to get resolved to a color
-        plot!(proxyscene, P, Attributes(plot_attr), plot_args...)
+        plot!(proxyscene, P, Attributes(;plot_attr...), plot_args...)
         if is2d(proxyscene)
             ax = Axis(fig; axis_kw...)
         else


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/GraphMakie.jl/issues/142

During `get_axis`, the Attributes for the plot recipe are constructed in a "wrong" way, in which nested attributes do not work as expected. I.e. named tuples in the Attributes become `Observable{Any}` instead of nested `Attributes` objects.

Was introduced in Makie@0.19.11 as part of #3275

MWE:
```julia
using Makie
@recipe(MyPlot, p) do scene
   Attributes(
       nt = (;)
   )
end
function Makie.plot!(mp::MyPlot)
    p = mp[:p]
    @show mp[:not] # see how it looks like in the recipe
    scatter!(mp, p)
end
```
```julia
julia> fig, a, p = myplot(rand(10); nt=(;named=:tuple))
mp[:nt] = Observable{Any}((named = :tuple,)) # "warmup" run
mp[:nt] = Attributes with 1 entry:           # actual run
  named => tuple
```

Not sure if the splat of the dict is the best way to solve this, suggestions welcome. On a different note: it might be nice to pass another attribute, such as `_warmup=true` to the recipe. `GraphMakie` could skip the (possibly expensive) layout algorithm in the warmup run...

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
