### PR TITLE
Skip resolution caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `PointBased` conversion trait to `scatterlines` recipe [#3603](https://github.com/MakieOrg/Makie.jl/pull/3603).
 - Multiple small fixes for `map_latest`, `WGLMakie` picking and `PlotSpec` [#3637](https://github.com/MakieOrg/Makie.jl/pull/3637).
 - Fixed PolarAxis `rticks` being incompatible with rich text. [#3615](https://github.com/MakieOrg/Makie.jl/pull/3615)
+- Fixed an issue causing lines, scatter and text to not scale with resolution after deleting plots in GLMakie. [#3649](https://github.com/MakieOrg/Makie.jl/pull/3649)
 
 ## [0.20.7] - 2024-02-04
 

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -181,9 +181,9 @@ function connect_camera!(plot, gl_attributes, cam, space = gl_attributes[:space]
     end
     # resolution in real hardware pixels, not scaled pixels/units
     get!(gl_attributes, :resolution) do
-        get!(cam.calculated_values, :resolution) do
+        # get!(cam.calculated_values, :resolution) do
             return lift(*, plot, gl_attributes[:px_per_unit], cam.resolution)
-        end
+        # end
     end
 
     delete!(gl_attributes, :space)

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -443,3 +443,23 @@ end
     im[3][] = zeros(RGBf, 25, 15) # larger size
     GLMakie.closeall()
 end
+
+@testset "Verify camera uniforms after delete" begin
+    f=Figure(size=(200,200))
+    screen = display(f, visible = false)
+    ax=Axis(f[1,1])
+    lines!(ax,sin.(0.0:0.1:2pi))
+    text!(ax,10.0,0.0,text="sine wave")
+    empty!(ax)
+    ids = [robj.id for (_, _, robj) in screen.renderlist]
+
+    lines!(ax, sin.(0.0:0.1:2pi))
+    text!(ax,10.0,0.0,text="sine wave")
+    resize!(current_figure(), 800, 800)
+
+    robj = filter(x -> !(x.id in ids), last.(screen.renderlist))[1]
+    cam = ax.scene.camera
+
+    @test robj.uniforms[:resolution][]     == screen.px_per_unit[] * cam.resolution[]
+    @test robj.uniforms[:projectionview][] == cam.projectionview[]
+end


### PR DESCRIPTION
# Description

Fixes #3639 by disabling caching for resolutions as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
