### PR TITLE
add typed argument conversion

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -497,7 +497,7 @@ function Base.delete!(screen::Screen, scene::Scene)
 
         # Remap scene IDs to a continuous range by replacing the largest ID
         # with the one that got removed
-        if deleted_id-1 != length(screen.screens)
+        if deleted_id - 1 != length(screen.screens)
             key, max_id = first(screen.screen2scene)
             for p in screen.screen2scene
                 if p[2] > max_id

--- a/MakieCore/src/conversion.jl
+++ b/MakieCore/src/conversion.jl
@@ -100,3 +100,105 @@ conversion_trait(::Type{<: Image}) = ImageLike()
 
 struct VolumeLike <: ConversionTrait end
 conversion_trait(::Type{<: Volume}) = VolumeLike()
+
+"""
+    convert_arguments_typed(::Type{<: AbstractPlot}, args...)::NamedTuple
+
+Converts the arguments to their correct type for the Plot type.
+Throws appropriate errors if it can't convert.
+"""
+function convert_arguments_typed end
+
+function convert_arguments_typed(P::Type{<:AbstractPlot}, @nospecialize(args...))
+    return convert_arguments_typed(typeof(conversion_trait(P, args...)), args...)
+end
+
+function convert_arguments_typed(ct::Type{<:ConversionTrait}, @nospecialize(args...))
+    # We currently just fall back to not doing anything if there isn't a convert_arguments_typed defined for certain plot types.
+    # This makes `@convert_target` an optional feature right now.
+    # It will require a bit more work to error here and request an overload for every plot type.
+    # We will have to think more about how to integrate it with user recipes, because otherwise all user defined recipes would error by default without a convert target.
+    return args
+end
+
+convert_arguments_typed(::NoConversion, args...) = args
+
+"""
+    @convert_target(expr)
+Allows to define a conversion target for a plot type, so that `convert_arguments` can be checked properly, if it converts to the correct types.
+Usage:
+```Julia
+@convert_target struct PointBased{N} # Can be the Plot type or a ConversionTrait
+    positions::AbstractVector{Point{N, Float32}}
+end
+```
+This defines an overload of `convert_arguments_typed` pretty much in this way (error handling etc omitted):
+```Julia
+function convert_arguments_typed(ct::Type{<: PointBased}, positions)
+    converted_positions = convert(AbstractVector{Point{N, Float32}} where N, positions)
+    return (positions = converted_positions,) # returns a NamedTuple corresponding to the layout of the struct
+end
+```
+This way, we can throw nice errors, if `convert_arguments` doesn't convert to `AbstractVector{Point{N, Float32}}`.
+Take a look at Makie/src/conversions.jl, to see a few of the core conversion targets.
+"""
+macro convert_target(struct_expr)
+    if !Meta.isexpr(struct_expr, :struct)
+        error("Expression must be `struct Target; fields...; end`")
+    else
+        target_name = struct_expr.args[2]
+
+        if Meta.isexpr(target_name, :curly)
+            target_name, targs... = target_name.args
+        else
+            targs = ()
+        end
+
+        body = struct_expr.args[3]
+        convert_expr = []
+        converted = Symbol[]
+        all_fields = filter(x -> !(x isa LineNumberNode), body.args)
+        if any(x -> !Meta.isexpr(x, :(::)), all_fields)
+            error("All fields need to be of type `name::Type`. Found: $(all_fields)")
+        end
+        names = map(x -> x.args[1], all_fields)
+        types = map(x -> :($(x.args[2]) where {$(targs...)}), all_fields)
+        for (name, TargetType) in zip(names, types)
+            conv_name = Symbol("converted_$name")
+            push!(converted, conv_name)
+            # We always add the where clause, since it's too complicated to match the static type parameters to the types that use them.
+            # This seems to work well, since Julia drops any unecessary where clause/ type parameter, while lowering.
+            # TODO figure out a way to drop the where close... Eval is the only thing I found, but shouldn't be used here.
+
+            expr = quote
+                # Unions etc don't work well with `convert(T, x)`, so we try not to convert if already the right type!
+                if $name isa $TargetType
+                    $conv_name = $name
+                else
+                    $conv_name = try
+                        convert($TargetType, $name)
+                    catch e
+                        arg_types = map(typeof, ($(names...),))
+                        err = """
+                        Can't convert argument $($(string(name)))::$(typeof($name)) to target type $($TargetType).
+                        Either define:
+                            convert_arguments(::Type{<: $($target_name)}, $(join(arg_types, ", "))) where {$($targs...)}) = ...
+                        Or use a type that can get converted to $($TargetType).
+                        """
+                        error(err)
+                    end
+                end
+            end
+            push!(convert_expr, expr)
+        end
+
+        expr = quote
+            function MakieCore.convert_arguments_typed(::Type{<:$(target_name)}, $(names...))
+                $(convert_expr...)
+                return NamedTuple{($(QuoteNode.(names)...),)}(($(converted...),))
+            end
+        end
+        return esc(expr)
+    end
+    return
+end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -247,7 +247,7 @@ end
     values = [sin(x[i]) * cos(y[j]) * sin(z[k]) for i in 1:20, j in 1:20, k in 1:20]
 
     # TO not make this fail in CairoMakie, we dont actually plot the volume
