### PR TITLE
try old JSServe

### DIFF
--- a/.github/workflows/wglmakie.yaml
+++ b/.github/workflows/wglmakie.yaml
@@ -45,7 +45,7 @@ jobs:
           using Pkg;
           # dev mono repo versions
           pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests"
-          pkg"pin JSServe@2.2.10"
+          pkg"add JSServe@2.2.10"
       - name: Run the tests
         continue-on-error: true
         run: >

--- a/.github/workflows/wglmakie.yaml
+++ b/.github/workflows/wglmakie.yaml
@@ -45,6 +45,7 @@ jobs:
           using Pkg;
           # dev mono repo versions
           pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests"
+          pkg"pin JSServe@2.2.10"
       - name: Run the tests
         continue-on-error: true
         run: >

--- a/.github/workflows/wglmakie.yaml
+++ b/.github/workflows/wglmakie.yaml
@@ -45,7 +45,7 @@ jobs:
           using Pkg;
           # dev mono repo versions
           pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests"
-          pkg"add JSServe@2.2.10"
+          pkg"add JSServe#sd/debug-wgl"
       - name: Run the tests
         continue-on-error: true
         run: >

--- a/WGLMakie/test/Project.toml
+++ b/WGLMakie/test/Project.toml
@@ -6,7 +6,3 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ReferenceTests = "d37af2e0-5618-4e00-9939-d430db56ee94"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-
-[compat]
-JSServe = "2.2.10"

--- a/WGLMakie/test/Project.toml
+++ b/WGLMakie/test/Project.toml
@@ -6,3 +6,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ReferenceTests = "d37af2e0-5618-4e00-9939-d430db56ee94"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+
+[compat]
+JSServe = "2.2.10"


### PR DESCRIPTION
I have no idea how the new JSServe could make WGLMakie  fail only on the CI, but that the failure popped up after the release is pretty suspicious.
