### PR TITLE
Make autolimits! default to current_axis()

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -907,7 +907,11 @@ function autolimits!(ax::Axis)
     ax.limits[] = (nothing, nothing)
     return
 end
-autolimits!() = autolimits!(current_axis())
+function autolimits!()
+    curr_ax = current_axis()
+    isnothing(curr_ax)  &&  throw(ArgumentError("Attempted to call `autolimits!` on `current_axis()`, but `current_axis()` returned nothing."))
+    autolimits!()
+end
 
 function autolimits(ax::Axis, dim::Integer)
     # try getting x limits for the axis and then union them with linked axes

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -897,14 +897,17 @@ function update_linked_limits!(block_limit_linking, xaxislinks, yaxislinks, tlim
 end
 
 """
+    autolimits!()
     autolimits!(la::Axis)
 
 Reset manually specified limits of `la` to an automatically determined rectangle, that depends on the data limits of all plot objects in the axis, as well as the autolimit margins for x and y axis.
+The argument `la` defaults to `current_axis()`.
 """
 function autolimits!(ax::Axis)
     ax.limits[] = (nothing, nothing)
     return
 end
+autolimits!() = autolimits!(current_axis())
 
 function autolimits(ax::Axis, dim::Integer)
     # try getting x limits for the axis and then union them with linked axes

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -910,7 +910,7 @@ end
 function autolimits!()
     curr_ax = current_axis()
     isnothing(curr_ax)  &&  throw(ArgumentError("Attempted to call `autolimits!` on `current_axis()`, but `current_axis()` returned nothing."))
-    autolimits!()
+    autolimits!(curr_ax)
 end
 
 function autolimits(ax::Axis, dim::Integer)


### PR DESCRIPTION
This PR makes `Makie.autolimits!` default to using `current_axis()`

## Type of change

Delete options that do not apply:
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
