### PR TITLE
clean up some more observables for blocks and axis

### DIFF
--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -535,7 +535,7 @@ end
 function init_observable!(@nospecialize(block), key::Symbol, @nospecialize(OT), @nospecialize(value::Observable))
     obstype = observable_type(OT)
     o = Observable{obstype}()
-    map!(o, value) do v
+    map!(block.blockscene, o, value) do v
         convert_for_attribute(obstype, v)
     end
     setfield!(block, key, o)

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -255,7 +255,8 @@ function initialize_block!(ax::Axis; palette = nothing)
     notify(ax.xscale)
 
     # 3. Update the view onto the plot (camera matrices)
-    onany(update_axis_camera, camera(scene), scene.transformation.transform_func, finallimits, ax.xreversed, ax.yreversed, priority = -2)
+    onany(update_axis_camera, blockscene, camera(scene), scene.transformation.transform_func, finallimits,
+          ax.xreversed, ax.yreversed; priority=-2)
 
     xaxis_endpoints = lift(blockscene, ax.xaxisposition, scene.viewport;
                            ignore_equal_values=true) do xaxisposition, area

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -489,3 +489,17 @@ end
         rethrow(e)
     end
 end
+
+@testset "Block attribute conversion observable cleanup" begin
+    limits = Observable((-1.0, 1.0, -1.0, 1.0))
+    for _ in 1:5
+        fig = Figure()
+        for i in 1:5
+            for j in 1:5
+                ax = Axis(fig[i, j]; limits)
+            end
+        end
+        empty!(fig)
+    end
+    @test isempty(limits.listeners)
+end


### PR DESCRIPTION
Improves test case:

```julia

using GLMakie

limits = Observable((-1.0, 1.0, -1.0, 1.0))

for _ in 1:5
    fig = Figure()
    for i in 1:5
        for j in 1:5
            ax = Axis(fig[i, j]; limits)
        end
    end
    empty!(fig)
end
GC.gc(true)@
@test isempty(limits.listeners) 
```
But still doesn't clean up if `empty!` is replaced by `display(fig)`.