### PR TITLE
Improve default near/far

### DIFF
--- a/docs/explanations/cameras.md
+++ b/docs/explanations/cameras.md
@@ -62,7 +62,7 @@ ez = Point3f(0,0,1)
 
 fig = Figure()
 scene = LScene(fig[1, 1])
-cc = Makie.Camera3D(scene.scene, projectiontype = Makie.Perspective, far = 3.0)
+cc = Makie.Camera3D(scene.scene, projectiontype = Makie.Perspective)
 
 linesegments!(scene, Rect3f(Point3f(-1), Vec3f(2)), color = :black)
 linesegments!(scene,
@@ -70,7 +70,7 @@ linesegments!(scene,
     color = [:red, :red, :green, :green, :blue, :blue]
 )
 center!(scene.scene)
-    
+
 cam = scene.scene.camera
 eyeposition = cc.eyeposition
 lookat = cc.lookat

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -13,11 +13,12 @@ struct Camera3D <: AbstractCamera3D
     eyeposition::Observable{Vec3f}
     lookat::Observable{Vec3f}
     upvector::Observable{Vec3f}
-	
+
     # perspective projection matrix
     fov::Observable{Float32}
     near::Observable{Float32}
     far::Observable{Float32}
+    bounding_sphere::Observable{Sphere{Float32}}
 end
 
 """
@@ -37,6 +38,7 @@ Settings include anything that isn't a mouse or keyboard button.
 - `fixed_axis = true`: If true panning uses the (world/plot) z-axis instead of the camera up direction.
 - `zoom_shift_lookat = true`: If true keeps the data under the cursor when zooming.
 - `cad = false`: If true rotates the view around `lookat` when zooming off-center.
+- `clipping_mode = :bbox_relative`: Controls how `near` and `far` get processed. With `:static` with get passed as is, with `:view_relative` they get scaled by `norm(eyeposition - lookat)` and with `:bbox_relative` they get scaled such that `far = 1` is at or behind the furthest point of the scene bounding box.
 
 - `keyboard_rotationspeed = 1f0` sets the speed of keyboard based rotations.
 - `keyboard_translationspeed = 0.5f0` sets the speed of keyboard based translations.
@@ -91,11 +93,11 @@ Some keyword arguments are used to initialize fields. These include
 - `upvector = Vec3f(0, 0, 1)`: The world direction corresponding to the up direction of the screen.
 
 - `fov = 45.0` is the field of view. This is irrelevant if the camera uses an orthographic projection.
-- `near = 0.1` sets the position of the near clip plane relative to `eyeposition - lookat`. Must be greater 0. Anything between the camera and the near clip plane is hidden.
-- `far = 10.0` sets the position of the far clip plane relative to `eyeposition - lookat`. Anything further away than the far clip plane is hidden.
+- `near = 0.01` sets the position of the near clip plane. Anything between the camera and the near clip plane is hidden. Must be greater 0. Usage depends on `clipping_mode`.
+- `far = automatic` sets the position of the far clip plane. Anything further away than the far clip plane is hidden. Usage depends on `clipping_mode`. Defaults to `1` for `clipping_mode = :bbox_relative`, `2` for `:view_relative` or a value derived from limits for `:static`.
 
 Note that updating these observables in an active camera requires a call to `update_cam(scene)`
-for them to be applied. For updating `eyeposition`, `lookat` and/or upvector 
+for them to be applied. For updating `eyeposition`, `lookat` and/or upvector
 `update_cam!(scene, eyeposition, lookat, upvector = Vec3f(0,0,1))` is preferred.
 
 The camera position and orientation can also be adjusted via the functions
@@ -150,20 +152,29 @@ function Camera3D(scene::Scene; kwargs...)
         mouse_rotationspeed = 1f0,
         mouse_translationspeed = 1f0,
         mouse_zoomspeed = 1f0,
-        
+
         projectiontype = Makie.Perspective,
         circular_rotation = (true, true, true),
         rotation_center = :lookat,
         update_rate = 1/30,
         zoom_shift_lookat = true,
         fixed_axis = true,
-        cad = false
+        cad = false,
+        clipping_mode = :bbox_relative
     )
 
     replace!(settings, :Camera3D, scene, overwrites)
 
+    if settings.clipping_mode[] === :view_relative
+        far_default = 2f0
+    elseif settings.clipping_mode[] === :bbox_relative
+        far_default = 1f0
+    else
+        far_default = 10f0 # will be set when inserting a plot
+    end
+
     cam = Camera3D(
-        settings, controls, 
+        settings, controls,
 
         # Internals - controls
         Observable(-1.0),
@@ -177,7 +188,8 @@ function Camera3D(scene::Scene; kwargs...)
         # Semi-Internal - projection matrix
         get(overwrites, :fov, Observable(45.0)),
         get(overwrites, :near, Observable(0.01)),
-        get(overwrites, :far, Observable(100.0)),
+        get(overwrites, :far, Observable(far_default)),
+        Sphere(Point3f(0), 1f0)
     )
 
     disconnect!(camera(scene))
@@ -201,7 +213,7 @@ function Camera3D(scene::Scene; kwargs...)
         :pan_left_key, :pan_right_key, :tilt_up_key, :tilt_down_key,
         :roll_clockwise_key, :roll_counterclockwise_key
     )
-    
+
     # Start ticking if relevant keys are pressed
     on(camera(scene), events(scene).keyboardbutton) do event
         if event.action in (Keyboard.press, Keyboard.repeat) && cam.pulser[] == -1.0 &&
@@ -257,7 +269,7 @@ end
 """
     cam3d!(scene[; kwargs...])
 
-Creates a `Camera3D` with `zoom_shift_lookat = true` and `fixed_axis = true`. 
+Creates a `Camera3D` with `zoom_shift_lookat = true` and `fixed_axis = true`.
 For more information, see [`Camera3D``](@ref)
 """
 cam3d!(scene; zoom_shift_lookat = true, fixed_axis = true, kwargs...) =
@@ -266,7 +278,7 @@ cam3d!(scene; zoom_shift_lookat = true, fixed_axis = true, kwargs...) =
 """
     cam3d_cad!(scene[; kwargs...])
 
-Creates a `Camera3D` with `cad = true`, `zoom_shift_lookat = false` and 
+Creates a `Camera3D` with `cad = true`, `zoom_shift_lookat = false` and
 `fixed_axis = false`. For more information, see [`Camera3D``](@ref)
 """
 cam3d_cad!(scene; cad = true, zoom_shift_lookat = false, fixed_axis = false, kwargs...) =
@@ -313,8 +325,8 @@ function on_pulse(scene, cam::Camera3D, timestep)
             viewnorm = norm(cam.lookat[] - cam.eyeposition[])
             xynorm = 2 * viewnorm * tand(0.5 * cam.fov[])
             translation = keyboard_translationspeed * timestep * Vec3f(
-                xynorm * (right - left), 
-                xynorm * (up - down), 
+                xynorm * (right - left),
+                xynorm * (up - down),
                 viewnorm * (backward - forward)
             )
         else
@@ -377,7 +389,7 @@ end
 function add_mouse_controls!(scene, cam::Camera3D)
     @extract cam.controls (translation_button, rotation_button, reposition_button, scroll_mod)
     @extract cam.settings (
-        mouse_translationspeed, mouse_rotationspeed, mouse_zoomspeed, 
+        mouse_translationspeed, mouse_rotationspeed, mouse_zoomspeed,
         cad, projectiontype, zoom_shift_lookat
     )
 
@@ -422,7 +434,7 @@ function add_mouse_controls!(scene, cam::Camera3D)
                 dragging[] = (false, false)
                 translate_cam!(scene, cam, mouse_translationspeed[] .* Vec3f(diff[1], diff[2], 0f0))
                 consume = true
-            elseif dragging[][2] 
+            elseif dragging[][2]
                 mousepos = mouseposition_px(scene)
                 dragging[] = (false, false)
                 rot_scaling = mouse_rotationspeed[] * (e.window_dpi[] * 0.005)
@@ -436,9 +448,9 @@ function add_mouse_controls!(scene, cam::Camera3D)
             if ispressed(scene, reposition_button[], event.button) && is_mouseinside(scene)
                 plt, _, p = ray_assisted_pick(scene)
                 if p !== Point3f(NaN) && to_value(get(plt, :space, :data)) == :data && parent_scene(plt) == scene
-                    # if translation/rotation happens with on-click reposition, 
+                    # if translation/rotation happens with on-click reposition,
                     # try uncommenting this
-                    # dragging[] = (false, false) 
+                    # dragging[] = (false, false)
                     shift = p - cam.lookat[]
                     update_cam!(scene, cam, cam.eyeposition[] + shift, p)
                 end
@@ -493,10 +505,10 @@ end
 """
     translate_cam!(scene, cam::Camera3D, v::Vec3)
 
-Translates the camera by the given vector in camera space, i.e. by `v[1]` to 
+Translates the camera by the given vector in camera space, i.e. by `v[1]` to
 the right, `v[2]` to the top and `v[3]` forward.
 
-Note that this method reacts to `fix_x_key` etc. If any of those keys are 
+Note that this method reacts to `fix_x_key` etc. If any of those keys are
 pressed the translation will be restricted to act in these directions.
 """
 function translate_cam!(scene, cam::Camera3D, t::VecTypes)
@@ -508,12 +520,12 @@ end
 """
     rotate_cam!(scene, cam::Camera3D, angles::Vec3)
 
-Rotates the camera by the given `angles` around the camera x- (left, right), 
-y- (up, down) and z-axis (in out). The rotation around the y axis is applied 
+Rotates the camera by the given `angles` around the camera x- (left, right),
+y- (up, down) and z-axis (in out). The rotation around the y axis is applied
 first, then x, then y.
 
-Note that this method reacts to `fix_x_key` etc and `fixed_axis`. The former 
-restrict the rotation around a specific axis when a given key is pressed. The 
+Note that this method reacts to `fix_x_key` etc and `fixed_axis`. The former
+restrict the rotation around a specific axis when a given key is pressed. The
 latter keeps the camera y axis fixed as the data space z axis.
 """
 function rotate_cam!(scene, cam::Camera3D, angles::VecTypes, from_mouse=false)
@@ -530,10 +542,10 @@ zoom!(scene, zoom_step) = zoom!(scene, cameracontrols(scene), zoom_step, false, 
 Zooms the camera in or out based on the multiplier `zoom_step`. A `zoom_step`
 of 1.0 is neutral, larger zooms out and lower zooms in.
 
-If `cad = true` zooming will also apply a rotation based on how far the cursor 
-is from the center of the scene. If `zoom_shift_lookat = true` and 
+If `cad = true` zooming will also apply a rotation based on how far the cursor
+is from the center of the scene. If `zoom_shift_lookat = true` and
 `projectiontype = Orthographic` zooming will keep the data under the cursor at
-the same screen space position. 
+the same screen space position.
 """
 function zoom!(scene, cam::Camera3D, zoom_step, cad = false, zoom_shift_lookat = false)
     _zoom!(scene, cam, zoom_step, cad, zoom_shift_lookat)
@@ -594,7 +606,7 @@ function _rotate_cam!(scene, cam::Camera3D, angles::VecTypes, from_mouse=false)
     rotation = Quaternionf(0, 0, 0, 1)
     if !xor(fix_x, fix_y, fix_z)
         # if there are more or less than one restriction apply all rotations
-        # Note that the y rotation needs to happen first here so that 
+        # Note that the y rotation needs to happen first here so that
         # fixed_axis = true actually keeps the the axis fixed.
         rotation *= qrotation(y_axis, angles[2])
         rotation *= qrotation(x_axis, angles[1])
@@ -643,7 +655,7 @@ function _zoom!(scene, cam::Camera3D, zoom_step, cad = false, zoom_shift_lookat 
     lookat = cam.lookat[]
     eyepos = cam.eyeposition[]
     viewdir = lookat - eyepos   # -z
-    
+
     if cad
         # Rotate view based on offset from center
         u_z = normalize(viewdir)
@@ -664,12 +676,12 @@ function _zoom!(scene, cam::Camera3D, zoom_step, cad = false, zoom_shift_lookat 
         ws = widths(scene.px_area[])
         rel_pos = (2.0 .* mouseposition_px(scene) .- ws) ./ ws[2]
         shift = (1 - zoom_step) * (rel_pos[1] * u_x + rel_pos[2] * u_y)
-        
+
         if cam.settings.projectiontype[] == Makie.Orthographic
             scale = norm(viewdir)
         else
             # With perspective projection depth scales shift, but there is no way
-            # to tell which depth the user may want to keep in view. So we just 
+            # to tell which depth the user may want to keep in view. So we just
             # assume it's the same depth as "lookat".
             scale = norm(viewdir) * tand(0.5 * cam.fov[])
         end
@@ -692,17 +704,27 @@ end
 
 # Update camera matrices
 function update_cam!(scene::Scene, cam::Camera3D)
-    @extractvalue cam (lookat, eyeposition, upvector, near, far, fov)
+    @extractvalue cam (lookat, eyeposition, upvector, near, far, fov, bounding_sphere)
 
     view = Makie.lookat(eyeposition, lookat, upvector)
 
+    if cam.settings.clipping_mode[] === :view_relative
+        scale = norm(eyeposition - lookat)
+    elseif cam.settings.clipping_mode[] === :bbox_relative
+        scale = radius(bounding_sphere) + norm(eyeposition - origin(bounding_sphere))
+    elseif cam.settings.clipping_mode[] === :static
+        scale = 1f0
+    else
+        @error "clipping_mode = $(cam.settings.clipping_mode[]) not recognized, using :static."
+        scale = 1f0
+    end
+
     aspect = Float32((/)(widths(scene.px_area[])...))
     if cam.settings.projectiontype[] == Makie.Perspective
-        view_norm = norm(eyeposition - lookat)
-        proj = perspectiveprojection(fov, aspect, view_norm * near, view_norm * far)
+        proj = perspectiveprojection(fov, aspect, scale * near,  scale * far)
     else
         h = norm(eyeposition - lookat); w = h * aspect
-        proj = orthographicprojection(-w, w, -h, h, h * near, h * far)
+        proj = orthographicprojection(-w, w, -h, h, scale * near, scale * far)
     end
 
     set_proj_view!(camera(scene), proj, view)
@@ -715,18 +737,25 @@ end
 function update_cam!(scene::Scene, cam::Camera3D, area3d::Rect)
     bb = Rect3f(area3d)
     width = widths(bb)
-    center = maximum(bb) - 0.5 * width
+    center = maximum(bb) - 0.5f0 * width
+    radius = 0.5f0 * norm(width)
+    cam.bounding_sphere[] = Sphere(Point3f(center), radius)
 
     old_dir = normalize(cam.eyeposition[] .- cam.lookat[])
     if cam.settings.projectiontype[] == Makie.Perspective
-        dist = 0.5 * norm(width) / tand(0.5 * cam.fov[])
+        dist = radius / tand(0.5f0 * cam.fov[])
     else
-        dist = 0.5 * norm(width)
+        dist = radius
     end
 
     cam.lookat[] = center
     cam.eyeposition[] = cam.lookat[] .+ dist * old_dir
     cam.upvector[] = Vec3f(0, 0, 1) # Should we reset this?
+
+    if cam.settings.clipping_mode[] === :static
+        cam.near[] = 0.01f0 * dist
+        cam.far[] = 2f0 * dist
+    end
 
     update_cam!(scene, cam)
 
@@ -748,10 +777,10 @@ update_cam!(scene::Scene, args::Real...) = update_cam!(scene, cameracontrols(sce
     update_cam!(scene, cam::Camera3D, ϕ, θ[, radius])
 
 Set the camera position based on two angles `0 ≤ ϕ ≤ 2π` and `-pi/2 ≤ θ ≤ pi/2`
-and an optional radius around the current `cam.lookat[]`. 
+and an optional radius around the current `cam.lookat[]`.
 """
 function update_cam!(
-        scene::Scene, camera::Camera3D, phi::Real, theta::Real, 
+        scene::Scene, camera::Camera3D, phi::Real, theta::Real,
         radius::Real = norm(camera.eyeposition[] - camera.lookat[]),
         center = camera.lookat[]
     )


### PR DESCRIPTION
# Description

In the original camera3d pr I changed near/far to be multiplied by `norm(eyeposition - lookat)` and set the default far to be very large to avoid clipping issues. This is problematic for OIT where depth is used to mix colors because without zooming plots occupy a very small depth range.

To summarize the issues with clipping:
- when zooming in (i.e. looking at details) a static `near` value will eventually become large relative to the limits one looks at. This will cause data to be clipped starting from the camera
- when zooming out a static `far` value will eventually clip the far side of the plot. This usually starts with the axis frame/grid disappearing

This pr makes static near/far values available again and adds a new (default) scaling mode which scales  `far` so that `far = 1` always ends up behind the scene bounding sphere, and calculates `near` to be just in front of it, but no closer than `norm(lookat - eyeposition) * near` (to avoid negative near). This continues to solve the clipping issues as `near` effectively scales with zooming, `far` is always outside/behind the region containing data, and it should improve OIT again by keeping the depth scale close to the minimum necessary.

### Camera setup from the OIT refimg test (scene area not matched exactly)

<details>

<summary> Code </summary>

```julia
begin
    using GLMakie
    using GeometryBasics, LinearAlgebra

    function frustum_snapshot(cam)
        r = Rect3f(Point3f(-1, -1, -1), Vec3f(2, 2, 2))
        rect_ps = coordinates(r) .|> Point3f
        insert!(rect_ps, 13, Point3f(1, -1, 1)) # fix bad line

        inv_pv = inv(cam.projectionview[])
        return map(rect_ps) do p
            p = inv_pv * to_ndim(Point4f, p, 1)
            return p[Vec(1,2,3)] / p[4]
        end
    end


    ex = Point3f(1,0,0)
    ey = Point3f(0,1,0)
    ez = Point3f(0,0,1)
end

begin
    fig = Figure()
    ax = LScene(fig[1, 1])
    cam3d!(ax.scene)
    r = Rect2f(-1, -1, 2, 2)
    for x in (0, 1)
        for (i, a) in enumerate((0.25, 0.5, 0.75, 1.0))
            ps = [Point3f(a, (0.15 + 0.01y)*(2x-1) , 0.2y) for y in 1:8]
            if x == 0
                cs = [RGBAf(1, 0, 0, 0.75), RGBAf(0, 1, 0, 0.5), RGBAf(0, 0, 1, 0.25)]
            elseif x == 1
                cs = [RGBAf(1, x, 0, a), RGBAf(0, 1, x, a), RGBAf(x, 0, 1, a)]
            end
            idxs = [1, 2, 3, 2, 1, 3, 1, 2, 1, 2, 3][i:7+i]
            meshscatter!(
                ax, ps, marker = r,
                color = cs[idxs], transparency = true
            )
        end
    end
    cc = cameracontrols(ax.scene)
    cc.fov[] = 22f0
    update_cam!(ax.scene, cc, Vec3f(0.625, 0, 3.5), Vec3f(0.625, 0, 0), Vec3f(0, 1, 0))

    scene = ax.scene
    cam = scene.camera
    eyeposition = cc.eyeposition
    lookat = cc.lookat
    frustum = map(pv -> frustum_snapshot(cam), cam.projectionview)

    scene2 = LScene(fig[1, 2])
    _cc = Makie.Camera3D(scene2.scene, projectiontype = Makie.Orthographic)
    lines!(scene2, frustum, color = :blue, linestyle = :dot)
    scatter!(scene2, eyeposition, color = :black)
    scatter!(scene2, lookat, color = :black)

    r = Rect2f(-1, -1, 2, 2)
    for x in (0, 1)
        for (i, a) in enumerate((0.25, 0.5, 0.75, 1.0))
            ps = [Point3f(a, (0.15 + 0.01y)*(2x-1) , 0.2y) for y in 1:8]
            if x == 0
                cs = [RGBAf(1, 0, 0, 0.75), RGBAf(0, 1, 0, 0.5), RGBAf(0, 0, 1, 0.25)]
            elseif x == 1
                cs = [RGBAf(1, x, 0, a), RGBAf(0, 1, x, a), RGBAf(x, 0, 1, a)]
            end
            idxs = [1, 2, 3, 2, 1, 3, 1, 2, 1, 2, 3][i:7+i]
            meshscatter!(
                scene2, ps, marker = r,
                color = cs[idxs], transparency = true
            )
        end
    end
    linesegments!(scene2, data_limits(scene), color = :black)

    r = map(frustum) do frustum
        r = Rect3f(frustum)
        Rect2f(origin(r)[Vec(1,2)], widths(r)[Vec(1,2)])
        # Rect3f(frustum)
    end
    m = mesh!(scene2, r, color = :lightblue)
    on(frustum) do frustum
        x, y, z = minimum(Rect3f(frustum))
        translate!(m, Vec3f(0, 0, z))
    end
    notify(frustum)

    fig
end
```

</details>

![Screenshot from 2023-10-13 20-30-59](https://github.com/MakieOrg/Makie.jl/assets/10947937/3dd3dabd-93d3-4429-9da1-3a159a10ca5d)

For reference, this is from master:

![Screenshot from 2023-10-13 16-28-16](https://github.com/MakieOrg/Makie.jl/assets/10947937/c5e8ec42-b261-4b08-bd94-e498b05faaf7)

And this from beta-20:

![Screenshot from 2023-10-13 16-33-23](https://github.com/MakieOrg/Makie.jl/assets/10947937/f3d5c036-50e1-4cf5-abaf-802b65cf0b82)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
