### PR TITLE
don't append screens

### DIFF
--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -103,6 +103,7 @@ end
     screen = display(fig)
     empty!(fig)
     @test screen in fig.scene.current_screens
+    @test length(fig.scene.current_screens) == 1
     @testset "all got freed" begin
         for (_, _, robj) in screen.renderlist
             for (k, v) in robj.uniforms

--- a/src/figures.jl
+++ b/src/figures.jl
@@ -183,10 +183,7 @@ function resize_to_layout!(fig::Figure)
 end
 
 function Base.empty!(fig::Figure)
-    screens = copy(fig.scene.current_screens)
     empty!(fig.scene)
-    # The empty! api doesn't gracefully handle screens for e.g. the figure scene which is supposed to be still used!
-    append!(fig.scene.current_screens, screens)
     empty!(fig.scene.events)
     foreach(GridLayoutBase.remove_from_gridlayout!, reverse(fig.layout.content))
     trim!(fig.layout)


### PR DESCRIPTION
I think we had this there, because `empty!` was emptying `current_screens` at some point, but then we factored that out into `free`, so now it would just grow `current_screens` every time you used `empty!(fig)`.
Fixes: https://discourse.julialang.org/t/how-to-efficiently-empty-makie-figure-delete-widgets/103612/19