-    _f, ax, cp = contour(x, y, z, values; levels=10, colormap=:viridis)
+    _f, ax, cp = contour(-1..1, -1..1, -1..1, values; levels=10, colormap=:viridis)
     Colorbar(fig[2, 1], cp; size=300)
 
     _f, ax, vs = volumeslices(x, y, z, values, colormap=:bluesreds)

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -98,7 +98,8 @@ export ConversionTrait, NoConversion, PointBased, GridBased, VertexGrid, CellGri
 export Pixel, px, Unit, plotkey, attributes, used_attributes
 export Linestyle
 
-const RealVector{T} = AbstractVector{T} where T <: Real
+const RealVector{T} = AbstractVector{T} where {T<:Real}
+const RealMatrix{T} = AbstractMatrix{T} where {T<:Real}
 const RGBAf = RGBA{Float32}
 const RGBf = RGB{Float32}
 const NativeFont = FreeTypeAbstraction.FTFont

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -90,14 +90,15 @@ import MakieCore: plot, plot!, theme, plotfunc, plottype, merge_attributes!, cal
 import MakieCore: create_axis_like, create_axis_like!, figurelike_return, figurelike_return!
 import MakieCore: arrows, heatmap, image, lines, linesegments, mesh, meshscatter, poly, scatter, surface, text, volume
 import MakieCore: arrows!, heatmap!, image!, lines!, linesegments!, mesh!, meshscatter!, poly!, scatter!, surface!, text!, volume!
-import MakieCore: convert_arguments, convert_attribute, default_theme, conversion_trait
+import MakieCore: convert_arguments, convert_attribute, default_theme, conversion_trait, @convert_target,
+                  convert_arguments_typed
 
 export @L_str, @colorant_str
 export ConversionTrait, NoConversion, PointBased, GridBased, VertexGrid, CellGrid, ImageLike, VolumeLike
 export Pixel, px, Unit, plotkey, attributes, used_attributes
 export Linestyle
 
-const RealVector{T} = AbstractVector{T} where T <: Number
+const RealVector{T} = AbstractVector{T} where T <: Real
 const RGBAf = RGBA{Float32}
 const RGBf = RGB{Float32}
 const NativeFont = FreeTypeAbstraction.FTFont

--- a/src/basic_recipes/volumeslices.jl
+++ b/src/basic_recipes/volumeslices.jl
@@ -17,7 +17,7 @@ $(ATTRIBUTES)
     )
 end
 
