### PR TITLE
Fix camera centering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix issues with Camera3D not centering [#3582](https://github.com/MakieOrg/Makie.jl/pull/3582)
+
 ## 0.20.5
 
 - Use plot plot instead of scene transform functions in CairoMakie, fixing missplaced h/vspan. [#3552](https://github.com/MakieOrg/Makie.jl/pull/3552)

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -3,6 +3,7 @@
     moon = loadasset("moon.png")
     fig, ax, meshplot = mesh(Sphere(Point3f(0), 1f0), color=moon, shading=NoShading, axis = (;show_axis=false))
     update_cam!(ax.scene, Vec3f(-2, 2, 2), Vec3f(0))
+    cameracontrols(ax).settings.center[] = false # avoid recenter on display
     fig
 end
 
@@ -585,6 +586,7 @@ end
     cam = cameracontrols(ax.scene)
     cam.fov[] = 22f0
     update_cam!(ax.scene, cam, Vec3f(0.625, 0, 3.5), Vec3f(0.625, 0, 0), Vec3f(0, 1, 0))
+    cameracontrols(ax).settings.center[] = false # avoid recenter on display
     fig
 end
 

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -259,8 +259,9 @@ function Camera3D(scene::Scene; kwargs...)
     end
 
     # reset
-    on(camera(scene), events(scene).keyboardbutton) do event
-        if cam.selected[] && ispressed(scene, controls[:reset][])
+    on(camera(scene), events(scene).keyboardbutton, events(scene).mousebutton, priority = 1) do ke, me
+        if cam.selected[] && ispressed(scene, controls[:reset][]) &&
+            (ke.action == Keyboard.press || me.action == Mouse.press)
             # center keeps the rotation of the camera so we reset that here
             # might make sense to keep user set lookat, upvector, eyeposition
             # around somewhere for this?
@@ -269,7 +270,9 @@ function Camera3D(scene::Scene; kwargs...)
         end
         return Consume(false)
     end
+
     update_cam!(scene, cam)
+
     cam
 end
 

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -45,7 +45,7 @@ Settings include anything that isn't a mouse or keyboard button.
     - `:adaptive` scales `near` by `norm(eyeposition - lookat)` and passes `far` as is
     - `:view_relative` scales `near` and `far` by `norm(eyeposition - lookat)`
     - `:bbox_relative` scales `near` and `far` to the scene bounding box as passed to the camera with `update_cam!(..., bbox)`. (More specifically `far = 1` is scaled to the furthest point of a bounding sphere and `near` is generally overwritten to be the closest point.)
-- `center = true`: Controls whether the camera placement gets reset when calling `update_cam!(scene[, cam], bbox)`, which is called when a new plot is added. This is automatically set to `false` after calling `update_cam!(scene[, cam], eyepos, lookat[, up])`.
+- `center = true`: Controls whether the camera placement gets reset when calling `center!(scene)`, which is called when a new plot is added.
 
 - `keyboard_rotationspeed = 1f0` sets the speed of keyboard based rotations.
 - `keyboard_translationspeed = 0.5f0` sets the speed of keyboard based translations.
@@ -785,7 +785,6 @@ end
 
 # Update camera position via camera Position & Orientation
 function update_cam!(scene::Scene, camera::Camera3D, eyeposition::VecTypes, lookat::VecTypes, up::VecTypes = camera.upvector[])
-    camera.settings.center[] = false
     camera.lookat[]      = Vec3f(lookat)
     camera.eyeposition[] = Vec3f(eyeposition)
     camera.upvector[]    = Vec3f(up)
@@ -806,7 +805,6 @@ function update_cam!(
         radius::Real = norm(camera.eyeposition[] - camera.lookat[]),
         center = camera.lookat[]
     )
-    camera.settings.center[] = false
     st, ct = sincos(theta)
     sp, cp = sincos(phi)
     v = Vec3f(ct * cp, ct * sp, st)

--- a/src/camera/camera3d.jl
+++ b/src/camera/camera3d.jl
@@ -265,7 +265,10 @@ function Camera3D(scene::Scene; kwargs...)
             # center keeps the rotation of the camera so we reset that here
             # might make sense to keep user set lookat, upvector, eyeposition
             # around somewhere for this?
+            old_center = cam.settings.center[]
+            cam.settings.center[] = true
             center!(scene)
+            cam.settings.center[] = old_center
             return Consume(true)
         end
         return Consume(false)


### PR DESCRIPTION
# Description

Changes:
- `center::Bool` setting no longer automatically sets itself to false if `update_cam!()` is called. Iirc this was supposed to avoid re-centering when adding plots after explicitly setting a camera position, but with the alt + click interaction also triggering it, it is more annoying than useful. 
- fix ctrl + click not centering the scene
- allow ctrl + click to center the camera even if `center = false`. The thought here is that you can disable to hotkey if you want to avoid this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
