### PR TITLE
Bounding Box Prototyping

### DIFF
--- a/MakieCore/Project.toml
+++ b/MakieCore/Project.toml
@@ -4,6 +4,7 @@ authors = ["Simon Danisch"]
 version = "0.7.2"
 
 [deps]
+GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 

--- a/MakieCore/src/LazyObservable.jl
+++ b/MakieCore/src/LazyObservable.jl
@@ -18,8 +18,8 @@ mutable struct LazyObservable{T}
     up_to_date::Observable{Bool}
     val::T
 
-    LazyObservable{T}(f::Function) = new{T}(f, Observable{Bool}(false))
-    LazyObservable(f::Function, init::T) = new{T}(f, Observable{Bool}(false), init)
+    LazyObservable{T}(f::Function) where T = new{T}(f, Observable{Bool}(false))
+    LazyObservable(f::Function, init::T) where T = new{T}(f, Observable{Bool}(false), init)
 end
 
 function update!(l::LazyObservable{T}) where T
@@ -30,19 +30,19 @@ function update!(l::LazyObservable{T}) where T
     return l.val
 end
 
-function notify(l::LazyObservable)
+function Observables.notify(l::LazyObservable)
     l.up_to_date[] = false
     return
 end
 
-getindex(l::LazyObservable) = update!(l)
-listeners(l::LazyObservable) = listeners(l.up_to_date)
+Base.getindex(l::LazyObservable) = update!(l)
+Observables.listeners(l::LazyObservable) = listeners(l.up_to_date)
 
-function on(@nospecialize(f), l::LazyObservable; kwargs...)
+function Observables.on(@nospecialize(f), l::LazyObservable; kwargs...)
     return on(l.up_to_date; kwargs...) do state
         state || f(l) # TODO: should this update? e.g. use l[]?
         return
     end
 end
 
-off(l::LazyObservable, @nospecialize(f)) = off(l.up_to_date, f)
+Observables.off(l::LazyObservable, @nospecialize(f)) = off(l.up_to_date, f)

--- a/MakieCore/src/LazyObservable.jl
+++ b/MakieCore/src/LazyObservable.jl
@@ -1,0 +1,48 @@
+"""
+    LazyObservable{T}(update::Function)
+    LazyObservable(update::Function, init::T)
+
+Creates a lazy observables which updates using the passed `update` Function when
+its value is requested by `lazyobs[]`.
+
+Notes:
+- `on()`, `map()` etc do not pass the value of the LazyObservable to the
+attached function. Instead they pass the LazyObservable itself, so that you
+need to explicitly call `lazyobs[]` to trigger an update.
+
+TODO: Should this just update and have something like
+`no_update(l::LazyObserbale) = l.up_to_date` for listening without updates?
+"""
+mutable struct LazyObservable{T}
+    updater::Function
+    up_to_date::Observable{Bool}
+    val::T
+
+    LazyObservable{T}(f::Function) = new{T}(f, Observable{Bool}(false))
+    LazyObservable(f::Function, init::T) = new{T}(f, Observable{Bool}(false), init)
+end
+
+function update!(l::LazyObservable{T}) where T
+    if !l.up_to_date[]
+        l.val = l.updater()::T
+        l.up_to_date.val = true
+    end
+    return l.val
+end
+
+function notify(l::LazyObservable)
+    l.up_to_date[] = false
+    return
+end
+
+getindex(l::LazyObservable) = update!(l)
+listeners(l::LazyObservable) = listeners(l.up_to_date)
+
+function on(@nospecialize(f), l::LazyObservable; kwargs...)
+    return on(l.up_to_date; kwargs...) do state
+        state || f(l) # TODO: should this update? e.g. use l[]?
+        return
+    end
+end
+
+off(l::LazyObservable, @nospecialize(f)) = off(l.up_to_date, f)

--- a/MakieCore/src/MakieCore.jl
+++ b/MakieCore/src/MakieCore.jl
@@ -7,11 +7,11 @@ end
 
 using Observables
 using Observables: to_value
+using GeometryBasics
 using Base: RefValue
 # Needing REPL for Base.Docs.doc on julia
 # https://github.com/MakieOrg/Makie.jl/issues/3276
 using REPL