-function plot!(plot::VolumeSlices)
+function Makie.plot!(plot::VolumeSlices)
     @extract plot (x, y, z, volume)
     replace_automatic!(plot, :colorrange) do
         map(extrema, volume)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -490,7 +490,7 @@ Takes 3 `AbstractVector` `x`, `y`, and `z` and the `AbstractMatrix` `i`, and put
 
 `P` is the plot Type (it is optional).
 """
-function convert_arguments(::VolumeLike, x::AbstractVector, y::AbstractVector, z::AbstractVector, i::AbstractArray{T, 3}) where T
+function convert_arguments(::VolumeLike, x::AbstractVector, y::AbstractVector, z::AbstractVector, i::AbstractArray{<: Real, 3})
     (to_interval(x, "x"), to_interval(y, "y"), to_interval(z, "z"), el32convert(i))
 end
 

--- a/src/figureplotting.jl
+++ b/src/figureplotting.jl
@@ -108,13 +108,81 @@ end
 
 const PlotOrNot = Union{AbstractPlot, Nothing}
 
+# For recipes (plot!(plot_object, ...)))
+MakieCore.create_axis_like!(::Dict, s::Union{Plot, Scene}) = s
+
+# For plotspec
+# MakieCore.create_axis_like!(::PlotSpecPlot, ::Dict, fig::Figure) = fig
+MakieCore.create_axis_like!(::Dict, f::Figure) = f
+
 """
-    create_axis_like(plot::PlotOrNot, attributes::Dict, ::Nothing)
+    create_axis_like!(attributes::Dict, ax::AbstractAxis)
+
+Method for e.g.: `plot!(ax, 1:4)`, which plots into an existing axis.
+"""
+function create_axis_like!(attributes::Dict, ax::AbstractAxis)
+    _disallow_keyword(:axis, attributes)
+    return ax
+end
+
+"""
+    create_axis_like!(attributes::Dict, gsp::GridSubposition)
+
+method to create an axis for e.g.: `plot!(fig[1, 1][1, 1], 1:4)`, which needs an axis in f[1, 1][1, 1].
+"""
+function MakieCore.create_axis_like!(attributes::Dict, gsp::GridSubposition)
+    _disallow_keyword(:figure, attributes)
+    layout = GridLayoutBase.get_layout_at!(gsp.parent; createmissing=false)
+    gp = layout[gsp.rows, gsp.cols, gsp.side]
+    c = contents(gp; exact=true)
+    if !(length(c) == 1 && can_be_current_axis(c[1]))
+        error("There is not just one axis at $(gp).")
+    end
+    _disallow_keyword(:axis, attributes)
+    return first(c)
+end
+
+"""
+    create_axis_like!(attributes::Dict, ::Nothing)
+
+method to create an axis for e.g.: `plot!(1:4)`, which requires a current figure and axis.
+"""
+function MakieCore.create_axis_like!(attributes::Dict, ::Nothing)
+    figure = current_figure()
+    isnothing(figure) && error("There is no current figure to plot into.")
+    _disallow_keyword(:figure, attributes)
+    ax = current_axis(figure)
+    isnothing(ax) && error("There is no current axis to plot into.")
+    _disallow_keyword(:axis, attributes)
+    return ax
+end
+
+"""
+    create_axis_like!(attributes::Dict, gp::GridPosition)
+
+method to create an axis for e.g.: `plot!(fig[1, 1], 1:4)`, which requires an axis to be in `f[1, 1]`.
+"""
+function MakieCore.create_axis_like!(attributes::Dict, gp::GridPosition)
+    _disallow_keyword(:figure, attributes)
+    c = contents(gp; exact=true)
+    if !(length(c) == 1 && can_be_current_axis(c[1]))
+        error("There needs to be a single axis-like object at $(gp.span), $(gp.side) to plot into.\nUse a non-mutating plotting command to create an axis implicitly.")
+    end
+    ax = first(c)
+    _disallow_keyword(:axis, attributes)
+    return ax
+end
+
+function create_axis_like(::AbstractPlot, ::Dict, ::Union{Scene,AbstractAxis})
+    return error("Plotting into an axis without `!` (e.g. `scatter` instead of `scatter!`)")
+end
+
+"""
+    create_axis_like(plot::AbstractPlot, attributes::Dict, ::Nothing)
 
 method to create an axis for e.g.: `plot(1:4)`, which has no axis nor a figure yet.
 """
-function create_axis_like(plot::PlotOrNot, attributes::Dict, ::Nothing)
-    isnothing(plot) && return nothing
+function create_axis_like(plot::AbstractPlot, attributes::Dict, ::Nothing)
     figure_kw = extract_attributes(attributes, :figure)
     figure = Figure(; figure_kw...)
     ax = create_axis_for_plot(figure, plot, attributes)
@@ -126,46 +194,12 @@ function create_axis_like(plot::PlotOrNot, attributes::Dict, ::Nothing)
     end
 end
 
-MakieCore.create_axis_like!(::PlotOrNot, attributes::Dict, s::Union{Plot, Scene}) = s
-
 """
