### PR TITLE
Fix a hang due to `limits!` being called recursively

### DIFF
--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1372,8 +1372,10 @@ function limits!(ax::Axis, rect::Rect2)
     Makie.ylims!(ax, ymin, ymax)
 end
 
-function limits!(args...)
-    limits!(current_axis(), args...)
+function limits!(args::Union{Nothing, Real, HyperRectangle}...)
+    axis = current_axis()
+    axis isa Nothing && error("There is no currently active axis!")
+    limits!(axis, args...)
 end
 
 Makie.transform_func(ax::Axis) = Makie.transform_func(ax.scene)

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -113,6 +113,7 @@ end
     @test ax.limits[] == (nothing, [5, 7])
     @test ax.targetlimits[] == BBox(-5, 11, 5, 7)
     @test ax.finallimits[] == BBox(-5, 11, 5, 7)
+    @test_throws MethodError limits!(f[1,1], -1, 1, -1, 1)
 end
 
 # issue 3240


### PR DESCRIPTION
# Description

Fixes #3564

Restricting the sans axis arguments to the expected types prevents the method from being called in a non-terminating loop which was the case if, for example, the function was called with an indexed `Figure` instead of an `Axis`; calling `limits!` without a current axis also resulted in a stack overflow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.