### PR TITLE
fix strong type conversion of markers

### DIFF
--- a/GLMakie/src/GLAbstraction/GLUtils.jl
+++ b/GLMakie/src/GLAbstraction/GLUtils.jl
@@ -14,7 +14,7 @@ Needed to match the lazy gl_convert exceptions.
     `x`: the variable that gets matched
 """
 matches_target(::Type{Target}, x::T) where {Target, T} = applicable(gl_convert, Target, x) || T <: Target  # it can be either converted to Target, or it's already the target
-matches_target(::Type{Target}, x::Observable{T}) where {Target, T} = applicable(gl_convert, Target, x)  || T <: Target
+matches_target(::Type{Target}, x::Observable{T}) where {Target, T} = applicable(gl_convert, Target, x) || T <: Target
 matches_target(::Function, x) = true
 matches_target(::Function, x::Nothing) = false
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1643,7 +1643,10 @@ struct FastPixel end
 Vector of anything that is accepted as a single marker will give each point it's own marker.
 Note that it needs to be a uniform vector with the same element type!
 """
-to_spritemarker(marker::AbstractVector) = map(to_spritemarker, marker)
+function to_spritemarker(marker::AbstractVector{T}) where T
+    spritemarker = map(to_spritemarker, marker)
+    convert(Vector{Union{T,eltype(spritemarker)}}, spritemarker)  # retain original type T
+end
 to_spritemarker(marker::AbstractVector{Char}) = marker # Don't dispatch to the above!
 to_spritemarker(x::FastPixel) = x
 to_spritemarker(x::Circle) = x
@@ -1687,9 +1690,6 @@ function to_spritemarker(marker::Symbol)
         return '●'
     end
 end
-
-
-
 
 convert_attribute(value, ::key"marker", ::key"scatter") = to_spritemarker(value)
 convert_attribute(value, ::key"isovalue", ::key"volume") = Float32(value)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -441,3 +441,12 @@ end
     @test isapprox(Makie.angle2align(pi/4),  Vec2f(1, 1), atol = 1e-12)
     @test isapprox(Makie.angle2align(5pi/4), Vec2f(0, 0), atol = 1e-12)
 end
+
+@testset "markers conversion" begin
+    T = Union{Char, Symbol}
+    marker = Observable(T[:cross, :cross])
+    marker_converted = Observable(convert_attribute(marker[], key"marker"(), key"scatter"()))
+    @test T <: eltype(marker_converted[])
+    marker[][1] = 'x'
+    marker_converted[] = marker[]
+end


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/Makie.jl/issues/3245.

Retain the original marker type in the output eltype `Union`, when a marker is converted through the `DEFAULT_MARKER_MAP` dictionary.

Another option is to go for `Any` ?

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
