### PR TITLE
Allow scalar number colors for legend entries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Allowed creating legend entries from plot objects with scalar numbers as colors [#3587](https://github.com/MakieOrg/Makie.jl/pull/3587).
+
 ## 0.20.5
 
 - Use plot plot instead of scene transform functions in CairoMakie, fixing missplaced h/vspan. [#3552](https://github.com/MakieOrg/Makie.jl/pull/3552)

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -147,6 +147,25 @@ end
     end
 end
 
+@reference_test "Legend with scalar colors" begin
+    f = Figure()
+    ax = Axis(f[1, 1])
+    for i in 1:3
+        lines!(ax, (1:3) .+ i, color = i, colorrange = (0, 4), colormap = :Blues, label = "Line $i", linewidth = 3)
+    end
+    for i in 1:3
+        scatter!(ax, (1:3) .+ i .+ 3, color = i, colorrange = (0, 4), colormap = :plasma, label = "Scatter $i", markersize = 15)
+    end
+    for i in 1:3
+        barplot!(ax, (1:3) .+ i .+ 8, fillto = (1:3) .+ i .+ 7.5, color = i, colorrange = (0, 4), colormap = :tab10, label = "Barplot $i")
+    end
+    for i in 1:3
+        poly!(ax, [Rect2f((j, i .+ 12 + j), (0.5, 0.5)) for j in 1:3], color = i, colorrange = (0, 4), colormap = :heat, label = "Poly $i")
+    end
+    Legend(f[1, 2], ax)
+    f
+end
+
 @reference_test "LaTeXStrings in Axis3 plots" begin
     xs = LinRange(-10, 10, 100)
     ys = LinRange(0, 15, 100)
@@ -305,3 +324,4 @@ end
     axislegend(ax)
     fig
 end
+

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -272,7 +272,10 @@ function legendelement_plots!(scene, element::MarkerElement, bbox::Observable{Re
     scat = scatter!(scene, points, color = attrs.markercolor, marker = attrs.marker,
         markersize = attrs.markersize,
         strokewidth = attrs.markerstrokewidth,
-        strokecolor = attrs.markerstrokecolor, inspectable = false)
+        strokecolor = attrs.markerstrokecolor, inspectable = false,
+        colormap = attrs.markercolormap,
+        colorrange = attrs.markercolorrange,
+    )
 
     return [scat]
 end
@@ -284,6 +287,7 @@ function legendelement_plots!(scene, element::LineElement, bbox::Observable{Rect
     fracpoints = attrs.linepoints
     points = lift((bb, fp) -> fractionpoint.(Ref(bb), fp), scene, bbox, fracpoints)
     lin = lines!(scene, points, linewidth = attrs.linewidth, color = attrs.linecolor,
+        colormap = attrs.linecolormap, colorrange = attrs.linecolorrange,
         linestyle = attrs.linestyle, inspectable = false)
 
     return [lin]
@@ -295,7 +299,8 @@ function legendelement_plots!(scene, element::PolyElement, bbox::Observable{Rect
     fracpoints = attrs.polypoints
     points = lift((bb, fp) -> fractionpoint.(Ref(bb), fp), scene, bbox, fracpoints)
     pol = poly!(scene, points, strokewidth = attrs.polystrokewidth, color = attrs.polycolor,
-        strokecolor = attrs.polystrokecolor, inspectable = false)
+        strokecolor = attrs.polystrokecolor, inspectable = false,
+        colormap = attrs.polycolormap, colorrange = attrs.polycolorrange)
 
     return [pol]
 end
@@ -368,18 +373,24 @@ end
 _renaming_mapping(::Type{LineElement}) = Dict(
     :points => :linepoints,
     :color => :linecolor,
+    :colormap => :linecolormap,
+    :colorrange => :linecolorrange,
 )
 _renaming_mapping(::Type{MarkerElement}) = Dict(
     :points => :markerpoints,
     :color => :markercolor,
     :strokewidth => :markerstrokewidth,
     :strokecolor => :markerstrokecolor,
+    :colormap => :markercolormap,
+    :colorrange => :markercolorrange,
 )
 _renaming_mapping(::Type{PolyElement}) = Dict(
     :points => :polypoints,
     :color => :polycolor,
     :strokewidth => :polystrokewidth,
     :strokecolor => :polystrokecolor,
+    :colormap => :polycolormap,
+    :colorrange => :polycolorrange,
 )
 
 function _rename_attributes!(T, a)
@@ -408,7 +419,10 @@ function legendelements(plot::Union{Lines, LineSegments}, legend)
     LegendElement[LineElement(
         color = extract_color(plot, legend.linecolor),
         linestyle = choose_scalar(plot.linestyle, legend.linestyle),
-        linewidth = choose_scalar(plot.linewidth, legend.linewidth))]
+        linewidth = choose_scalar(plot.linewidth, legend.linewidth),
+        colormap = plot.colormap,
+        colorrange = plot.colorrange,
+    )]
 end
 
 function legendelements(plot::Scatter, legend)
@@ -418,6 +432,8 @@ function legendelements(plot::Scatter, legend)
         markersize = choose_scalar(plot.markersize, legend.markersize),
         strokewidth = choose_scalar(plot.strokewidth, legend.markerstrokewidth),
         strokecolor = choose_scalar(plot.strokecolor, legend.markerstrokecolor),
+        colormap = plot.colormap,
+        colorrange = plot.colorrange,
     )]
 end
 
@@ -427,12 +443,23 @@ function legendelements(plot::Union{Poly, Violin, BoxPlot, CrossBar, Density}, l
         color = color,
         strokecolor = choose_scalar(plot.strokecolor, legend.polystrokecolor),
         strokewidth = choose_scalar(plot.strokewidth, legend.polystrokewidth),
+        colormap = plot.colormap,
+        colorrange = plot.colorrange,
     )]
 end
 
 function legendelements(plot::Band, legend)
     # there seems to be no stroke for Band, so we set it invisible
-    LegendElement[PolyElement(polycolor = choose_scalar(plot.color, legend.polystrokecolor), polystrokecolor = :transparent, polystrokewidth = 0)]
+    return LegendElement[PolyElement(;
+        polycolor = choose_scalar(
+            plot.color,
+            legend.polystrokecolor
+        ),
+        polystrokecolor = :transparent,
+        polystrokewidth = 0,
+        polycolormap = plot.colormap,
+        polycolorrange = plot.colorrange,
+    )]
 end
 
 # if there is no specific overload available, we go through the child plots and just stack

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -76,9 +76,9 @@ end
 function attributenames(::Type{LegendEntry})
     (:label, :labelsize, :labelfont, :labelcolor, :labelhalign, :labelvalign,
         :patchsize, :patchstrokecolor, :patchstrokewidth, :patchcolor,
-        :linepoints, :linewidth, :linecolor, :linestyle,
-        :markerpoints, :markersize, :markerstrokewidth, :markercolor, :markerstrokecolor,
-        :polypoints, :polystrokewidth, :polycolor, :polystrokecolor)
+        :linepoints, :linewidth, :linecolor, :linestyle, :linecolorrange, :linecolormap,
+        :markerpoints, :markersize, :markerstrokewidth, :markercolor, :markerstrokecolor, :markercolorrange, :markercolormap,
+        :polypoints, :polystrokewidth, :polycolor, :polystrokecolor, :polycolorrange, :polycolormap)
 end
 
 function extractattributes(attributes::Attributes, typ::Type)

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1213,10 +1213,18 @@ const EntryGroup = Tuple{Any, Vector{LegendEntry}}
         linewidth = theme(scene, :linewidth)
         "The default line color used for LineElements"
         linecolor = theme(scene, :linecolor)
