### PR TITLE
CairoMakie allocations

### DIFF
--- a/CairoMakie/Project.toml
+++ b/CairoMakie/Project.toml
@@ -4,7 +4,7 @@ author = ["Simon Danisch <sdanisch@gmail.com>"]
 version = "0.11.1"
 
 [deps]
-Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
@@ -14,7 +14,6 @@ GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [compat]
 Cairo = "1.0.4"
@@ -23,12 +22,10 @@ FFTW = "1"
 FileIO = "1.1"
 FreeType = "3, 4.0"
 GeometryBasics = "0.4.1"
+LinearAlgebra = "1.0, 1.6"
 Makie = "=0.20.1"
 PrecompileTools = "1.0"
-SHA = "0.7, 1.6, 1.7"
 julia = "1.3"
-Base64 = "1.0, 1.6"
-LinearAlgebra = "1.0, 1.6"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/CairoMakie/src/CairoMakie.jl
+++ b/CairoMakie/src/CairoMakie.jl
@@ -2,8 +2,7 @@ module CairoMakie
 
 using Makie, LinearAlgebra
 using Colors, GeometryBasics, FileIO
-import SHA
-import Base64
+import CRC32c
 import Cairo
 
 using Makie: Scene, Lines, Text, Image, Heatmap, Scatter, @key_str, broadcast_foreach

--- a/CairoMakie/src/display.jl
+++ b/CairoMakie/src/display.jl
@@ -76,11 +76,11 @@ function Makie.backend_show(screen::Screen{SVG}, io::IO, ::MIME"image/svg+xml", 
         svg = replace(svg, id => "surface$i")
     end
 
-    # salt svg ids with the first 8 characters of the base64 encoded
-    # sha512 hash to avoid collisions across svgs when embedding them on
-    # websites. the hash and therefore the salt will always be the same for the same file
+    # salt svg ids with the 8 hex characters of the crc32 checksum to avoid collisions
+    # across svgs when embedding them on websites.
+    # the hash and therefore the salt will always be the same for the same file
     # so the output is deterministic
-    salt = String(Base64.base64encode(SHA.sha512(svg)))[1:8]
+    salt = repr(CRC32c.crc32c(svg))[end-7:end]
 
     ids = sort(unique(collect(m[1] for m in eachmatch(r"id\s*=\s*\"([^\"]*)\"", svg))))
 

--- a/CairoMakie/src/display.jl
+++ b/CairoMakie/src/display.jl
@@ -82,12 +82,8 @@ function Makie.backend_show(screen::Screen{SVG}, io::IO, ::MIME"image/svg+xml", 
     # so the output is deterministic
     salt = repr(CRC32c.crc32c(svg))[end-7:end]
 
-    ids = sort(unique(collect(m[1] for m in eachmatch(r"id\s*=\s*\"([^\"]*)\"", svg))))
-
-    for id in ids
-        svg = replace(svg, id => "$id-$salt")
-    end
-
+    svg = replace(svg, r"((?:id|xlink:href)=\"[^\"]+)" => SubstitutionString("\\1-$salt"))
+    
     print(io, svg)
     return screen
 end

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -442,7 +442,22 @@ function draw_marker(ctx, beziermarker::BezierPath, pos, scale, strokecolor, str
     Cairo.restore(ctx)
 end
 
-draw_path(ctx, bp::BezierPath) = foreach(x -> path_command(ctx, x), bp.commands)
+function draw_path(ctx, bp::BezierPath)
+    for i in eachindex(bp.commands)
+        @inbounds command = bp.commands[i]
+        if command isa MoveTo
+            path_command(ctx, command)
+        elseif command isa LineTo
+            path_command(ctx, command)
+        elseif command isa CurveTo
+            path_command(ctx, command)
+        elseif command isa ClosePath
+            path_command(ctx, command)
+        elseif command isa EllipticalArc
+            path_command(ctx, command)
+        end
+    end
+end
 path_command(ctx, c::MoveTo) = Cairo.move_to(ctx, c.p...)
 path_command(ctx, c::LineTo) = Cairo.line_to(ctx, c.p...)
 path_command(ctx, c::CurveTo) = Cairo.curve_to(ctx, c.c1..., c.c2..., c.p...)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## master
 
+- Switched from SHA512 to CRC32c salting in CairoMakie svgs, drastically improving svg rendering speed [#3435](https://github.com/MakieOrg/Makie.jl/pull/3435). 
 - Fixed a bug with h/vlines and h/vspan not correctly resolving transformations [#3418](https://github.com/MakieOrg/Makie.jl/pull/3418)
 - Fixed a bug with h/vlines and h/vspan returning the wrong limits, causing an error in Axis [#3427](https://github.com/MakieOrg/Makie.jl/pull/3427)
 


### PR DESCRIPTION
Noticed that the speed of CairoMakie svg generation was sometimes really really slow. Turns out this was mostly because of the slow sha512 hashing, I replaced that with crc32 (it doesn't have to be cryptographically secure, just random enough to be practical). And I improved the id replacement and added some manual union splitting that also seemed to allocate quite a bit when drawing scatters.

Net result is drastic, but of course usually you wouldn't want the svg format anyway if you have many data points:

```julia
## before

julia> @time begin
           f = Figure()
           ax = Axis(f[1, 1])
           scatter!(ax, 1:10000)
           save("test2.svg", f)
       end;
 12.317504 seconds (444.40 k allocations: 125.444 MiB, 0.60% gc time)

## after

julia> @time begin
           f = Figure()
           ax = Axis(f[1, 1])
           scatter!(ax, 1:10000)
           save("test2.svg", f)
       end;
  0.100446 seconds (59.69 k allocations: 15.657 MiB)
```