### PR TITLE
fix redisplaying figures on same screen

### DIFF
--- a/GLMakie/src/display.jl
+++ b/GLMakie/src/display.jl
@@ -2,6 +2,10 @@ function Base.display(screen::Screen, scene::Scene; connect=true)
     # So, the GLFW window events are not guarantee to fire
     # when we close a window, so we ensure this here!
     if !Makie.is_displayed(screen, scene)
+        if !isnothing(screen.root_scene)
+            delete!(screen, screen.root_scene)
+            screen.root_scene = nothing
+        end
         display_scene!(screen, scene)
     else
         @assert screen.root_scene === scene "internal error. Scene already displayed by screen but not as root scene"


### PR DESCRIPTION
The following would retain previously scene objects:
```julia
using GLMakie
GLMakie.activate!(float=true)

screen = GLMakie.Screen(; size=(600, 450))

f1 = Figure()
Axis(f1[1, 1])
display(screen, f1)

sleep(3)

f2 = Figure()
Axis3(f2[1, 1])
display(screen, f2)

display(screen, Figure().scene)
```
This PR fixes it!