### PR TITLE
Fix calculation of focal length for RPRMakie

### DIFF
--- a/RPRMakie/src/scene.jl
+++ b/RPRMakie/src/scene.jl
@@ -5,7 +5,6 @@ function update_rpr_camera!(oldvals, camera, cam_controls, cam)
     c = cam_controls
     l, u, p, fov = c.lookat[], c.upvector[], c.eyeposition[], c.fov[]
     far, near, res = c.far[], c.near[], cam.resolution[]
-    fov = 45f0 # The current camera ignores fov updates
     new_vals = (; l, u, p, fov, far, near, res)
     new_vals == oldvals && return oldvals
     wd = norm(l - p)
@@ -14,8 +13,8 @@ function update_rpr_camera!(oldvals, camera, cam_controls, cam)
     lookat!(camera, p, l, u)
     RPR.rprCameraSetFarPlane(camera, far)
     RPR.rprCameraSetNearPlane(camera, near)
-    h = norm(res)
-    RPR.rprCameraSetFocalLength(camera, (30*h)/fov)
+    focal_length = res[2] / (2 * tand(fov / 2)) # fov is vertical
+    RPR.rprCameraSetFocalLength(camera, focal_length)
     # RPR_CAMERA_FSTOP
     # RPR_CAMERA_MODE
     return new_vals


### PR DESCRIPTION
With this change, fov looks the same in GLMakie and RPRMakie for me. Before, we just had this hardcoded value for some reason.

![grafik](https://github.com/MakieOrg/Makie.jl/assets/22495855/03558bfd-7f76-45e4-b5e2-86901883c517)
![grafik](https://github.com/MakieOrg/Makie.jl/assets/22495855/2abcba55-92fc-4c4e-bf5c-96d95eded041)
