### PR TITLE
Make ScatterLines a PointBased plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## master
+
+- Gave the `scatterlines` recipe a `PointBased` conversion trait (previously not defined) [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603)
+
 ## 0.20.7
 
 - Equalized alignment point of mirrored ticks to that of normal ticks [#3598](https://github.com/MakieOrg/Makie.jl/pull/3598).

--- a/src/basic_recipes/scatterlines.jl
+++ b/src/basic_recipes/scatterlines.jl
@@ -28,6 +28,8 @@ $(ATTRIBUTES)
     )
 end
 
+conversion_trait(::Type{<: ScatterLines}) = PointBased()
+
 
 function plot!(p::Plot{scatterlines, <:NTuple{N, Any}}) where N
 


### PR DESCRIPTION
# Description

I noticed that scatterlines did not have a conversion trait established, so this PR is a quick fix for that.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
