### PR TITLE
Histogram: fix a bug when data changes to allequal values

### DIFF
--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -144,7 +144,7 @@ function pick_hist_edges(vals, bins)
     if bins isa Int
         mi, ma = float.(extrema(vals))
         if mi == ma
-            return [mi - 0.5, ma + 0.5]
+            return (mi - 0.5):(ma + 0.5)
         end
         # hist is right-open, so to include the upper data point, make the last bin a tiny bit bigger
         ma = nextfloat(ma)

--- a/test/hist.jl
+++ b/test/hist.jl
@@ -1,0 +1,16 @@
+@testset "Histogram plotting" begin
+    unequal_vec = [1; rand(2:9, rand(1:9))]
+    allequal_vec = fill(rand(1:9), rand(1:9))
+    # normal range
+    @test_nowarn hist(0:rand(1:9))
+    # initialize with unequal observable vector
+    v = Observable(unequal_vec)
+    @test_nowarn hist(v)
+    # change to allequal vector
+    @test_nowarn v[] = allequal_vec
+    # initialize with allequal observable vector
+    v = Observable(allequal_vec)
+    @test_nowarn hist(v)
+    # change to unequal vector
+    @test_nowarn v[] = unequal_vec
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,4 +36,5 @@ using Makie: volume
     include("PolarAxis.jl")
     include("barplot.jl")
     include("bezier.jl")
+    include("hist.jl")
 end


### PR DESCRIPTION
# Description

Fixes #2452

When plotting Observables if the contained collection changed such that all values were equal the minimum and maximum values would match causing `pick_hist_edges` to return a vector. This in turn would result in a conversion error if the previous value was a range. This is fixed by simply returning a range instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.