-    create_axis_like!(::PlotOrNot, attributes::Dict, ::Nothing)
-
-method to create an axis for e.g.: `plot!(1:4)`, which requires a current figure and axis.
-"""
-function MakieCore.create_axis_like!(@nospecialize(::PlotOrNot), attributes::Dict, ::Nothing)
-    figure = current_figure()
-    isnothing(figure) && error("There is no current figure to plot into.")
-    _disallow_keyword(:figure, attributes)
-    ax = current_axis(figure)
-    isnothing(ax) && error("There is no current axis to plot into.")
-    _disallow_keyword(:axis, attributes)
-    return ax
-end
-
-"""
-    create_axis_like!(::PlotOrNot, attributes::Dict, gp::GridPosition)
-
-method to create an axis for e.g.: `plot!(fig[1, 1], 1:4)`, which requires an axis to be in `f[1, 1]`.
-"""
-function MakieCore.create_axis_like!(::PlotOrNot, attributes::Dict, gp::GridPosition)
-    _disallow_keyword(:figure, attributes)
-    c = contents(gp; exact=true)
-    if !(length(c) == 1 && can_be_current_axis(c[1]))
-        error("There needs to be a single axis-like object at $(gp.span), $(gp.side) to plot into.\nUse a non-mutating plotting command to create an axis implicitly.")
-    end
-    ax = first(c)
-    _disallow_keyword(:axis, attributes)
-    return ax
-end
-
-
-"""
-    create_axis_like(plot::PlotOrNot, attributes::Dict, gp::GridPosition)
+    create_axis_like(plot::AbstractPlot, attributes::Dict, gp::GridPosition)
 
 method to create an axis for e.g.: `plot(fig[1, 1], 1:4)`, which creates a new axis in f[1, 1].
 """
-function create_axis_like(plot::PlotOrNot, attributes::Dict, gp::GridPosition)
+function create_axis_like(plot::AbstractPlot, attributes::Dict, gp::GridPosition)
     isnothing(plot) && return nothing
     _disallow_keyword(:figure, attributes)
     figure = get_top_parent(gp)
@@ -187,30 +221,12 @@ function create_axis_like(plot::PlotOrNot, attributes::Dict, gp::GridPosition)
     end
 end
 
-
 """
