### PR TITLE
Fix a DataInspector bug if `inspector_label` is used with RGB images

### DIFF
--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -653,7 +653,8 @@ function show_imagelike(inspector, plot, name, edge_based)
     end
 
     if haskey(plot, :inspector_label)
-        tt.text[] = plot[:inspector_label][](plot, (i, j), Point3f(pos[1], pos[2], z))
+        ins_p = z isa Colorant ? (pos[1], pos[2], z) : Point3f(pos[1], pos[2], z)
+        tt.text[] = plot[:inspector_label][](plot, (i, j), ins_p)
     else
         tt.text[] = color2text(name, x, y, z)
     end


### PR DESCRIPTION
# Description

If the creation of a custom tooltip was attempted with `RGB` type images the inspector would error after attempting to convert the `Colorant` to a `Float32` using the `Point3f` constructor for the position parameter.

For cases in which RGB values are being plotted we now call the `inspector_label` function using a `Tuple` for its third argument instead, avoiding the error and allowing the RGB values to be used in the construction of the custom string.

Reproduction of the bug:

```julia
using GLMakie # git master
img = [RGBf(1.0, 1.0, 1.0) RGBf(1.0, 0.0, 0.0)
       RGBf(0.0, 1.0, 0.0) RGBf(0.0, 0.0, 1.0)]
figure, axis, plot = image(img; interpolate = false,
    inspector_label = (_, i, p) -> "$i = $(p[3])")
DataInspector(figure)
figure
```
which would produce
```julia
MethodError: Cannot `convert` an object of type ColorTypes.RGB{Float32} to an object of type Float32
```

As for the solution, we could skip the `Colorant` check and just return a `Tuple` instead, but if for whatever reason someone's script or package is currently expecting a `Point3f` type as before this would change that behaviour, so we call using a `Tuple` only when `z` is a `Colorant`; although using a `Tuple` universally here is much simpler of course.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
