### PR TITLE
Fix camera observable caching and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed bugs with format strings and add new features by switching to Format.jl [#3633](https://github.com/MakieOrg/Makie.jl/pull/3633).
 - Fixed an issue where CairoMakie would unnecessarily rasterize polygons [#3605](https://github.com/MakieOrg/Makie.jl/pull/3605).
 - Added `PointBased` conversion trait to `scatterlines` recipe [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603).
+- Fixed a bug with line/text/scatter resolutions getting disconnected by `empty!()` in GLMakie and re-enabled camera caching. [#3640](https://github.com/MakieOrg/Makie.jl/pull/3640)
 
 ## [0.20.7] - 2024-02-04
 

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -181,9 +181,14 @@ function connect_camera!(plot, gl_attributes, cam, space = gl_attributes[:space]
     end
     # resolution in real hardware pixels, not scaled pixels/units
     get!(gl_attributes, :resolution) do
-        get!(cam.calculated_values, :resolution) do
-            return lift(*, plot, gl_attributes[:px_per_unit], cam.resolution)
-        end
+        # Note:
+        # robj cleanup deletes all uniforms so to avoid deleting the cached
+        # resolution we need to create a copy here.
+        # TODO closing the screen should delete the cached entry as px_per_unit
+        # could be different in the next screen
+        lift(identity, get!(cam.calculated_values, :resolution) do
+            return lift(*, gl_attributes[:px_per_unit], cam.resolution)
+        end)
     end
 
     delete!(gl_attributes, :space)

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -443,3 +443,25 @@ end
     im[3][] = zeros(RGBf, 25, 15) # larger size
     GLMakie.closeall()
 end
+
+@testset "Camera caching" begin
+    f=Figure(size=(200,200))
+    screen = display(f, visible = false)
+    ax=Axis(f[1,1])
+    lines!(ax,sin.(0.0:0.1:2pi))
+    text!(ax,10.0,0.0,text="sine wave")
+    expected_keys = [
+        :projection_data, :view_data, :projectionview_pixel, :projectionview_data,
+        :px_resolution, :projection_pixel, :view_pixel
+    ]
+    for key in expected_keys
+        @test haskey(ax.scene.camera.calculated_values, key)
+        @test !isempty(ax.scene.camera.calculated_values[key].inputs)
+    end
+    empty!(ax)
+    for key in expected_keys
+        @test haskey(ax.scene.camera.calculated_values, key)
+        @test !isempty(ax.scene.camera.calculated_values[key].inputs)
+    end
+    GLMakie.closeall()
+end


### PR DESCRIPTION
# Description

Fixes #3639 by
- detaching the cached scaled resolution from plot to avoid plot based cleanup
- adding a dublication observable to avoid robj based cleanup

#### Changes to camera matrix caching

The calculation of cached matrices depends on existing matrices in `scene.camera` which are unrelated to the plot or renderobject, and on `plot.space` which may change dynamically. Therefore cached camera matrices 
- must use a static space
- must not get deleted when a plot or renderobject is deleted
- must be created dynamically based on the plots `space`

TODO:
- [x] re-enable camera matrix caching
- [x] check WGLMakie
- [x] add tests

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
