### PR TITLE
Make artifact names unique

### DIFF
--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -51,9 +51,10 @@ jobs:
           julia --color=yes --project=monorepo -e 'using Pkg; Pkg.test("CairoMakie", coverage=true)'
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
       - name: Upload test Artifacts
+        if: matrix.version == '1'
         uses: actions/upload-artifact@v3
         with:
-          name: ReferenceImages_CairoMakie_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
+          name: ReferenceImages_CairoMakie
           path: ./CairoMakie/test/recorded_reference_images/
       - name: Fail after artifacts if tests failed
         if: ${{ env.TESTS_SUCCESSFUL != 'true' }}
@@ -100,9 +101,10 @@ jobs:
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --color=yes --project=monorepo -e 'using Pkg; Pkg.test("GLMakie", coverage=true)'
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
       - name: Upload test Artifacts
+        if: matrix.version == '1'
         uses: actions/upload-artifact@v3
         with:
-          name: ReferenceImages_GLMakie_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
+          name: ReferenceImages_GLMakie
           path: |
             ./GLMakie/test/recorded_reference_images/
       - name: Save number of missing refimages to file
@@ -160,9 +162,10 @@ jobs:
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --color=yes --project=monorepo -e 'using Pkg; Pkg.test("WGLMakie", coverage=true)'
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV
       - name: Upload test Artifacts
+        if: matrix.version == '1'
         uses: actions/upload-artifact@v3
         with:
-          name: ReferenceImages_WGLMakie_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
+          name: ReferenceImages_WGLMakie
           path: ./WGLMakie/test/recorded_reference_images/
       - name: Fail after artifacts if tests failed
         if: ${{ env.TESTS_SUCCESSFUL != 'true' }}

--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload test Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ReferenceImages_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
+          name: ReferenceImages_CairoMakie_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
           path: ./CairoMakie/test/recorded_reference_images/
       - name: Fail after artifacts if tests failed
         if: ${{ env.TESTS_SUCCESSFUL != 'true' }}
@@ -102,7 +102,7 @@ jobs:
       - name: Upload test Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ReferenceImages_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
+          name: ReferenceImages_GLMakie_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
           path: |
             ./GLMakie/test/recorded_reference_images/
       - name: Save number of missing refimages to file
@@ -162,7 +162,7 @@ jobs:
       - name: Upload test Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ReferenceImages_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
+          name: ReferenceImages_WGLMakie_${{ matrix.os }}_${{ matrix.arch }}_${{ matrix.version }}
           path: ./WGLMakie/test/recorded_reference_images/
       - name: Fail after artifacts if tests failed
         if: ${{ env.TESTS_SUCCESSFUL != 'true' }}


### PR DESCRIPTION
With the consolidation into a single workflow, the artifacts were overwriting each other.