### PR TITLE
Allow band to pass the `alpha` attribute to its mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
 - Added `PointBased` conversion trait to `scatterlines` recipe [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603).
+- Fixed `band` not passing the `alpha` keyword to its mesh [#3612](https://github.com/MakieOrg/Makie.jl/pull/3612)
 
 ## [0.20.7] - 2024-02-04
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1392,3 +1392,11 @@ end
     ylims!(ax, 0, 1)
     fig
 end
+
+@reference_test "transparency in band (#3356)" begin
+    f = Figure()
+    ax = Axis(f[1, 1])
+    band!(ax, 1:10, 1:10, 2:11)
+    band!(ax, reverse(1:10), 1:10, 2:11, alpha = 0.5)
+    f
+end

--- a/src/basic_recipes/band.jl
+++ b/src/basic_recipes/band.jl
@@ -54,6 +54,7 @@ function Makie.plot!(plot::Band)
     end
     attr = Attributes(plot)
     attr[:color] = meshcolor
+    attr[:alpha] = plot.alpha
     mesh!(plot, attr, coordinates, connectivity)
 end
 


### PR DESCRIPTION
# Description

Fixes #3356

Just forwards the attribute to `mesh` called internally in `plot!(band)`.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [X] Added reference image tests for new plotting functions, recipes, visual options, etc.
