### PR TITLE
update pagefind to 1.0.4

### DIFF
--- a/docs/_layout/foot.html
+++ b/docs/_layout/foot.html
@@ -26,8 +26,8 @@
     <script src="/libs/lunr/lunr_index.js"></script>
     <script src="/libs/lunr/lunrclient.min.js"></script> -->
 
-    <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
-    <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+    <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+    <script src="/pagefind/pagefind-ui.js" type="text/javascript"></script>
     <script>
         window.addEventListener('DOMContentLoaded', (event) => {
             new PagefindUI({

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -13,9 +13,9 @@ using Tar
 
 pagefind = let
     url = if Sys.isapple()
-        "https://github.com/CloudCannon/pagefind/releases/download/v0.12.0/pagefind-v0.12.0-aarch64-apple-darwin.tar.gz"
+        "https://github.com/CloudCannon/pagefind/releases/download/v1.0.4/pagefind-v1.0.4-aarch64-apple-darwin.tar.gz"
     elseif Sys.islinux()
-        "https://github.com/CloudCannon/pagefind/releases/download/v0.12.0/pagefind-v0.12.0-x86_64-unknown-linux-musl.tar.gz"
+        "https://github.com/CloudCannon/pagefind/releases/download/v1.0.4/pagefind-v1.0.4-x86_64-unknown-linux-musl.tar.gz"
     else
         error()
     end
@@ -68,7 +68,7 @@ serve(; single=true, cleanup=false, clear=true, fail_on_warning=true)
 # cd(@__DIR__); serve(single=false, cleanup=true, clear=true, fail_on_warning = false)
 
 cd("__site") do
-    run(`$pagefind --source . --root-selector .franklin-content`)
+    run(`$pagefind --site . --root-selector .franklin-content`)
 end
 
 # by making all links relative, we can forgo the `prepath` setting of Franklin


### PR DESCRIPTION
This should improve the quality of search results, as in the old version headings are not weighted additionally, so finding the `Colors` page doesn't work unless you scroll down quite far

<img width="834" alt="grafik" src="https://github.com/MakieOrg/Makie.jl/assets/22495855/f12f0edc-293c-4bc1-af3b-99feef2c617a">
