### PR TITLE
Histogram: fix a plot updating bug for plot specific attributes

### DIFF
--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -78,8 +78,8 @@ function Makie.plot!(plot::StepHist)
     pop!(attr, :normalization)
     pop!(attr, :scale_to)
     pop!(attr, :bins)
-    # plot the values, not the observables, to be in control of updating
-    stairs!(plot, points[]; attr..., color=color)
+    stairs!(plot, points; attr..., color=color)
+    plot
 end
 
 """
@@ -186,6 +186,9 @@ function Makie.plot!(plot::Hist)
     on(plot, widths) do w
         bp[1].val = points[]
         bp.width = w
+    end
+    onany(plot, plot.normalization, plot.scale_to, plot.weights) do _, _, _
+        bp[1][] = points[]
     end
     plot
 end


### PR DESCRIPTION
# Description

Fixes #3362

This fixes a bug where dynamic changes to histogram specific Observables would fail to cause the histogram plots to update.

For `hist` this was because the plot updating is handled by watching `widths`, but that didn't receive updates whenever the `normalization`, `scale_to`, and `weights` attributes changed. To fix this we now explicitly observe these attributes and set the points whenever they update.

Note that alternatively watching `points` doesn't work; if that's done instead the updating of the histogram breaks in some cases. Also, the Observables themselves are not passed to `barplot!` in order to avoid redundant updates as `points` and `widths` depend upon some of the same Observables.

For the step histogram, the three aforementioned attributes along with `bins` were not being listened to so as a result the plot would fail to update whenever any of these Observables changed. This is fixed by simply passing the `points` Observable instead of the values to `stairs!`.

`stephist` is different compared to `hist` as there's no `widths` so there are no efficiency gains by managing updates separately. Any updates to the four attributes will update `points` here so the plot updating is handled correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