-
 
 include("LazyObservable.jl")
 include("types.jl")

--- a/MakieCore/src/MakieCore.jl
+++ b/MakieCore/src/MakieCore.jl
@@ -13,6 +13,7 @@ using Base: RefValue
 using REPL
 
 
+include("LazyObservable.jl")
 include("types.jl")
 include("attributes.jl")
 include("recipes.jl")

--- a/MakieCore/src/types.jl
+++ b/MakieCore/src/types.jl
@@ -50,7 +50,6 @@ struct Attributes
     attributes::Dict{Symbol, Observable}
 end
 
-
 # If a bounding box does not extend in a dimension it's bounding box is NaN in
 # that dimension. TODO: how does this combine with e.g. vlines?
 struct LazyBoundingBox

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -92,6 +92,7 @@ import MakieCore: create_axis_like, create_axis_like!, figurelike_return, figure
 import MakieCore: arrows, heatmap, image, lines, linesegments, mesh, meshscatter, poly, scatter, surface, text, volume
 import MakieCore: arrows!, heatmap!, image!, lines!, linesegments!, mesh!, meshscatter!, poly!, scatter!, surface!, text!, volume!
 import MakieCore: convert_arguments, convert_attribute, default_theme, conversion_trait
+import MakieCore: LazyObservable, LazyBoundingBox
 
 export @L_str, @colorant_str
 export ConversionTrait, NoConversion, PointBased, GridBased, VertexGrid, CellGrid, ImageLike, VolumeLike

--- a/src/layouting/BoundingBox.jl
+++ b/src/layouting/BoundingBox.jl
@@ -1,0 +1,49 @@
+function init(parent::SceneLike)
+    for space in (:data, :transformed, :pixel, :relative, :clip) # TODO: use spaces() once it has :transformed
+        bb.fast_bbox[space] = LazyObservable(_ -> calculate_fast_bbox(parent, space), Rect3f())
+        bb.fast_bbox[space] = LazyObservable(_ -> calculate_full_bbox(parent, space), Rect3f())
+    end
+    # TODO: attach notifiers:
+    # Plot:
+    # - all have onany(plot.converted)
+    # - :transformed, ... on(transform_func)
+    # - :pixel, ... on(camera.projectionview)
+    # Scene:
+    # - on(plot.bbox) per space for every child
+    return
+end
+
+boundingbox(obj::SceneLike; space = :data, mode = :full) = boundingbox(obj, space, mode)
+function boundingbox(obj::SceneLike, space = :data, mode = :full)
+    if mode == :fast
+        return obj.fast_bbox[space][]
+    elseif mode == :full
+        return obj.full_bbox[space][]
+    else
+        throw(ArgumentError("Mode $mode not recognized."))
+    end
+end
+
+data_limits(obj::SceneLike) = boundingbox(obj, :data, :fast)
+
+# TODO: maybe also:
+# boundingbox(obj::SceneLike; space = :data, mode = :full) = boundingbox(obj, space, mode)
+# function boundingbox(obj::SceneLike, space = :data, mode = :full)
+#     # use obj.cache[:marker_bbox] or something like this?
+# end
+
+function calculate_fast_bbox(plot::Combined, space::Symbol)
+    # TODO: what exactly do we do with this?
+    # - :data bbox from plot, other from :data bbox (this would generally make bbox less tight)
+    # - bbox from transformed plot data (more expensive)
+    # - should we include marker bboxes if they are simple to include (e.g. linear transform in 2D?)
+    # - use only max marker bbox to reduce cost?
+
+end
+
+function calculate_full_bbox(plot::Combined, space::Symbol)
+    # TODO
+    # include everything we reasonably can:
+    # - transform data
+    # - with markers, transform data to markerspace, add marker bbox, transform to target
+end

