### PR TITLE
fix bezier construction for strings starting with m

### DIFF
--- a/docs/reference/plots/scatter.md
+++ b/docs/reference/plots/scatter.md
@@ -243,7 +243,7 @@ scatter(1:5,
 #### Construction from svg path strings
 
 You can also create a bezier path from an [svg path specification string](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#path_commands).
-You can automatically resize the path and flip the y- and x-axes (svgs usually have a coordinate system where y increases downwards) with the keywords `fit`, `yflip`, and `xflip`.
+You can automatically resize the path and flip the y- and x-axes (svgs usually have a coordinate system where y increases downwards) with the keywords `fit`, `flipy`, and `flipx`.
 By default, the bounding box for the fitted path is a square of width 1 centered on zero.
 You can pass a different bounding `Rect` with the `bbox` keyword argument.
 By default, the aspect of the path is left intact, and if it's not matching the new bounding box, the path is centered so it fits inside.

--- a/test/bezier.jl
+++ b/test/bezier.jl
@@ -3,8 +3,8 @@ using Makie, Test
 # nice reference: https://www.nan.fyi/svg-paths
 @testset "BezierPath construction" begin
     @test_nowarn BezierPath("m 0,9 L 0,5138 0,9 z")
-    @test_broken BezierPath("m 0,1e-5 L 0,5138 0,9 z")
+    @test_broken BezierPath("m 0,1e-5 L 0,5138 0,9 z") isa BezierPath
     @test_nowarn BezierPath("M 100,100 C 100,200 200,100 200,200 z")
-    @test_broken BezierPath("M 100,100 Q 50,150,100,100 z")
-    @test_broken BezierPath("M 3.0 10.0 A 10.0 7.5 0.0 0.0 0.0 20.0 15.0 z")
+    @test_broken BezierPath("M 100,100 Q 50,150,100,100 z") isa BezierPath
+    @test_broken BezierPath("M 3.0 10.0 A 10.0 7.5 0.0 0.0 0.0 20.0 15.0 z") isa BezierPath
 end

--- a/test/bezier.jl
+++ b/test/bezier.jl
@@ -1,0 +1,10 @@
+using Makie, Test
+
+# nice reference: https://www.nan.fyi/svg-paths
+@testset "BezierPath construction" begin
+    @test_nowarn BezierPath("m 0,9 L 0,5138 0,9 z")
+    @test_broken BezierPath("m 0,1e-5 L 0,5138 0,9 z")
+    @test_nowarn BezierPath("M 100,100 C 100,200 200,100 200,200 z")
+    @test_broken BezierPath("M 100,100 Q 50,150,100,100 z")
+    @test_broken BezierPath("M 3.0 10.0 A 10.0 7.5 0.0 0.0 0.0 20.0 15.0 z")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,4 +35,5 @@ using Makie: volume
     include("ray_casting.jl")
     include("PolarAxis.jl")
     include("barplot.jl")
+    include("bezier.jl")
 end


### PR DESCRIPTION
# Description

Before this `BezierPath("m 0,9 11289,0 0,5129 L 0,5138 0,9 z")` would error on trying to access the empty `command` array.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
