### PR TITLE
fix bad limits with rotation (no s) attribute

### DIFF
--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -252,10 +252,11 @@ end
 
 function data_limits(plot::MeshScatter)
     # TODO: avoid mesh generation here if possible
-    @get_attribute plot (marker, markersize, rotations)
+    @get_attribute plot (marker, markersize)
     marker_bb = Rect3f(marker)
     positions = iterate_transformed(plot)
     scales = markersize
+    rotations = to_rotation(to_value(get(plot, :rotation, plot.rotations)))
     # fast path for constant markersize
     if scales isa VecTypes{3} && rotations isa Quaternion
         bb = limits_from_transformed_points(positions)


### PR DESCRIPTION
# Description

Fixes this:

![Screenshot from 2023-11-24 16-19-44](https://github.com/MakieOrg/Makie.jl/assets/10947937/c187e065-bd3f-4594-9344-fa74e3d89e28)

until we either deprecate `rotation` or `rotations` as an attribute (for meshscatter). After:

![Screenshot from 2023-11-24 16-21-06](https://github.com/MakieOrg/Makie.jl/assets/10947937/f1506e58-adcc-4d3b-9a2f-6d45d5ee9d94)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
