### PR TITLE
Avoid vertical space with `backend_show`

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -489,6 +489,7 @@ function backend_show(screen::MakieScreen, io::IO, ::Union{WEB_MIMES...}, scene:
     png_io = IOBuffer()
     backend_show(screen, png_io, MIME"image/png"(), scene)
     b64 = Base64.base64encode(String(take!(png_io)))
-    print(io, "<img width=$w height=$h style='object-fit: contain;' src=\"data:image/png;base64, $(b64)\"/>")
+    style = "object-fit: contain; height: auto;"
+    print(io, "<img width=$w height=$h style='$style' src=\"data:image/png;base64, $(b64)\"/>")
     return
 end


### PR DESCRIPTION
# Description

When using CairoMakie in Pluto.jl, a lot of whitespace is in some cases shown above and below the Makie images. For example, when plotting

```julia
let
  fig = Figure(; size=(1400, 600))
  ax = Axis(fig[1, 1])
  scatter!(ax, Point2f[(100, 300), (200, 400)])
  fig
end
```
with Makie `v0.11.8`, the output looks as follows:

![image](https://github.com/MakieOrg/Makie.jl/assets/20724914/6363ee55-533b-46ad-9913-1e66a2f62def)

The root cause for this seems to be that Makie generates the following HTML:

```html
<img width="1400" height="600" style="object-fit: contain;" src="data:image/png;base64,...">
```

Here, it makes sense that the `width` and `height` are set explicitly because that metadata cannot be set in the base64 encoded image if I'm not mistaken. Next, the `object-fit: contain;` causes the image to always retain the original aspect ratio by rescaling the image width or height when needed. However, `object-fit: contain` will not automatically rescale the HTML element width or height when needed. Instead, those remain fixed and the object will be "letterboxed" (more information at [the Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)). In the example image, for example, the height remains 600 even though the image height is rescaled to 291. 

This PR suggests to fix that by setting `height: auto` in the style. This tells the browser that the height of the containing element can be rescaled if needed. I've tested this with `Pluto.jl` and `PlutoStaticHTML.jl` and in both cases this will avoid the vertical space.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in NEWS.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