--- a/src/layouting/new_bbox.jl
+++ b/src/layouting/new_bbox.jl
@@ -1,0 +1,234 @@
+# Note:
+# This is from before the other changes and may not fit in directly...
+
+################################################################################
+### BoundingBox Util
+################################################################################
+
+nanmin(a::VecTypes, b::VecTypes) = nanmin(to_ndim(Vec3f, a, NaN32), to_ndim(Vec3f, b, NaN32))
+nanmin(a::VecTypes{3}, b::VecTypes{3}) = nanmin.(a, b)
+function nanmin(a::Real, b::Real)
+    isnan(b) && return a
+    isnan(a) && return b
+    return min(a, b)
+end
+
+nanmax(a::VecTypes, b::VecTypes) = nanmax(to_ndim(Vec3f, a, NaN32), to_ndim(Vec3f, b, NaN32))
+nanmax(a::VecTypes{3}, b::VecTypes{3}) = nanmax.(a, b)
+function nanmin(a::Real, b::Real)
+    isnan(b) && return a
+    isnan(a) && return b
+    return max(a, b)
+end
+
+
+function boundingbox(positions::AbstractVector)
+    N = length(positions)
+    low = Point3f(NaN)
+    high = Point3f(NaN)
+
+    # Seek first non-nan element so we can set low and high to something finite
+    # and avoid left isnan checks during iteration
+    i = 1
+    @inbounds while i < N
+        if !isnan(positions[i])
+            low = to_ndim(Point3f, positions[i], NaN32)
+            high = to_ndim(Point3f, positions[i], NaN32)
+            break
+        end
+        i += 1
+    end
+
+    @inbounds for j in i+1:N
+        p = positions[j]
+        if !isnan(p)
+            low = min.(low, p)
+            high = max.(high, p)
+        end
+    end
+
+    return Rec3f(low, high - low)
+end
+
+function boundingbox(a::Rect3, b::Rect3)
+    min = nanmin(minimum(a), minimum(b))
+    max = nanmax(maximum(a), maximum(b))
+    return Rect3f(min, max)
+end
+
+
+################################################################################
+### get positions
+################################################################################
+
+
+function positions(plot::Union{Scatter, MeshScatter, Lines, LineSegments})
+    return plot.positions[]
+end
+
+function positions(plot::Text) #TODO: is this ok?
+    if isempty(plot.plots)
+        return plot.positions[]
+    else
+        return positions(plot.plots[1])
+    end
+end
+
+positions(mesh::GeometryBasics.Mesh) = decompose(Point, mesh)
+positions(plot::Mesh) = positions(plot.mesh[])
+
+function positions(plot::Union{Image, Heatmap, Surface, Volume})
+    rect = data_limits(plot)
+    return unique(decompose(Point3f, rect))
+end
+
+# Generic
+function positions(@nospecialize(plot::Combined))
+    output = Point3f[]
+    for p in plot.plots
+        append!(output, positions(p))
+    end
+    return output
+end
+
+
+################################################################################
+### get bbox of positions
+################################################################################
+
+
+function data_limits(plot::Union{Image, Heatmap})
+    xmin, xmax = extrema(plot[1][])
+    ymin, ymax = extrema(plot[2][])
+    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
+end
+
+function data_limits(plot::Union{Surface, Volume})
+    xmin, xmax = extrema(plot[1][])
+    ymin, ymax = extrema(plot[2][])
+    zmin, zmax = extrema(plot[3][])
+    return Rect3f(Point3f(xmin, ymin, zmin), Vec3f(xmax - xmin, ymax - ymin, zmax - zmin))
+end
+
+# Generic
+data_limits(@nospecialize(plot::Combined)) = boundingbox(position(plot))
+
+
+################################################################################
+### Generic boundingbox methods
+################################################################################
+
+# User entrypoint
+# scenes & plots
+function boundingbox(@nospecialize(obj::SceneLike); transform = false, project = false)
+    return _boundingbox(obj, project, transform)
+end
+
+function _boundingbox(@nospecialize(obj::SceneLike), project::Bool, transform::Bool)
+    if isempty(obj.plots)
+        bbox = _boundingbox(obj, project)
+        if transform
+            ps = corners(bbox)
+            ps = apply_transform(obj, ps)
+            return boundingbox(ps)
+        else
+            return bbox
+        end
+    else
+        final_bbox = Rect3f()
+        for plot in obj.plots
+            bbox = _boundingbox(plot, project, transform)
+            final_bbox = boundingbox(final_bbox, bbox)
+        end
+        return final_bbox
+    end
+end
+
+
+################################################################################
+### Primitive boundingbox methods
+################################################################################
+
+
+function _boundingbox(@nospecialize(plot::Scatter), project::Bool)
+    if project
+        bbox = Rect3f()
+        # ...
+        N = length(plot)
+        N0 = findfirst(!isnan, plot.positions[])
+        if !isnothing(N0)
+            # TODO: always project, never transform for scatter
+            bbox = _boundingbox(plot, N0)
+            for i in N0+1 : N
+                bbox = boundingbox(bbox, _boundingbox(plot, i))
+            end
+        end
+        return bbox
+    else
+        return data_limits(plot)
+    end
+end
+
+function _boundingbox(@nospecialize(plot::Union{Lines, Linesegments}), project::Bool)
+    return data_limits(plot)
+end
+
+function _boundingbox(@nospecialize(plot::MeshScatter), project::Bool)
+    if project
+        # TODO
+    else
+        return data_limits(plot)
+    end
+end
+
+function _boundingbox(@nospecialize(plot::Text), project::Bool)
+    if project
+        # TODO
+    else
+        return data_limits(plot)
+    end
+end
+
+_boundingbox(@nospecialize(plot::Mesh), project::Bool) = data_limits(plot)
+
+function _boundingbox(@nospecialize(plot::Union{Image, Heatmap, Surface, Volume}), project::Bool)
+    return data_limits(plot)
+end
+
+
+################################################################################
+### Element versions
+################################################################################
+
+# Very TODO stil...
+# - general: maybe split off marker_boundingbox
+# - general: boundingbox(plot, idx) should also project, transform
+#    - this lends itself to doing `projectionview * model` and `pvm * local_model`?
+# - text: maybe add bbox to glyphcollection
+
+function _boundingbox(@nospecialize(plot::Scatter), idx::Integer, project::Bool)
+    p = plot.positions[][i]
+    return Rect3f(p)
+
+    m_p = project(plot, p, plot.space[], plot.markerspace[])
+    m_size = Vec2f(attr_broadcast_getindex(plot.markersize, idx))
+    m_offset = Vec2f(attr_broadcast_getindex(plot.marker_offset))
+    m_bbox = boundingbox(attr_broadcast_getindex(plot.marker[]))
+
+    # TODO: transform_marker
+    # TODO: 2D vs 3D
+    m_bbox = m_bbox * m_size + m_p + m_offset
+
+    # decompose, inverse transform, boundingbox return
+end
+
+function _boundingbox(@nospecialize(plot::Text), idx::Integer, project::Bool)
+    _boundingbox(plot.plots[1], idx, project)
+end
+function _boundingbox(@nospecialize(plot::Text{<:Tuple{<:GlyphCollection}}), idx::Integer, project::Bool)
+    idx == 1 || throw(BoundsError("Text plot only contains one string."))
+
+end
+function _boundingbox(@nospecialize(plot::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}}), idx::Integer, project::Bool)
+
+end

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -68,6 +68,8 @@ mutable struct Scene <: AbstractScene
     "The [`Transformation`](@ref) of the Scene."
     transformation::Transformation
 
