### PR TITLE
Fix axis mirrored ticks alignment

### DIFF
--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -122,13 +122,13 @@ end
 # https://github.com/MakieOrg/Makie.jl/issues/3579
 @reference_test "Axis yticksmirrored" begin
     f = Figure(size = (200, 200))
-    Axis(f[1, 1], yticksmirrored = true, yticksize = 10, ytickwidth = 4)
+    Axis(f[1, 1], yticksmirrored = true, yticksize = 10, ytickwidth = 4, spinewidth = 5)
     Colorbar(f[1, 2])
     f
 end
 @reference_test "Axis xticksmirrored" begin
     f = Figure(size = (200, 200))
-    Axis(f[1, 1], xticksmirrored = true, xticksize = 10, xtickwidth = 4)
+    Axis(f[1, 1], xticksmirrored = true, xticksize = 10, xtickwidth = 4, spinewidth = 5)
     Colorbar(f[0, 1], vertical = false)
     f
 end

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -377,22 +377,22 @@ function initialize_block!(ax::Axis; palette = nothing)
     end
 
     xticksmirrored = lift(mirror_ticks, blockscene, xaxis.tickpositions, ax.xticksize, ax.xtickalign,
-                          scene.viewport, :x, ax.xaxisposition[])
+                          scene.viewport, :x, ax.xaxisposition[], ax.spinewidth)
     xticksmirrored_lines = linesegments!(blockscene, xticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xticksvisible)),
         linewidth = ax.xtickwidth, color = ax.xtickcolor)
     translate!(xticksmirrored_lines, 0, 0, 10)
     yticksmirrored = lift(mirror_ticks, blockscene, yaxis.tickpositions, ax.yticksize, ax.ytickalign,
-                          scene.viewport, :y, ax.yaxisposition[])
+                          scene.viewport, :y, ax.yaxisposition[], ax.spinewidth)
     yticksmirrored_lines = linesegments!(blockscene, yticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yticksvisible)),
         linewidth = ax.ytickwidth, color = ax.ytickcolor)
     translate!(yticksmirrored_lines, 0, 0, 10)
     xminorticksmirrored = lift(mirror_ticks, blockscene, xaxis.minortickpositions, ax.xminorticksize,
-                               ax.xminortickalign, scene.viewport, :x, ax.xaxisposition[])
+                               ax.xminortickalign, scene.viewport, :x, ax.xaxisposition[], ax.spinewidth)
     xminorticksmirrored_lines = linesegments!(blockscene, xminorticksmirrored, visible = @lift($(ax.xticksmirrored) && $(ax.xminorticksvisible)),
         linewidth = ax.xminortickwidth, color = ax.xminortickcolor)
     translate!(xminorticksmirrored_lines, 0, 0, 10)
     yminorticksmirrored = lift(mirror_ticks, blockscene, yaxis.minortickpositions, ax.yminorticksize,
-                               ax.yminortickalign, scene.viewport, :y, ax.yaxisposition[])
+                               ax.yminortickalign, scene.viewport, :y, ax.yaxisposition[], ax.spinewidth)
     yminorticksmirrored_lines = linesegments!(blockscene, yminorticksmirrored, visible = @lift($(ax.yticksmirrored) && $(ax.yminorticksvisible)),
         linewidth = ax.yminortickwidth, color = ax.yminortickcolor)
     translate!(yminorticksmirrored_lines, 0, 0, 10)
@@ -521,7 +521,7 @@ function initialize_block!(ax::Axis; palette = nothing)
     return ax
 end
 
-function mirror_ticks(tickpositions, ticksize, tickalign, viewport, side, axisposition)
+function mirror_ticks(tickpositions, ticksize, tickalign, viewport, side, axisposition, spinewidth)
     a = viewport
     if side === :x
         opp = axisposition === :bottom ? top(a) : bottom(a)
@@ -532,15 +532,16 @@ function mirror_ticks(tickpositions, ticksize, tickalign, viewport, side, axispo
     end
     d = ticksize * sign
     points = Vector{Point2f}(undef, 2*length(tickpositions))
+    spineoffset = sign * (0.5 * spinewidth)
     if side === :x
         for (i, (x, _)) in enumerate(tickpositions)
-            points[2i-1] = Point2f(x, opp - d * tickalign)
-            points[2i] = Point2f(x, opp + d - d * tickalign)
+            points[2i-1] = Point2f(x, opp - d * tickalign + spineoffset)
+            points[2i] = Point2f(x, opp + d - d * tickalign + spineoffset)
         end
     else
         for (i, (_, y)) in enumerate(tickpositions)
-            points[2i-1] = Point2f(opp - d * tickalign, y)
-            points[2i] = Point2f(opp + d - d * tickalign, y)
+            points[2i-1] = Point2f(opp - d * tickalign + spineoffset, y)
+            points[2i] = Point2f(opp + d - d * tickalign + spineoffset, y)
         end
     end
     return points


### PR DESCRIPTION
- move mirrored ticks by spine width
- adjust test

Fixes https://github.com/MakieOrg/Makie.jl/issues/3431