### PR TITLE
Global figure time

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -931,3 +931,5 @@ function plot2robjs(screen::Screen, plot)
 end
 
 export plot2robjs
+
+render_tick(screen::Screen) = screen.render_tick

--- a/src/display.jl
+++ b/src/display.jl
@@ -161,7 +161,7 @@ function Base.display(figlike::FigureLike; backend=current_backend(),
         screen = getscreen(backend, scene; screen_config...)
 
         if figlike isa Figure
-            sync_global_time(figlike, screen.render_tick)
+            sync_global_time(figlike, render_tick(screen))
         end
 
         display(screen, scene)

--- a/src/display.jl
+++ b/src/display.jl
@@ -159,11 +159,12 @@ function Base.display(figlike::FigureLike; backend=current_backend(),
         scene = get_scene(figlike)
         update && update_state_before_display!(figlike)
         screen = getscreen(backend, scene; screen_config...)
-        display(screen, scene)
-    end
 
-    if figlike isa Figure
-        notify(figlike.displayed)
+        if figlike isa Figure
+            sync_global_time(figlike, screen.render_tick)
+        end
+
+        display(screen, scene)
     end
 
     return screen

--- a/src/display.jl
+++ b/src/display.jl
@@ -140,13 +140,13 @@ function Base.display(figlike::FigureLike; backend=current_backend(),
         """)
     end
 
+
     # We show inline if explicitely requested or if automatic and we can actually show something inline!
     if (inline === true || inline === automatic) && can_show_inline(backend)
         Core.invoke(display, Tuple{Any}, figlike)
         # In WGLMakie, we need to wait for the display being done
         screen = getscreen(get_scene(figlike))
         wait_for_display(screen)
-        return screen
     else
         if inline === true
             @warn """
@@ -160,8 +160,13 @@ function Base.display(figlike::FigureLike; backend=current_backend(),
         update && update_state_before_display!(figlike)
         screen = getscreen(backend, scene; screen_config...)
         display(screen, scene)
-        return screen
     end
+
+    if figlike isa Figure
+        notify(figlike.displayed)
+    end
+
+    return screen
 end
 
 is_displayed(screen::MakieScreen, scene::Scene) = screen in scene.current_screens

--- a/src/interaction/events.jl
+++ b/src/interaction/events.jl
@@ -33,6 +33,7 @@ end
 
 to_native(window::MakieScreen) = error("to_native(window) not implemented for $(typeof(window)).")
 disconnect!(window::MakieScreen, signal) = disconnect!(to_native(window), signal)
+render_tick(::MakieScreen) = Observable(nothing)
 
 function disconnect_screen(scene::Scene, screen)
     e = events(scene)

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -611,7 +611,6 @@ struct Figure
     attributes::Attributes
     current_axis::Ref{Any}
     time::Observable
-    displayed::Base.Event
 
     function Figure(args...)
         f = new(args...)

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -610,6 +610,8 @@ struct Figure
     content::Vector
     attributes::Attributes
     current_axis::Ref{Any}
+    time::Observable
+    displayed::Base.Event
 
     function Figure(args...)
         f = new(args...)


### PR DESCRIPTION
# Description

Implement a global figure time that is incremented when the figure is displayed. This allow to have some animation shown when the GLMakie windows shows up for example and to have everything in sync across the figure.

For example with this PR
```julia
using GLMakie

begin
    fig = Figure()

    axs = [Axis(fig[i, j]) for i in 1:2, j in 1:2]
    xlims = [[-1.2, 0], [0, 1.2]]
    ylims = [[0, 1.2], [-1.2, 0]]
    wavelengths = [
        5 8
        11 14
    ]
    ω = 0.3
    θs = range(0, 2π ; length = 1000)

    for i in 1:2 
        for j in 1:2
            ax = axs[i, j]
            xlims!(ax, xlims[j])
            ylims!(ax, ylims[i])
            w = wavelengths[i, j]

            ρs = @lift [sin(w * (θ + ω * $(fig.time))) for θ in θs]
            xx = @lift $ρs .* cos.(θs)
            yy = @lift $ρs .* sin.(θs)

            lines!(ax, xx, yy)
        end
    end
    
    fig
end

record(fig, "flower.gif", 1:240) do i
    fig.time[] = i/24
end
```
Gives (whenever the figure is displayed)
![flower](https://github.com/MakieOrg/Makie.jl/assets/17861033/df09a2c2-f8e2-4487-a966-db772a760eea)

Documentation will be straightforward once we are set on the semantic, but I have no idea if it would be possible to have the feature tested.

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