+    bbox::LazyBoundingBox
+
     "The plots contained in the Scene."
     plots::Vector{AbstractPlot}
 
@@ -114,6 +116,7 @@ mutable struct Scene <: AbstractScene
             camera,
             camera_controls,
             transformation,
+            LazyBoundingBox(),
             plots,
             theme,
             children,


### PR DESCRIPTION
# Description

I wanted to put some of my thoughts on bounding boxes into writing/code.

## What uses bounding boxes?

- Axis, Axis3, PolarAxis, axis3d! use bounding boxes for limits, ticks
- Axis, Axis3, PolarAxis, Scene use bounding boxes for camera placement
- PolarAxis and more indirectly Axis, Axis3 and Scene use bounding boxes for clipping

Other uses/influences:
- OIT uses depth as weight, so it works better if the depth range is filled completely, i.e. if near and far are tightly picked. It would benefit from tracking scene bounding boxes to correctly select near and far
- shadow mapping would benefit from scene bounding boxes to more easily generate different camera perspectives
- (full) ray based picking would require accurate bounding boxes to quickly discard missed plots and sort potential hits
- collisions would require them for the same

Since limits are used for plotted data pretty much everywhere we should just have a common scene bounding box, derived from plot bounding boxes.

### About coordinate spaces

Generally bounding boxes are needed in the space their data is in:
- limits (Axis, Axis3, PolarAxis, axis3d) require data space bounding boxes
- layouting (e.g. tick and axis label spacing) requires pixel space bounding boxes of text placed in pixel space (PolarAxis placed ticks in data space but skips the conversion for layouting. Axis3 maybe does something similar?)

