### PR TITLE
GLMakie image size update bug

### DIFF
--- a/GLMakie/src/GLAbstraction/AbstractGPUArray.jl
+++ b/GLMakie/src/GLAbstraction/AbstractGPUArray.jl
@@ -16,7 +16,7 @@ size(A::GPUArray) = A.size
 function checkdimensions(value::Array, ranges::Union{Integer, UnitRange}...)
     array_size   = size(value)
     indexes_size = map(length, ranges)
-    (array_size != indexes_size) && throw(DimensionMismatch("asigning a $array_size to a $(indexes_size) location"))
+    (array_size != indexes_size) && throw(DimensionMismatch("Assigning a $array_size to a $(indexes_size) location"))
     return true
 end
 function to_range(index)
@@ -57,8 +57,8 @@ function update!(A::GPUArray{T, N}, value::AbstractArray{T2, N}) where {T, N, T2
 end
 function update!(A::GPUArray{T, N}, value::AbstractArray{T, N}) where {T, N}
     switch_context!(A)
-    if length(A) != length(value)
-        if isa(A, GLBuffer)
+    if size(A) != size(value)
+        if isa(A, GLBuffer) && length(A) != length(value)
             resize!(A, length(value))
         elseif isa(A, Texture)
             resize_nocopy!(A, size(value))

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -393,3 +393,13 @@ end
 
     GLMakie.closeall()
 end
+
+@testset "image size changes" begin
+    s = Scene()
+    im = image!(s, 0..10, 0..10, zeros(RGBf, 10, 20))
+    display(s)
+    im[3][] = zeros(RGBf, 20, 10) # same length, different size
+    im[3][] = zeros(RGBf, 15, 5) # smaller size
+    im[3][] = zeros(RGBf, 25, 15) # larger size
+    GLMakie.closeall()
+end

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fixed bug in GLMakie where the update from a (i, j) sized GPU buffer to a (j, i) sized buffer would fail [#3456](https://github.com/MakieOrg/Makie.jl/pull/3456).
+
 ## 0.20.2
 
 - Switched from SHA512 to CRC32c salting in CairoMakie svgs, drastically improving svg rendering speed [#3435](https://github.com/MakieOrg/Makie.jl/pull/3435).


### PR DESCRIPTION
Fixes a bug where an update from an (i, j) sized image to a (j, i) sized image would fail.