### PR TITLE
doc: Fix typos in `VideoStreamOptions` docs

### DIFF
--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -17,13 +17,13 @@
     higher numbers giving lower quality and smaller file sizes (higher compression). The
     minimum value is `0` (lossless encoding).
     - For `mp4`, `51` is the maximum. Note that `compression = 0` only works with `mp4` if
-    `profile = high444`.
+    `profile = "high444"`.
     - For `webm`, `63` is the maximum.
     - `compression` has no effect on `mkv` and `gif` outputs.
 - `profile = "high422"`: A ffmpeg compatible profile. Currently only applies to `mp4`. If
 you have issues playing a video, try `profile = "high"` or `profile = "main"`.
 - `pixel_format = "yuv420p"`: A ffmpeg compatible pixel format (`-pix_fmt`). Currently only
-applies to `mp4`. Defaults to `yuv444p` for `profile = high444`.
+applies to `mp4`. Defaults to `yuv444p` for `profile = "high444"`.
 - `loop = 0`: Number of times the video is repeated, for a `gif`. Defaults to `0`, which
 means infinite looping. A value of `-1` turns off looping, and a value of `n > 0` and above
 means `n` repetitions (i.e. the video is played `n+1` times).


### PR DESCRIPTION


# Description

This is a very small change.  

The docs for `VideoStreamOptions` give example values for `profile`
which are unquoted strings.
Add quotes to the example strings in the docs.



## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.

Most of these don't apply here.