### PR TITLE
Don't return false early just because one MIME type isn't displayable

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -110,8 +110,8 @@ end
 can_show_inline(::Missing) = false # no backend
 function can_show_inline(Backend)
     for mime in (MIME"juliavscode/html"(), MIME"text/html"(), MIME"image/png"(), MIME"image/svg+xml"())
-        if backend_showable(Backend.Screen, mime)
-            return has_mime_display(mime)
+        if backend_showable(Backend.Screen, mime) && has_mime_display(mime)
+            return true
         end
     end
     return false


### PR DESCRIPTION
This caused a bug, for example in VSCode Jupyter Notebook mode, where the plot would not be shown inline ever.