-    create_axis_like!(@nospecialize(::PlotOrNot), attributes::Dict, gsp::GridSubposition)
-
-method to create an axis for e.g.: `plot!(fig[1, 1][1, 1], 1:4)`, which needs an axis in f[1, 1][1, 1].
-"""
-function MakieCore.create_axis_like!(::PlotOrNot, attributes::Dict, gsp::GridSubposition)
-    _disallow_keyword(:figure, attributes)
-    layout = GridLayoutBase.get_layout_at!(gsp.parent; createmissing=false)
-    gp = layout[gsp.rows, gsp.cols, gsp.side]
-    c = contents(gp; exact=true)
-    if !(length(c) == 1 && can_be_current_axis(c[1]))
-        error("There is not just one axis at $(gp).")
-    end
-    _disallow_keyword(:axis, attributes)
-    return first(c)
-end
-
-"""
-    create_axis_like(@nospecialize(::PlotOrNot), attributes::Dict, gsp::GridSubposition)
+    create_axis_like(plot::AbstractPlot, attributes::Dict, gsp::GridSubposition)
 
 method to create an axis for e.g.: `plot(fig[1, 1][1, 1], 1:4)`, which creates an axis in f[1, 1][1, 1].
 """
-function create_axis_like(plot::PlotOrNot, attributes::Dict, gsp::GridSubposition)
+function create_axis_like(plot::AbstractPlot, attributes::Dict, gsp::GridSubposition)
     isnothing(plot) && return nothing
     _disallow_keyword(:figure, attributes)
     GridLayoutBase.get_layout_at!(gsp.parent; createmissing=true)
@@ -230,15 +246,6 @@ function create_axis_like(plot::PlotOrNot, attributes::Dict, gsp::GridSubpositio
     ax = create_axis_for_plot(figure, plot, attributes)
     gsp.parent[gsp.rows, gsp.cols, gsp.side] = ax
     return ax
-end
-
-function create_axis_like!(::PlotOrNot, attributes::Dict, ax::AbstractAxis)
-    _disallow_keyword(:axis, attributes)
-    return ax
-end
-
-function create_axis_like(::PlotOrNot, ::Dict, ::Union{Scene,AbstractAxis})
-    return error("Plotting into an axis without !")
 end
 
 figurelike_return(fa::FigureAxis, plot::AbstractPlot) = FigureAxisPlot(fa.figure, fa.axis, plot)
@@ -280,13 +287,8 @@ default_plot_func(::typeof(plot), args) = plotfunc(plottype(map(to_value, args).
     figarg, pargs = plot_args(args...)
     figkws = fig_keywords!(attributes)
 
-    # we need to see if we plot into an existing axis before creating the plot
-    # For axis specific converts.
-    # If this is a plotting function which newly creates an axis, we can skip this and it will return nothing
-    maybe_ax = create_axis_like(nothing, figkws, figarg)
     plot = Plot{default_plot_func(F, pargs)}(pargs, attributes)
-    # Now, create the axis if it wasn't existing before
-    ax = isnothing(maybe_ax) ? create_axis_like(plot, figkws, figarg) : maybe_ax
+    ax = create_axis_like(plot, figkws, figarg)
     plot!(ax, plot)
     return figurelike_return(ax, plot)
 end
@@ -297,10 +299,8 @@ end
     # we need to see if we plot into an existing axis before creating the plot
     # For axis specific converts.
     # If this is a plotting function which newly creates an axis, we can skip this and it will return nothing
-    maybe_ax = create_axis_like!(nothing, figkws, figarg)
+    ax = create_axis_like!(figkws, figarg)
     plot = Plot{default_plot_func(F, pargs)}(pargs, attributes)
-    # Now, create the axis if it wasn't existing before
-    ax = isnothing(maybe_ax) ? create_axis_like!(plot, figkws, figarg) : maybe_ax
     plot!(ax, plot)
     return figurelike_return!(ax, plot)
 end
@@ -318,8 +318,9 @@ const PlotSpecPlot = Plot{plot, Tuple{<: GridLayoutSpec}}
 
 figurelike_return(f::GridPosition, p::PlotSpecPlot) = p
 figurelike_return(f::Figure, p::PlotSpecPlot) = FigureAxisPlot(f, nothing, p)
-MakieCore.create_axis_like!(::PlotSpecPlot, attributes::Dict, fig::Figure) = fig
-MakieCore.create_axis_like!(::PlotOrNot, attributes::Dict, fig::Figure) = nothing
+
+
+
 
 # Axis interface
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -220,7 +220,7 @@ plottype(::MultiPolygon) = Lines
 
 
 # all the plotting functions that get a plot type
-const PlotFunc = Union{Type{Any},Type{<:AbstractPlot}}
+const PlotFunc = Type{<:AbstractPlot}
 
 function plot!(::Plot{F}) where {F}
     if !(F in atomic_functions)

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -193,6 +193,8 @@ end
 
 GridLayoutSpec(contents...; kwargs...) = GridLayoutSpec([contents...]; kwargs...)
 
+apply_typed_convert(P, @nospecialize(args::Tuple)) = values(convert_arguments_typed(P, args...))
+
 """
 apply for return type PlotSpec
 """
@@ -203,7 +205,8 @@ function apply_convert!(P, attributes::Attributes, x::PlotSpec)
     for (k, v) in pairs(kwargs)
         attributes[k] = v
     end
-    return (plottype(plottype(x), P), (args...,))
+    NP = plottype(plottype(x), P)
+    return (NP, apply_typed_convert(NP, (args...,)))
 end
 
 function apply_convert!(P, ::Attributes, x::AbstractVector{PlotSpec})
@@ -214,7 +217,7 @@ end
 apply for return type
     (args...,)
 """
