### PR TITLE
Fix CairoMakie erroring when recipes return lists of PlotSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
+- Fixed a method ambiguity in CairoMakie when plotting lists of PlotSpecs (`plotlist`) [#3612](https://github.com/MakieOrg/Makie.jl/pull/3612).
 - Added `PointBased` conversion trait to `scatterlines` recipe [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603).
 
 ## [0.20.7] - 2024-02-04

--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -182,6 +182,8 @@ Base.size(screen::Screen) = round.(Int, (screen.surface.width, screen.surface.he
 # we render the scene directly, since we have
 # no screen dependent state like in e.g. opengl
 Base.insert!(screen::Screen, scene::Scene, plot) = nothing
+Base.insert!(screen::Screen, scene::Scene, plot::Plot{Makie.plotlist}) = nothing # resolve ambiguity
+
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
     # Currently, we rerender every time, so nothing needs
     # to happen here.  However, in the event that changes,

--- a/ReferenceTests/src/tests/recipes.jl
+++ b/ReferenceTests/src/tests/recipes.jl
@@ -59,3 +59,16 @@ end
         molecule_plot[:advance] = i
     end
 end
+
+@reference_test "PlotList support" begin
+    struct PlotlistTestType end
+    Makie.plottype(::PlotlistTestType) = Makie.Lines
+    function Makie.convert_arguments(::Type{<: Makie.Lines}, obj::PlotlistTestType)
+        return [
+            Makie.SpecApi.Lines([0, 1], [0, 1]),
+            Makie.SpecApi.Scatter([0.5], [0.5]),
+        ]
+    end
+    plot(PlotlistTestType())
+end
+end


### PR DESCRIPTION
# Description

CairoMakie suffered from a method ambiguity when a `convert_arguments` returned a list of plotspecs using the new SpecApi.  This PR eliminates that method ambiguity and adds a reference test for it, so we know that all backends support plotlists!

I will probably need some help updating the reference images though!

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
