### PR TITLE
Allow empty! on Axis3 and LScene

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1397,12 +1397,14 @@ function limits!(args...)
     limits!(current_axis(), args...)
 end
 
-function Base.delete!(ax::Axis, plot::AbstractPlot)
+const AxisOrLScene = Union{Axis, Axis3, LScene}
+
+function Base.delete!(ax::AxisOrLScene, plot::AbstractPlot)
     delete!(ax.scene, plot)
     ax
 end
 
-function Base.empty!(ax::Axis)
+function Base.empty!(ax::AxisOrLScene)
     while !isempty(ax.scene.plots)
         delete!(ax, ax.scene.plots[end])
     end


### PR DESCRIPTION
# Description

Fixes #3370

This includes `Axis3` and `LScene` in the allowed argument types for `delete!` and `empty!`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