-apply_convert!(P, ::Attributes, x::Tuple) = (P, x)
+apply_convert!(P, ::Attributes, args::Tuple) = (P, apply_typed_convert(P, args))
 
 function MakieCore.argtypes(plot::PlotSpec)
     args_converted = convert_arguments(plottype(plot), plot.args...)

--- a/src/stats/density.jl
+++ b/src/stats/density.jl
@@ -1,4 +1,4 @@
-function convert_arguments(P::PlotFunc, d::KernelDensity.UnivariateKDE)
+function convert_arguments(P::Type{<:AbstractPlot}, d::KernelDensity.UnivariateKDE)
     ptype = plottype(P, Lines) # choose the more concrete one
     to_plotspec(ptype, convert_arguments(ptype, d.x, d.density))
 end
@@ -11,7 +11,7 @@ function convert_arguments(::Type{<:Poly}, d::KernelDensity.UnivariateKDE)
     (points,)
 end
 
-function convert_arguments(P::PlotFunc, d::KernelDensity.BivariateKDE)
+function convert_arguments(P::Type{<:AbstractPlot}, d::KernelDensity.BivariateKDE)
     ptype = plottype(P, Heatmap)
     to_plotspec(ptype, convert_arguments(ptype, d.x, d.y, d.density))
 end

--- a/src/stats/distributions.jl
+++ b/src/stats/distributions.jl
@@ -16,9 +16,9 @@ isdiscrete(::Distribution{<:VariateForm,<:Discrete}) = true
 support(dist::Distribution) = default_range(dist)
 support(dist::Distribution{<:VariateForm,<:Discrete}) = UnitRange(endpoints(default_range(dist))...)
 
-convert_arguments(P::PlotFunc, dist::Distribution) = convert_arguments(P, support(dist), dist)
+convert_arguments(P::Type{<:AbstractPlot}, dist::Distribution) = convert_arguments(P, support(dist), dist)
 
-function convert_arguments(P::PlotFunc, x::Union{Interval,AbstractVector}, dist::Distribution)
+function convert_arguments(P::Type{<:AbstractPlot}, x::Union{Interval,AbstractVector}, dist::Distribution)
     default_ptype = isdiscrete(dist) ? ScatterLines : Lines
     ptype = plottype(P, default_ptype)
     to_plotspec(ptype, convert_arguments(ptype, x, x -> pdf(dist, x)))

--- a/src/stats/ecdf.jl
+++ b/src/stats/ecdf.jl
@@ -5,8 +5,8 @@ function ecdf_xvalues(ecdf::StatsBase.ECDF, npoints)
     return @inbounds range(x[1], x[n]; length=npoints)
 end
 
-used_attributes(::PlotFunc, ::StatsBase.ECDF) = (:npoints,)
-function convert_arguments(P::PlotFunc, ecdf::StatsBase.ECDF; npoints=10_000)
+used_attributes(::Type{<:AbstractPlot}, ::StatsBase.ECDF) = (:npoints,)
+function convert_arguments(P::Type{<:AbstractPlot}, ecdf::StatsBase.ECDF; npoints=10_000)
     ptype = plottype(P, Stairs)
     x0 = ecdf_xvalues(ecdf, npoints)
     if ptype <: Stairs
@@ -20,13 +20,13 @@ function convert_arguments(P::PlotFunc, ecdf::StatsBase.ECDF; npoints=10_000)
     return to_plotspec(ptype, convert_arguments(ptype, x, ecdf(x)); kwargs...)
 end
 
-function convert_arguments(P::PlotFunc, x::AbstractVector, ecdf::StatsBase.ECDF)
+function convert_arguments(P::Type{<:AbstractPlot}, x::AbstractVector, ecdf::StatsBase.ECDF)
     ptype = plottype(P, Stairs)
     kwargs = ptype <: Stairs ? (; step=:post) : NamedTuple()
     return to_plotspec(ptype, convert_arguments(ptype, x, ecdf(x)); kwargs...)
 end
 