+        "The default colormap for LineElements"
+        linecolormap = theme(scene, :colormap)
+        "The default colorrange for LineElements"
+        linecolorrange = automatic
         "The default line style used for LineElements"
         linestyle = :solid
         "The default marker color for MarkerElements"
         markercolor = theme(scene, :markercolor)
+        "The default marker colormap for MarkerElements"
+        markercolormap = theme(scene, :colormap)
+        "The default marker colorrange for MarkerElements"
+        markercolorrange = automatic
         "The default marker for MarkerElements"
         marker = theme(scene, :marker)
         "The default marker points used for MarkerElements in normalized coordinates relative to each label patch."
@@ -1235,6 +1243,10 @@ const EntryGroup = Tuple{Any, Vector{LegendEntry}}
         polycolor = theme(scene, :patchcolor)
         "The default poly stroke color used for PolyElements."
         polystrokecolor = theme(scene, :patchstrokecolor)
+        "The default colormap for PolyElements"
+        polycolormap = theme(scene, :colormap)
+        "The default colorrange for PolyElements"
+        polycolorrange = automatic
         "The orientation of the legend (:horizontal or :vertical)."
         orientation = :vertical
         "The gap between each group title and its group."


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/Makie.jl/issues/3551, https://github.com/MakieOrg/Makie.jl/issues/3532, https://github.com/MakieOrg/Makie.jl/issues/1905, 

Picks up `colormap` and `colorrange` settings from plot objects so that a number color does not error anymore when passed down to the plotting primitives of the legend entries.

```julia
f = Figure()
ax = Axis(f[1, 1])
for i in 1:3
    lines!(ax, (1:3) .+ i, color = i, colorrange = (0, 4), colormap = :Blues, label = "Line $i", linewidth = 3)
end
for i in 1:3
    scatter!(ax, (1:3) .+ i .+ 3, color = i, colorrange = (0, 4), colormap = :plasma, label = "Scatter $i", markersize = 15)
end
for i in 1:3
    barplot!(ax, (1:3) .+ i .+ 8, fillto = (1:3) .+ i .+ 7.5, color = i, colorrange = (0, 4), colormap = :tab10, label = "Barplot $i")
end
for i in 1:3
    poly!(ax, [Rect2f((j, i .+ 12 + j), (0.5, 0.5)) for j in 1:3], color = i, colorrange = (0, 4), colormap = :heat, label = "Poly $i")
end
Legend(f[1, 2], ax)
f
```

<img width="597" alt="image" src="https://github.com/MakieOrg/Makie.jl/assets/22495855/de1e0228-863a-40de-8f73-2cdce6693ddb">


## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
