### PR TITLE
Add naive depth sorting for scatter & text

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -572,6 +572,7 @@ function draw_atomic(screen::Screen, scene::Scene,
         gl_attributes[:distancefield] = get_texture!(atlas)
         gl_attributes[:visible] = plot.visible
         gl_attributes[:fxaa] = get(plot, :fxaa, Observable(false))
+        gl_attributes[:depthsorting] = get(plot, :depthsorting, false)
         cam = scene.camera
         # gl_attributes[:preprojection] = Observable(Mat4f(I))
         gl_attributes[:preprojection] = lift(plot, space, markerspace, cam.projectionview, cam.resolution) do s, ms, pv, res

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Add `depthsorting` as a hidden attribute for scatter plots in GLMakie as an alternative fix for outline artifacts. [#3432](https://github.com/MakieOrg/Makie.jl/pull/3432)
 - Disable SDF based anti-aliasing in scatter, text and lines plots when `fxaa = true` in GLMakie. This allows removing outline artifacts at the cost of quality. [#3408](https://github.com/MakieOrg/Makie.jl/pull/3408)
 - Fixed a bug with h/vlines and h/vspan not correctly resolving transformations [#3418](https://github.com/MakieOrg/Makie.jl/pull/3418)
 - Fixed a bug with h/vlines and h/vspan returning the wrong limits, causing an error in Axis [#3427](https://github.com/MakieOrg/Makie.jl/pull/3427)

--- a/docs/reference/plots/scatter.md
+++ b/docs/reference/plots/scatter.md
@@ -378,6 +378,7 @@ Currently there are a few ways to mitigate this problem, but they all come at a 
 - `fxaa = true` will disable the native anti-aliasing of scatter markers and use fxaa instead. This results in less detailed markers, especially for thin markers like characters.
 - `transparency = true` will disable depth testing to a degree, resulting in all markers being rendered without artifacts. However with this markers always have some level of transparency
 - `overdraw = true` will disable depth testing entirely (read and write) for the plot, removing artifacts. This will however change the z-order of markers and allow plots rendered later to show up on top of the scatter plot
+- `depthsorting = true` will sort markers by depth before rendering to fix the issue. This only works within a plot call, so when other plots are involved the issue may reappear.
 
 \begin{examplefigure}{}
 ```julia
@@ -386,15 +387,22 @@ GLMakie.activate!() # hide
 
 ps = rand(Point3f, 500)
 cs = rand(500)
-f = Figure(size = (600, 650))
+f = Figure(size = (900, 650))
 Label(f[1, 1], "base", tellwidth = false)
 scatter(f[2, 1], ps, color = cs, markersize = 20, fxaa = false)
 Label(f[1, 2], "fxaa = true", tellwidth = false)
 scatter(f[2, 2], ps, color = cs, markersize = 20, fxaa = true)
+
 Label(f[3, 1], "transparency = true", tellwidth = false)
 scatter(f[4, 1], ps, color = cs, markersize = 20, transparency = true)
 Label(f[3, 2], "overdraw = true", tellwidth = false)
 scatter(f[4, 2], ps, color = cs, markersize = 20, overdraw = true)
+
+Label(f[1, 3], "depthsorting = true", tellwidth = false)
+scatter(f[2, 3], ps, color = cs, markersize = 20, depthsorting = true)
+Label(f[3, 3], "depthsorting = true", tellwidth = false)
+scatter(f[4, 3], ps, color = cs, markersize = 20, depthsorting = true)
+mesh!(Rect3f(Point3f(0), Vec3f(0.9, 0.9, 0.9)), color = :orange)
 f
 ```
 \end{examplefigure}


### PR DESCRIPTION
# Description

Fixes https://discourse.julialang.org/t/hide-stroke-in-3d-scatter-using-makie-jl/106383

Sort of an alternative to #3408.

Adds `depthsorting::Bool` which results in sorting of markers in GLMakie when true. This fixes artifacts for markers coming from one plot call

![Screenshot from 2023-11-29 17-46-03](https://github.com/MakieOrg/Makie.jl/assets/10947937/5373f09c-8292-4c7b-9a16-445f0d34a5c0)

but still produces them when other plot calls are involved: (second example involves 2 scatter plots)

![Screenshot from 2023-11-29 17-55-03](https://github.com/MakieOrg/Makie.jl/assets/10947937/b0c301fa-6039-41b7-aea3-30401c55c408)

![Screenshot from 2023-11-29 17-58-15](https://github.com/MakieOrg/Makie.jl/assets/10947937/1ade931f-9e31-4be9-a1ae-f2c5e1333ae1)

Unlike #3408 this does not degrade the quality of markers though, so it might be preferable in some situations

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