-function convert_arguments(P::PlotFunc, x0::AbstractInterval, ecdf::StatsBase.ECDF)
+function convert_arguments(P::Type{<:AbstractPlot}, x0::AbstractInterval, ecdf::StatsBase.ECDF)
     xmin, xmax = extrema(x0)
     z = ecdf_xvalues(ecdf, Inf)
     n = length(z)

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -470,3 +470,22 @@ function available_plotting_methods()
     end
     return meths
 end
+
+function extract_method_arguments(m::Method)
+    tv, decls, file, line = Base.arg_decl_parts(m)
+    tnames = map(decls[3:end]) do (n, t)
+        return string(n, "::", t)
+    end
+    return join(tnames, ", ")
+end
+
+function available_conversions(PlotType)
+    result = []
+    for m in methods(convert_arguments, (PlotType, Vararg{Any}))
+        push!(result, extract_method_arguments(m))
+    end
+    for m in methods(convert_arguments, (typeof(Makie.conversion_trait(PlotType)), Vararg{Any}))
+        push!(result, extract_method_arguments(m))
+    end
+    return result
+end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -177,7 +177,8 @@ end
 @testset "single conversions" begin
     myvector = MyVector(collect(1:10))
     mynestedvector = MyNestedVector(MyVector(collect(11:20)))
-    @test_throws ErrorException convert_arguments(Lines, myvector, mynestedvector)
+    @test convert_arguments(Lines, myvector, mynestedvector) ===
+                                (myvector, mynestedvector)
 
     Makie.convert_single_argument(v::MyNestedVector) = v.v
     Makie.convert_single_argument(v::MyVector) = v.v
@@ -333,8 +334,8 @@ end
         @test convert_arguments(Image, m3)         == (0f0..10f0, 0f0..6f0, o3)
         @test convert_arguments(Image, v1, r2, m3) == (1f0..10f0, 1f0..6f0, o3)
         @test convert_arguments(Image, i1, v2, m3) == (1f0..10f0, 1f0..6f0, o3)
-        @test_throws ErrorException convert_arguments(Image, m1, m2, m3)
-        @test_throws ErrorException convert_arguments(Heatmap, m1, m2)
+        @test convert_arguments(Image, m1, m2, m3) === (m1, m2, m3)
+        @test convert_arguments(Heatmap, m1, m2) === (m1, m2)
     end
 
     @testset "VertexGrid conversion" begin
@@ -356,8 +357,10 @@ end
         @test convert_arguments(Heatmap, r1, i2, m3) == (o1, o2, o3)
         @test convert_arguments(Heatmap, v1, r2, m3) == (o1, o2, o3)
         @test convert_arguments(Heatmap, 0:10, v2, m3) == (collect(0f0:10f0), o2, o3)
-        @test_throws ErrorException convert_arguments(Heatmap, m1, m2, m3)
-        @test_throws ErrorException convert_arguments(Heatmap, m1, m2)
+        # TODO, this throws ERROR: MethodError: no method matching adjust_axes(::CellGrid, ::Matrix{Int64}, ::Matrix{Int64}, ::Matrix{Float64})
+        # Is this what we want to test for?
+        @test_throws MethodError convert_arguments(Heatmap, m1, m2, m3) === (m1, m2, m3)
+        @test convert_arguments(Heatmap, m1, m2) === (m1, m2)
     end
 end
 

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -8,7 +8,6 @@
     @test points[] == [Point2f(5), Point2f(15)]
 end
 
-
 @testset "arrows" begin
     # Test for:
     # https://github.com/MakieOrg/Makie.jl/issues/3273

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ using Makie: volume
 
 @testset "Unit tests" begin
     @testset "#659 Volume errors if data is not a cube" begin
-        fig, ax, vplot = volume(1:8, 1:8, 1:10, rand(8, 8, 10))
+        fig, ax, vplot = volume(1..8, 1..8, 1..10, rand(8, 8, 10))
         lims = Makie.data_limits(vplot)
         lo, hi = extrema(lims)
         @test all(lo .<= 1)


### PR DESCRIPTION
This is step 1 for #3226, to clean up `convert_arguments`, to be able to better know when a conversion was successful or needs axis converts.

This should:
* improve error messages for types that don't convert for the plot type
* allow better recursive application of `convert_arguments` 
* closes #3548