Some require transformations down the pipeline:
- cameras may require world space bounding boxes if not controlled via an Axis
- shadow mapping would require world space bounding boxes

Moving up the pipeline is less clear:
- a :pixel or :relative space text annotation in an Axis should not affect its bounding box / limits
- a plot without a transform_func in and a Scene with one should maybe influence limits

Plots should probably have space conversion for their bounding boxes. Scenes should either filter (e.g. only consider :data space plots for a :data space bounding box) or transform only :data, :transformed and :world space into each other as data in those spaces depend on things the scene (may) control.

### About accurate bounding boxes / marker bounding boxes

- some cases require the inclusion of marker bboxes i.e. including the size of a scattered marker or mesh (e.g. ray based picking, collisions)
- most care more about speed but would still like them to be included (limits, camera placement, clipping)
- none need marker bounding boxes to be excluded

So I think we want a fast and an accurate version of `boundingbox()`. Fast can include marker bounding boxes if they are cheap, while accurate always includes them.

I'm not sure how fast the fast version should be/needs to be. E.g. should bounding boxes in other spaces just transform the data space bounding box or transform data and then calculate a new bounding box?

### About caching / Lazy bounding boxes

Bounding Boxes are generally not something we need to process asap
- limits and cameras don't update on bbox changes, only on plot insertions
- layouting does react immediately and may need to do multiple round trips... if not it only needs to react up to once per (potential) frame
- shadow mapping would require once per frame
- ray based picking and DataInspector (e.g. for mesh) are on demand
- collisions would be once per time step

And also something we need regardless of whether they changed
- layouting may require bounding boxes of unchanged objects when other things change (other plots, scene resolution) (?)
- camera may need bounding box again to keep clipping correct when zooming
- shadow mapping, DataInspector, ray based picking and collisions all need a bounding box regardless of whether it changed

To avoid lots of redundant calculations bounding boxes should be cached and lazy. It would be nice to have an `on_bounding_box_change` though.

### Other Notes

- Some cases only care about marker bounding boxes (i.e. position argument ignored). E.g. DataInspector for meshscatter, maybe layouting for ticks. (May apply to: scatter, text, meshscatter, linesegments, voxels, arrows, ...)
- Many bboxes are only 2d. I think this can be handled by just setting the z values to NaN
- `vlines` (...) should not result in y (...) limits changes in Axis etc. Imo this should not discard a dimension of the bounding box, as that dimension still affects the bounds of the plot/visualization. This should be handled by the Axis instead. Maybe that dimension should be `Inf`, if that's not impractical...
- Adding `plot.transformed = apply_transform(transform_func(plot), plot.converted)` would give us cheaper/more accurate bounding boxes in `:transformed` space

## Summary of Goals

- add cached bounding boxes to plots and scenes
- make updates of bounding boxes lazy/on demand
- offer a fast and an accurate `boundingbox(obj, mode = :fast/:accurate)`
- deprecate `data_limits` for fast bounding boxes
-  figure out how to handle spaces, maybe:
    - have `boundingbox(plot, space)` transform to the given space
    - have `boundingbox(scene, space)` only regard plots in that space
    - or have `boudningbox(scene, space)` transform plot bboxes to the given space, but only for :data, :transformed and :world space plots (ignoring :pixel, :relative and :clip space plots and returning invalid bbox if the passed space is one of those)
- offer bounding boxes for markers (w/o position applied), maybe just internally
- offer bounding boxes of specific elements `boundingbox(obj, index)`
- maybe offer some utility for reacting to changes of the bounding box

----

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
