### PR TITLE
Tweak Camera3D clipping

### DIFF
--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -728,7 +728,7 @@ function update_cam!(scene::Scene, cam::Camera3D)
         far = far_dist * far
     elseif cam.settings.clipping_mode[] === :adaptive
         view_dist = norm(eyeposition - lookat)
-        near = view_dist * near; far = far
+        near = view_dist * near; far = max(1f0, view_dist) * far
     elseif cam.settings.clipping_mode[] !== :static
         @error "clipping_mode = $(cam.settings.clipping_mode[]) not recognized, using :static."
     end
@@ -775,7 +775,7 @@ function update_cam!(scene::Scene, cam::Camera3D, area3d::Rect, recenter::Bool =
         cam.far[] = 2f0 * dist
     elseif cam.settings.clipping_mode[] === :adaptive
         cam.near[] = 0.1f0 * dist / norm(cam.eyeposition[] - cam.lookat[])
-        cam.far[] = 2f0 * dist
+        cam.far[] = 2.2f0 * dist / norm(cam.eyeposition[] - cam.lookat[])
     end
 
     update_cam!(scene, cam)


### PR DESCRIPTION
# Description

I noticed that when zooming out you pretty quickly get to a point where the axis gets clipped:

![Screenshot from 2023-11-30 13-02-44](https://github.com/MakieOrg/Makie.jl/assets/10947937/a3b642d6-390b-4d88-aa51-fe68b181e430)

The pr tweaks the default clipping behavior a bit to avoid this by scaling `far` with `max(1, view_norm)`. This makes the frustum grow larger (rather than more or less translating it) when zooming out while keeping `far` large enough to include the back side of the axis when zooming in. At least with the case I tested, using default camera placement.

https://github.com/MakieOrg/Makie.jl/assets/10947937/ed305c72-3e2a-4580-b079-9032c47c21a4

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
