### PR TITLE
add interpolate option to volume

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -802,11 +802,14 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Volume)
             )
             return convert(Mat4f, m) * m2
         end
+        interp = to_value(pop!(gl_attributes, :interpolate))
+        interp = interp ? :linear : :nearest
+        Tex(x) = Texture(x; minfilter=interp)
         if haskey(gl_attributes, :intensity)
             intensity = pop!(gl_attributes, :intensity)
-            return draw_volume(screen, intensity, gl_attributes)
+            return draw_volume(screen, Tex(intensity), gl_attributes)
         else
-            return draw_volume(screen, plot[4], gl_attributes)
+            return draw_volume(screen, Tex(plot[4]), gl_attributes)
         end
     end
 end

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -192,6 +192,7 @@ Available algorithms are:
 - `algorithm::Union{Symbol, RaymarchAlgorithm} = :mip` sets the volume algorithm that is used.
 - `isorange::Real = 0.05` sets the range of values picked up by the IsoValue algorithm.
 - `isovalue = 0.5` sets the target value for the IsoValue algorithm.
+- `interpolate::Bool = true` sets whether the volume data should be sampled with interpolation.
 
 $(Base.Docs.doc(shading_attributes!))
 
@@ -205,7 +206,7 @@ $(Base.Docs.doc(MakieCore.generic_plot_attributes!))
         algorithm = :mip,
         isovalue = 0.5,
         isorange = 0.05,
-
+        interpolate = true,
         fxaa = true,
     )
     generic_plot_attributes!(attr)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - DataInspector Fixes: Fixed depth order, positional labels being in transformed space and `:inspector_clear` not getting called when moving from one plot to another. [#3454](https://github.com/MakieOrg/Makie.jl/pull/3454)
 - Fixed bug in GLMakie where the update from a (i, j) sized GPU buffer to a (j, i) sized buffer would fail [#3456](https://github.com/MakieOrg/Makie.jl/pull/3456).
+- Add `interpolate=true` to `volume(...)`, allowing to disable interpolation [#3485](https://github.com/MakieOrg/Makie.jl/pull/3485).
 
 ## 0.20.2
 


### PR DESCRIPTION
Feature  for https://discourse.julialang.org/t/how-to-unsmooth-glmakie-volume-plot/107659/3

```julia
using GLMakie

f, ax, pl = volume([0; 0; 0;; 0; 0; 0;; 0; 0; 0;;;
        0; 0; 0;; 0; 1; 0;; 0; 0; 0;;;
        0; 0; 0;; 0; 0; 0;; 0; 0; 0];  interpolate=false, axis=(; type=Axis3, title="interpolate=false"))

volume(f[1, 2], [0; 0; 0;; 0; 0; 0;; 0; 0; 0;;;
        0; 0; 0;; 0; 1; 0;; 0; 0; 0;;;
        0; 0; 0;; 0; 0; 0;; 0; 0; 0]; interpolate=true, axis=(; type=Axis3, title="interpolate=true"))
f
```
<img width="443" alt="image" src="https://github.com/MakieOrg/Makie.jl/assets/1010467/ace954d1-b404-437b-94b3-d29f52f43ff5">

