### PR TITLE
change vertical axis with `trimspine == true`

### DIFF
--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -78,8 +78,8 @@ function create_linepoints(
             return [from, to]
         else
             x = position
-            pstart = Point2f(-0.5f0 * tickwidth, 0)
-            pend = Point2f(0.5f0 * tickwidth, 0)
+            pstart = Point2f(0, -0.5f0 * tickwidth)
+            pend = Point2f(0, 0.5f0 * tickwidth)
             from = trimspine[1] ? tickpositions[1] .+ pstart : Point2f(x, extents_oriented[1] - 0.5spine_width)
             to = trimspine[2] ? tickpositions[end] .+ pend : Point2f(x, extents_oriented[2] + 0.5spine_width)
             return [from, to]


### PR DESCRIPTION
To fix issue #2664. Top of the y-axis was displaced half a tickwidth to the right when trimspine was true, rather than being made half a tickwidth longer.

# Description

Fixes #2664

When trimspine is true, the bottom of the y-axis was displaced half a tickwidth to the left and the top half a tickwidth to the right. This changes that to make the axis vertical, and extends each end by half a tickwidth so that the axis aligns with the ends of the tickmarks.

## Type of change

Delete options that do not apply:

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
