### PR TITLE
Add entry about how to trouble shoot GLMakie crashing on macOS

### DIFF
--- a/docs/explanations/backends/glmakie.md
+++ b/docs/explanations/backends/glmakie.md
@@ -73,3 +73,9 @@ Troubleshooting:
 2.) WSL has some problems with passing through localhost, so one may need to use: `export DISPLAY=192.168.178.31:0`, with the local ip of the pcs network adapter, which runs VcXsrv
 
 3.) One may need `mv /opt/julia-1.5.2/lib/julia/libstdc++.so.6 /opt/julia-1.5.2/lib/julia/libcpp.backup`, another form of [GLFW#198](https://github.com/JuliaGL/GLFW.jl/issues/198)
+
+## GLMakie does not show Figure or crashes on full screen mode on macOS
+
+MacOS gives a warning if a graphical user interface (GUI) is not started from an AppBundle and this exception can crash the Julia process that initiated the GUI. 
+This warning only occurs if macOS Settings->Desktop & Dock->Menu Bar->Automatically hide and show the menu bar is not set to Never.
+Therefore make sure this setting is set to `Never` to enable the use of GLMakie on macOS.


### PR DESCRIPTION
This should be fixing #2629 by providing a better documentation about how to circumvent the problem.


