### PR TITLE
Fix position of mirrored ticks when single dimension updates

### DIFF
--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -119,6 +119,20 @@ end
     f
 end
 
+# https://github.com/MakieOrg/Makie.jl/issues/3579
+@reference_test "Axis yticksmirrored" begin
+    f = Figure(size = (200, 200))
+    Axis(f[1, 1], yticksmirrored = true, yticksize = 10, ytickwidth = 4)
+    Colorbar(f[1, 2])
+    f
+end
+@reference_test "Axis xticksmirrored" begin
+    f = Figure(size = (200, 200))
+    Axis(f[1, 1], xticksmirrored = true, xticksize = 10, xtickwidth = 4)
+    Colorbar(f[0, 1], vertical = false)
+    f
+end
+
 @reference_test "Legend draw order" begin
     with_theme(Lines = (linewidth = 10,)) do
         f = Figure()

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -377,22 +377,22 @@ function initialize_block!(ax::Axis; palette = nothing)
     end
 
     xticksmirrored = lift(mirror_ticks, blockscene, xaxis.tickpositions, ax.xticksize, ax.xtickalign,
-                          Ref(scene.viewport), :x, ax.xaxisposition[])
+                          scene.viewport, :x, ax.xaxisposition[])
     xticksmirrored_lines = linesegments!(blockscene, xticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xticksvisible)),
         linewidth = ax.xtickwidth, color = ax.xtickcolor)
     translate!(xticksmirrored_lines, 0, 0, 10)
     yticksmirrored = lift(mirror_ticks, blockscene, yaxis.tickpositions, ax.yticksize, ax.ytickalign,
-                          Ref(scene.viewport), :y, ax.yaxisposition[])
+                          scene.viewport, :y, ax.yaxisposition[])
     yticksmirrored_lines = linesegments!(blockscene, yticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yticksvisible)),
         linewidth = ax.ytickwidth, color = ax.ytickcolor)
     translate!(yticksmirrored_lines, 0, 0, 10)
     xminorticksmirrored = lift(mirror_ticks, blockscene, xaxis.minortickpositions, ax.xminorticksize,
-                               ax.xminortickalign, Ref(scene.viewport), :x, ax.xaxisposition[])
+                               ax.xminortickalign, scene.viewport, :x, ax.xaxisposition[])
     xminorticksmirrored_lines = linesegments!(blockscene, xminorticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xminorticksvisible)),
         linewidth = ax.xminortickwidth, color = ax.xminortickcolor)
     translate!(xminorticksmirrored_lines, 0, 0, 10)
     yminorticksmirrored = lift(mirror_ticks, blockscene, yaxis.minortickpositions, ax.yminorticksize,
-                               ax.yminortickalign, Ref(scene.viewport), :y, ax.yaxisposition[])
+                               ax.yminortickalign, scene.viewport, :y, ax.yaxisposition[])
     yminorticksmirrored_lines = linesegments!(blockscene, yminorticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yminorticksvisible)),
         linewidth = ax.yminortickwidth, color = ax.yminortickcolor)
     translate!(yminorticksmirrored_lines, 0, 0, 10)
@@ -522,7 +522,7 @@ function initialize_block!(ax::Axis; palette = nothing)
 end
 
 function mirror_ticks(tickpositions, ticksize, tickalign, viewport, side, axisposition)
-    a = viewport[][]
+    a = viewport
     if side === :x
         opp = axisposition === :bottom ? top(a) : bottom(a)
         sign =  axisposition === :bottom ? 1 : -1


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/3579

Might be that with this the update structure is not ideal, but that could be fixed later if it turns out to be an issue. More important is that the ticks are not wrongly positioned.