### PR TITLE
Accept vectors with correct element type

### DIFF
--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -96,7 +96,7 @@ mutable struct Scene <: AbstractScene
     transformation::Transformation
 
     "The plots contained in the Scene."
-    plots::Vector{AbstractPlot}
+    plots::Vector{<:AbstractPlot}
 
     theme::Attributes
 
@@ -112,7 +112,7 @@ mutable struct Scene <: AbstractScene
     backgroundcolor::Observable{RGBAf}
     visible::Observable{Bool}
     ssao::SSAO
-    lights::Vector{AbstractLight}
+    lights::Vector{<:AbstractLight}
     deregister_callbacks::Vector{Observables.ObserverFunction}
 
     function Scene(
@@ -123,14 +123,14 @@ mutable struct Scene <: AbstractScene
             camera::Camera,
             camera_controls::AbstractCamera,
             transformation::Transformation,
-            plots::Vector{AbstractPlot},
+            plots::Vector{<:AbstractPlot},
             theme::Attributes,
             children::Vector{Scene},
             current_screens::Vector{MakieScreen},
             backgroundcolor::Observable{RGBAf},
             visible::Observable{Bool},
             ssao::SSAO,
-            lights::Vector{AbstractLight}
+            lights::Vector{<:AbstractLight}
         )
         scene = new(
             parent,


### PR DESCRIPTION
The previous type restriction prevented, e.g., 
```julia
    lights = [
        PointLight(Vec3f(0, -10, 0), RGBf(radiance, radiance, radiance*1.1))
    ]
```
since this array has a more specific element type than `AbstractLight`. One was thus forced to pass something like

```julia
    lights = Makie.AbstractLight[
        PointLight(Vec3f(0, -10, 0), RGBf(radiance, radiance, radiance*1.1))
    ]
```
which was highly non-obvious.

# Description

Fixes # (issue)

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
