### PR TITLE
fix WGLMakie benchmark

### DIFF
--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -214,7 +214,7 @@ ENV["JULIA_PKG_PRECOMPILE_AUTO"] = 0
 project1 = make_project_folder("current-pr")
 Pkg.activate(project1)
 if Package == "WGLMakie"
-    Pkg.add([(; name="Electron"), (; name="JSServe", rev="master")])
+    Pkg.add([(; name="Electron")])
 end
 pkgs = NamedTuple[(; path="./MakieCore"), (; path="."), (; path="./$Package")]
 # cd("dev/Makie")


### PR DESCRIPTION
Some experiment left JSServe#master in the benchmarks, which is now Bonito with a different UUID, so the project can't be instantiated.