### PR TITLE
Allow Cycled colors to be passed with transparency like normal colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
 - Added `PointBased` conversion trait to `scatterlines` recipe [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603).
+- Allowed Cycled colors to be passed with transparency as `(Cycled(n::Int), 0.4)` [#3611](https://github.com/MakieOrg/Makie.jl/pull/3611).
 
 ## [0.20.7] - 2024-02-04
 

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -697,6 +697,10 @@ function to_color(scene::Scene, attribute_name, cycled::Cycled)
     return attr_palette[mod1(index, length(attr_palette))]
 end
 
+function to_color(scene::Scene, attribute_name, cycled::Tuple{<: Cycled, <: Real})
+    return Colors.alphacolor(to_color(scene, attribute_name, cycled[1]), cycled[2])
+end
+
 function add_cycle_attributes!(@nospecialize(plot), cycle::Cycle, cycler::Cycler, palette::Attributes)
     # check if none of the cycled attributes of this plot
     # were passed manually, because we don't use the cycler


### PR DESCRIPTION
# Description

A quick fix which allows Cycled colors to be passed with transparency a la `(Cycled(n), α)`.  Will add a test as well!

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
