### PR TITLE
Don't clear args, rely on delete deregister_callbacks

### DIFF
--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -467,9 +467,6 @@ function free(plot::AbstractPlot)
     for f in plot.deregister_callbacks
         Observables.off(f)
     end
-    for arg in plot.args
-        Observables.clear(arg)
-    end
     foreach(free, plot.plots)
     empty!(plot.plots)
     empty!(plot.deregister_callbacks)


### PR DESCRIPTION
We did clear the arguments of a plot incorrectly.
I think this is a leftover from the refactor, where the ownership of the observables in `plot.arg` changed (before it was always created just for the plot).
Needs some tests, to make sure we don't introduce any memory leaks with this change.
Closes #3542