### PR TITLE
Match url ids but not image data blobs in svg salting

### DIFF
--- a/CairoMakie/src/display.jl
+++ b/CairoMakie/src/display.jl
@@ -82,7 +82,11 @@ function Makie.backend_show(screen::Screen{SVG}, io::IO, ::MIME"image/svg+xml", 
     # so the output is deterministic
     salt = repr(CRC32c.crc32c(svg))[end-7:end]
 
-    svg = replace(svg, r"((?:id|xlink:href)=\"[^\"]+)" => SubstitutionString("\\1-$salt"))
+    # matches:
+    # id="someid"
+    # xlink:href="someid" (but not xlink:href="data:someothercontent" which is how image data is attached)
+    # url(#someid)
+    svg = replace(svg, r"((?:(?:id|xlink:href)=\"(?!data:)[^\"]+)|url\(#[^)]+)" => SubstitutionString("\\1-$salt"))
     
     print(io, svg)
     return screen


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/3440 which was a regression introduced by https://github.com/MakieOrg/Makie.jl/pull/3435 because the regex doing more efficient salting accidentally also matched image base64 blobs, making them invalid:

```html
xlink:href="data:image/png;base64,iVBOR ... SuQmCC-f0f66279"/>
```