### PR TITLE
Fix issues with explicitly transformed recipes in DataInspector

### DIFF
--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -1042,3 +1042,35 @@ function show_data(inspector::DataInspector, plot::Band, idx::Integer, mesh::Mes
 
     return true
 end
+
+
+
+function show_data(inspector::DataInspector, plot::Union{HLines, VLines}, idx)
+    a = inspector.attributes
+    tt = inspector.plot
+    scene = parent_scene(plot)
+
+    lineplot = plot.plots[1]
+
+    # cast ray from cursor into screen, find closest point to line
+    pos = position_on_plot(lineplot, idx, apply_transform = true)
+    proj_pos = shift_project(scene, pos)
+    update_tooltip_alignment!(inspector, proj_pos)
+
+    tt.offset[] = ifelse(
+        a.apply_tooltip_offset[],
+        sv_getindex(lineplot.linewidth[], idx) + 2,
+        a.offset[]
+    )
+
+    pos = apply_transform(inverse_transform(transform_func(lineplot)), pos)
+    if haskey(plot, :inspector_label)
+        tt.text[] = plot[:inspector_label][](plot, idx, eltype(plot[1][])(pos))
+    else
+        tt.text[] = position2string(eltype(plot[1][])(pos))
+    end
+    tt.visible[] = true
+    a.indicator_visible[] && (a.indicator_visible[] = false)
+
+    return true
+end


### PR DESCRIPTION
# Description

Fixes #3526

With a plot structure like
```
recipe_plot
  primitive
```
where recipe_plot does not implement it's own `show_data` method, DataInspector will fall back on `show_data` for `primitive`. There it will assume that the input data of the primitive plot is in data space. If the recipe_plot handles the transform function directly, passing the result to primitive, the assumption that the input data is in data space is not correct. So you get incorrect labels.

This should affect every recipe plot that applies `transform_func` before creating child plots. That is:
- h/vlines
- h/vspan
- maybe barplot
- bracket
- contours
- error/rangebars
- poly
- text with lines (tex)
- tooltip
- triplot
- voronoiplot

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
