### PR TITLE
Fix incorrect limits in h/vlines and h/vspan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## master
 
 - Fixed a bug with h/vlines and h/vspan not correctly resolving transformations [#3418](https://github.com/MakieOrg/Makie.jl/pull/3418)
+- Fixed a bug with h/vlines and h/vspan returning the wrong limits, causing an error in Axis [#3427](https://github.com/MakieOrg/Makie.jl/pull/3427)
 
 ## 0.20.1
 

--- a/src/basic_recipes/hvlines.jl
+++ b/src/basic_recipes/hvlines.jl
@@ -91,17 +91,17 @@ end
 function data_limits(p::HLines)
     scene = parent_scene(p)
     limits = projview_to_2d_limits(scene.camera.projectionview[])
-    xmin = minimum(limits)[1]
-    w = widths(limits)[1]
+    itf = inverse_transform(p.transformation.transform_func[])
+    xmin, xmax = apply_transform.(itf[1], first.(extrema(limits)))
     ymin, ymax = extrema(p[1][])
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(w, ymax - ymin, 0))
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
 end
 
 function data_limits(p::VLines)
     scene = parent_scene(p)
     limits = projview_to_2d_limits(scene.camera.projectionview[])
+    itf = inverse_transform(p.transformation.transform_func[])
     xmin, xmax = extrema(p[1][])
-    ymin = minimum(limits)[2]
-    h = widths(limits)[2]
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, h, 0))
+    ymin, ymax = apply_transform.(itf[2], getindex.(extrema(limits), 2))
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
 end

--- a/src/basic_recipes/hvlines.jl
+++ b/src/basic_recipes/hvlines.jl
@@ -87,3 +87,21 @@ function Makie.plot!(p::Union{HLines, VLines})
     linesegments!(p, line_attributes, points)
     p
 end
+
+function data_limits(p::HLines)
+    scene = parent_scene(p)
+    limits = projview_to_2d_limits(scene.camera.projectionview[])
+    xmin = minimum(limits)[1]
+    w = widths(limits)[1]
+    ymin, ymax = extrema(p[1][])
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(w, ymax - ymin, 0))
+end
+
+function data_limits(p::VLines)
+    scene = parent_scene(p)
+    limits = projview_to_2d_limits(scene.camera.projectionview[])
+    xmin, xmax = extrema(p[1][])
+    ymin = minimum(limits)[2]
+    h = widths(limits)[2]
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, h, 0))
+end

--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -93,19 +93,19 @@ _apply_y_transform(::typeof(identity), v) = v
 function data_limits(p::HSpan)
     scene = parent_scene(p)
     limits = projview_to_2d_limits(scene.camera.projectionview[])
-    xmin = minimum(limits)[1]
-    w = widths(limits)[1]
+    itf = inverse_transform(p.transformation.transform_func[])
+    xmin, xmax = apply_transform.(itf[1], first.(extrema(limits)))
     ymin = minimum(p[1][])
     ymax = maximum(p[2][])
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(w, ymax - ymin, 0))
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
 end
 
 function data_limits(p::VSpan)
     scene = parent_scene(p)
     limits = projview_to_2d_limits(scene.camera.projectionview[])
+    itf = inverse_transform(p.transformation.transform_func[])
     xmin = minimum(p[1][])
     xmax = maximum(p[2][])
-    ymin = minimum(limits)[2]
-    h = widths(limits)[2]
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, h, 0))
+    ymin, ymax = apply_transform.(itf[2], getindex.(extrema(limits), 2))
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
 end

--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -88,3 +88,24 @@ _apply_x_transform(other, v) = error("x transform not defined for transform func
 _apply_y_transform(t::Tuple, v) = apply_transform(t[2], v)
 _apply_y_transform(other, v) = error("y transform not defined for transform function $(typeof(other))")
 _apply_y_transform(::typeof(identity), v) = v
+
+
+function data_limits(p::HSpan)
+    scene = parent_scene(p)
+    limits = projview_to_2d_limits(scene.camera.projectionview[])
+    xmin = minimum(limits)[1]
+    w = widths(limits)[1]
+    ymin = minimum(p[1][])
+    ymax = maximum(p[2][])
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(w, ymax - ymin, 0))
+end
+
+function data_limits(p::VSpan)
+    scene = parent_scene(p)
+    limits = projview_to_2d_limits(scene.camera.projectionview[])
+    xmin = minimum(p[1][])
+    xmax = maximum(p[2][])
+    ymin = minimum(limits)[2]
+    h = widths(limits)[2]
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, h, 0))
+end

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -15,6 +15,23 @@ end
 
     fig, ax, p = bracket(ps...)
     @test data_limits(p) ≈ Rect3f(Point3f(0), Vec3f(1, 1, 0))
+
+    fig = Figure()
+    ax = Axis(fig[1, 1], yscale=log, xscale=log)
+    scatter!(ax, [0.5, 1, 2], [0.5, 1, 2])
+    p1 = vlines!(ax, [0.5])
+    p2 = hlines!(ax, [0.5])
+    p3 = vspan!(ax, [0.25], [0.75])
+    p4 = hspan!(ax, [0.25], [0.75])
+    Makie.reset_limits!(ax)
+
+    lims = ax.finallimits[]
+    x, y = minimum(lims); w, h = widths(lims)
+
+    @test data_limits(p1) ≈ Rect3f(Point3f(0.5, y, 0), Vec3f(0, h, 0))
+    @test data_limits(p2) ≈ Rect3f(Point3f(x, 0.5, 0), Vec3f(w, 0, 0))
+    @test data_limits(p3) ≈ Rect3f(Point3f(0.25, y, 0), Vec3f(0.5, h, 0))
+    @test data_limits(p4) ≈ Rect3f(Point3f(x, 0.25, 0), Vec3f(w, 0.5, 0))
 end
 
 @testset "boundingbox(plot)" begin


### PR DESCRIPTION
# Description

Fixes #3271

Since we removed the back-and-forth transformation in those plots the child plots end up in a transformed space (i.e. post transform_func). With the default `data_limits` just looking at child plots we end up getting transformed limits as a result. This pr fixes that by adding custom `data_limits` methods. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
