### PR TITLE
Fix scatterlines scalar number color

### DIFF
--- a/src/basic_recipes/scatterlines.jl
+++ b/src/basic_recipes/scatterlines.jl
@@ -17,8 +17,8 @@ $(ATTRIBUTES)
         linestyle = l_theme.linestyle,
         linewidth = l_theme.linewidth,
         markercolor = automatic,
-        markercolormap = s_theme.colormap,
-        markercolorrange = get(s_theme.attributes, :colorrange, automatic),
+        markercolormap = automatic,
+        markercolorrange = automatic,
         markersize = s_theme.markersize,
         strokecolor = s_theme.strokecolor,
         strokewidth = s_theme.strokewidth,
@@ -32,14 +32,23 @@ end
 function plot!(p::Plot{scatterlines, <:NTuple{N, Any}}) where N
 
     # markercolor is the same as linecolor if left automatic
-    # RGBColors -> union of all colortypes that `to_color` accepts + returns
-    real_markercolor = Observable{RGBColors}()
+    real_markercolor = Observable{Any}()
     map!(real_markercolor, p.color, p.markercolor) do col, mcol
         if mcol === automatic
             return to_color(col)
         else
             return to_color(mcol)
         end
+    end
+
+    real_markercolormap = Observable{Any}()
+    map!(real_markercolormap, p.colormap, p.markercolormap) do col, mcol
+        mcol === automatic ? col : mcol
+    end
+
+    real_markercolorrange = Observable{Any}()
+    map!(real_markercolorrange, p.colorrange, p.markercolorrange) do col, mcol
+        mcol === automatic ? col : mcol
     end
 
     lines!(p, p[1:N]...;
@@ -57,9 +66,9 @@ function plot!(p::Plot{scatterlines, <:NTuple{N, Any}}) where N
         strokewidth = p.strokewidth,
         marker = p.marker,
         markersize = p.markersize,
-        colormap = p.markercolormap,
+        colormap = real_markercolormap,
         colorscale = p.colorscale,
-        colorrange = p.markercolorrange,
+        colorrange = real_markercolorrange,
         inspectable = p.inspectable
     )
 end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -48,3 +48,28 @@ end
 #     linesegments!(Makie.data_limits(ax.scene), color=:red)
 #     display(fig)
 # end
+
+
+# https://github.com/MakieOrg/Makie.jl/issues/3551
+@testset "scalar color for scatterlines" begin
+    colorrange = (1, 5)
+    colormap = :Blues
+    f, ax, sl = scatterlines(1:10,1:10,color=3,colormap=colormap,colorrange=colorrange)
+    l = sl.plots[1]::Lines
+    sc = sl.plots[2]::Scatter
+    @test l.color[] == 3
+    @test l.colorrange[] == colorrange
+    @test l.colormap[] == colormap
+    @test sc.color[] == 3
+    @test sc.colorrange[] == colorrange
+    @test sc.colormap[] == colormap
+    sl.markercolor = 4
+    sl.markercolormap = :jet
+    sl.markercolorrange = (2, 7)
+    @test l.color[] == 3
+    @test l.colorrange[] == colorrange
+    @test l.colormap[] == colormap
+    @test sc.color[] == 4
+    @test sc.colorrange[] == (2, 7)
+    @test sc.colormap[] == :jet
+end


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/3551

This also adjusts behavior so that colorrange and colormap of the markers are copied from the main color by default. I would classify the old behavior as weird because you would not by default want to have a different colormap and range there if you already go to the trouble of specifying your own one. This code will not break cases where the default colormap and range were used, or the case where these were specified for both lines and markers separately. It will only break the case where a colormap was used on lines but somehow the user was fine having `:viridis` on the markers. I don't think this is a reasonable case to worry about, so I wouldn't classify as breaking.