### PR TITLE
Check converted as well as input args in polygon drawing in CairoMakie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 
+- Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
 - Added `PointBased` conversion trait to `scatterlines` recipe [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603).
 
 ## [0.20.7] - 2024-02-04
 
-- Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
 - Equalized alignment point of mirrored ticks to that of normal ticks [#3598](https://github.com/MakieOrg/Makie.jl/pull/3598).
 - Fixed stack overflow error on conversion of gridlike data with missings [#3597](https://github.com/MakieOrg/Makie.jl/pull/3597).
 - Fixed mutation of CairoMakie src dir when displaying png files [#3588](https://github.com/MakieOrg/Makie.jl/pull/3588).

--- a/CairoMakie/test/Project.toml
+++ b/CairoMakie/test/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+GeoInterfaceMakie = "0edc0954-3250-4c18-859d-ec71c1660c08"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 ReferenceTests = "d37af2e0-5618-4e00-9939-d430db56ee94"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/CairoMakie/test/rasterization_tests.jl
+++ b/CairoMakie/test/rasterization_tests.jl
@@ -6,7 +6,7 @@ function svg_has_image(x)
         save(path, x)
         # this is rough but an easy way to catch rasterization,
         # if an image element is present in the svg
-        return !occursin("<image id=", read(path, String))
+        return occursin("<image id=", read(path, String))
     end
 end
 
@@ -18,13 +18,14 @@ end
     pl = poly!(ax, Makie.GeometryBasics.Polygon(pts))
 
     @testset "Unrasterized SVG" begin
-        @test svg_has_image(fig)
+        @test !svg_has_image(fig)
     end
 
     @testset "Rasterized SVG" begin
         lp.rasterize = true
-        @test !svg_has_image(fig)
+        @test svg_has_image(fig)
         lp.rasterize = 10
-        @test !svg_has_image(fig)
+        @test svg_has_image(fig)
     end
+
 end

--- a/CairoMakie/test/svg_tests.jl
+++ b/CairoMakie/test/svg_tests.jl
@@ -30,6 +30,21 @@ end
     @test svg_isnt_rasterized(poly(BezierPath([
         MoveTo(0.0, 0.0), LineTo(1.0, 0.0), LineTo(1.0, 1.0), CurveTo(1.0, 1.0, 0.5, 1.0, 0.5, 0.5), ClosePath()
     ])))
+    @test !svg_isnt_rasterized(poly(rand(Point2f, 10); color = rand(RGBA, 10)))
+
+    poly1 = Makie.GeometryBasics.Polygon(rand(Point2f, 10))
+    @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1])))
+    @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1]), color = :red))
+    @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1]), color = [:red, :blue]))
+
+    @testset "GeoInterface polygons" begin
+        using GeoInterface, GeoInterfaceMakie
+        poly2 = GeoInterface.convert(GeoInterface.Wrappers, poly1)
+        @test svg_isnt_rasterized(poly(poly2))
+        @test svg_isnt_rasterized(poly(poly2, color = :red))
+        @test svg_isnt_rasterized(poly(GeoInterface.Wrappers.MultiPolygon([poly2, poly2]), color = [:red, :blue]))
+    end
+
 end
 
 @testset "reproducable svg ids" begin

--- a/CairoMakie/test/svg_tests.jl
+++ b/CairoMakie/test/svg_tests.jl
@@ -30,7 +30,7 @@ end
     @test svg_isnt_rasterized(poly(BezierPath([
         MoveTo(0.0, 0.0), LineTo(1.0, 0.0), LineTo(1.0, 1.0), CurveTo(1.0, 1.0, 0.5, 1.0, 0.5, 0.5), ClosePath()
     ])))
-    @test !svg_isnt_rasterized(poly(rand(Point2f, 10); color = rand(RGBA, 10)))
+    @test !svg_isnt_rasterized(poly(rand(Point2f, 10); color = rand(RGBAf, 10)))
 
     poly1 = Makie.GeometryBasics.Polygon(rand(Point2f, 10))
     @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1])))

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 0.20.7
 
+- Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
 - Equalized alignment point of mirrored ticks to that of normal ticks [#3598](https://github.com/MakieOrg/Makie.jl/pull/3598).
 - Fixed stack overflow error on conversion of gridlike data with missings [#3597](https://github.com/MakieOrg/Makie.jl/pull/3597).
 - Fixed mutation of CairoMakie src dir when displaying png files [#3588](https://github.com/MakieOrg/Makie.jl/pull/3588).


### PR DESCRIPTION
# Description

CairoMakie decided whether or not to draw polygons as meshes based on the type of the input arguments.  However, this excluded types which are later converted to polygons via `convert_arguments` from the direct polygon drawing path, forcing them to be meshed and rasterized.

This PR enables CairoMakie to decide whether to use meshes or not based on both the input and converted argument types.  It first checks whether there is an available `draw_poly` method for the input types (`plot.args...`), if there is then it proceeds.  If not, it checks whether there is an available `draw_poly` method for the converted types (`plot.converted...`), and proceeds there.  The last/base case is of course a call to `draw_poly_as_mesh`.

This has eliminated the generic fallback for `draw_poly(scene, screen, plot)` as the decision-making is now done in `draw_plot`.

As an example: `Rect`, `BezierPath`, `Vector{<: Point}`, or `Polygon` input will be processed directly.  Inputs from other geometry packages like ArchGDAL, GeoJSON, etc which were previously interpreted as requiring meshing will now be drawn as polygons, since after conversion they are usually `GeometryBasics.Polygon` or similar which have dispatches in `draw_poly`.

I also added some tests to make sure this behaviour stays consistent!

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [X] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.

Fixes #3600
Fixes MakieOrg/GeoMakie.jl#181
