### PR TITLE
fix document links about `Camera3D`

### DIFF
--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -278,7 +278,7 @@ end
     cam3d!(scene[; kwargs...])
 
 Creates a `Camera3D` with `zoom_shift_lookat = true` and `fixed_axis = true`.
-For more information, see [`Camera3D``](@ref)
+For more information, see [`Camera3D`](@ref)
 """
 cam3d!(scene; zoom_shift_lookat = true, fixed_axis = true, kwargs...) =
     Camera3D(scene, zoom_shift_lookat = zoom_shift_lookat, fixed_axis = fixed_axis; kwargs...)
@@ -287,7 +287,7 @@ cam3d!(scene; zoom_shift_lookat = true, fixed_axis = true, kwargs...) =
     cam3d_cad!(scene[; kwargs...])
 
 Creates a `Camera3D` with `cad = true`, `zoom_shift_lookat = false` and
-`fixed_axis = false`. For more information, see [`Camera3D``](@ref)
+`fixed_axis = false`. For more information, see [`Camera3D`](@ref)
 """
 cam3d_cad!(scene; cad = true, zoom_shift_lookat = false, fixed_axis = false, kwargs...) =
     Camera3D(scene, cad = cad, zoom_shift_lookat = zoom_shift_lookat, fixed_axis = fixed_axis; kwargs...)


### PR DESCRIPTION
# Description

Fix documents of `cam3d!` and `cam3d_cad!` to link `Camera3D` correctly.

## Type of change

Document fix
