### PR TITLE
fix line inversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - WGLMakie: Added line joints
   - WGLMakie: Added native anti-aliasing which generally improves quality but introduces outline artifacts in some cases (same as GLMakie)
   - Both: Adjusted handling of thin lines which may result in different color intensities
+- Fixed an issue with lines being drawn in the wrong direction in 3D (with perspective projection) [#3651](https://github.com/MakieOrg/Makie.jl/pull/3651)
 
 ## [0.20.8] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   - WGLMakie: Added line joints
   - WGLMakie: Added native anti-aliasing which generally improves quality but introduces outline artifacts in some cases (same as GLMakie)
   - Both: Adjusted handling of thin lines which may result in different color intensities
-- Fixed an issue with lines being drawn in the wrong direction in 3D (with perspective projection) [#3651](https://github.com/MakieOrg/Makie.jl/pull/3651)
+- Fixed an issue with lines being drawn in the wrong direction in 3D (with perspective projection) [#3651](https://github.com/MakieOrg/Makie.jl/pull/3651).
 
 ## [0.20.8] - 2024-02-22
 

--- a/GLMakie/assets/shader/line_segment.geom
+++ b/GLMakie/assets/shader/line_segment.geom
@@ -57,8 +57,25 @@ void main(void)
     }
 
     // get start and end point of line segment
-    vec3 p1 = screen_space(gl_in[0].gl_Position);
-    vec3 p2 = screen_space(gl_in[1].gl_Position);
+    // Note:
+    // We are applying the xyz / w division here to move to pixel space. This
+    // sort of breaks clipping with perspective projection, as positions behind
+    // the camera are mapped ... TODO
+
+    // restrict to visible area
+    vec3 p1, p2;
+    {
+        vec4 _p1 = gl_in[0].gl_Position, _p2 = gl_in[1].gl_Position;
+        vec4 v1 = _p2 - _p1;
+
+        if (_p1.w < 0.0)
+            _p1 = _p1 + (-_p1.w - _p1.z) / (v1.z + v1.w) * v1;
+        if (_p2.w < 0.0)
+            _p2 = _p2 + (-_p2.w - _p2.z) / (v1.z + v1.w) * v1;
+
+        p1 = screen_space(_p1);
+        p2 = screen_space(_p2);
+    }
 
     // get vector in line direction and vector in linewidth direction
     vec3 v1 = (p2 - p1);

--- a/GLMakie/assets/shader/line_segment.geom
+++ b/GLMakie/assets/shader/line_segment.geom
@@ -57,12 +57,7 @@ void main(void)
     }
 
     // get start and end point of line segment
-    // Note:
-    // We are applying the xyz / w division here to move to pixel space. This
-    // sort of breaks clipping with perspective projection, as positions behind
-    // the camera are mapped ... TODO
-
-    // restrict to visible area
+    // restrict to visible area (see lines.geom)
     vec3 p1, p2;
     {
         vec4 _p1 = gl_in[0].gl_Position, _p2 = gl_in[1].gl_Position;

--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -212,21 +212,7 @@ void main(void)
     // extends the line. First let's get some vectors we need.
 
     // Get the four vertices passed to the shader in pixel space.
-    // Without FAST_PATH the conversions happen on the CPU
-// #ifdef FAST_PATH
-//     vec4 p0 = screen_space(gl_in[0].gl_Position); // start of previous segment
-//     vec4 p1 = screen_space(gl_in[1].gl_Position); // end of previous segment, start of current segment
-//     vec4 p2 = screen_space(gl_in[2].gl_Position); // end of current segment, start of next segment
-//     vec4 p3 = screen_space(gl_in[3].gl_Position); // end of next segment
-// #else
-//     vec4 p0 = gl_in[0].gl_Position; // start of previous segment
-//     vec4 p1 = gl_in[1].gl_Position; // end of previous segment, start of current segment
-//     vec4 p2 = gl_in[2].gl_Position; // end of current segment, start of next segment
-//     vec4 p3 = gl_in[3].gl_Position; // end of next segment
-// #endif
-
     // TODO: document
-
     vec3 p0, p1, p2, p3;
     {
         vec4 _p0 = gl_in[0].gl_Position; // start of previous segment
@@ -238,12 +224,10 @@ void main(void)
         if (_p1.w < 0.0) { // means behind camera
             isvalid[0] = false; // not connected
             _p1 = _p1 + (-_p1.w - _p1.z) / (v1.z + v1.w) * v1;
-            f_color1 = vec4(1,0,0,1);
         }
         if (_p2.w < 0.0) {
             isvalid[3] = false;
             _p2 = _p2 + (-_p2.w - _p2.z) / (v1.z + v1.w) * v1;
-            f_color2 = vec4(1,0,0,1);
         }
 
         p0 = screen_space(_p0); // start of previous segment

--- a/GLMakie/assets/shader/lines.vert
+++ b/GLMakie/assets/shader/lines.vert
@@ -25,6 +25,7 @@ out float g_lastlen;
 out int g_valid_vertex;
 out float g_thickness;
 
+vec4 to_vec4(vec4 v){return v;}
 vec4 to_vec4(vec3 v){return vec4(v, 1);}
 vec4 to_vec4(vec2 v){return vec4(v, 0, 1);}
 

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -456,15 +456,11 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::Lines))
             data[:fast] = false
 
             pvm = lift(*, plot, data[:projectionview], data[:model])
-            positions = lift(plot, transform_func, positions, space, pvm,
-                            data[:resolution]) do f, ps, space, pvm, res
+            positions = lift(plot, transform_func, positions, space, pvm) do f, ps, space, pvm
                 transformed = apply_transform(f, ps, space)
-                output = Vector{Point3f}(undef, length(transformed))
-                scale = Vec3f(0.5 * res[1], 0.5 * res[2], 1f0)
-                offset = Vec3f(0.5 * res[1], 0.5 * res[2], 0)
+                output = Vector{Point4f}(undef, length(transformed))
                 for i in eachindex(transformed)
-                    clip = pvm * to_ndim(Point4f, to_ndim(Point3f, transformed[i], 0f0), 1f0)
-                    output[i] = scale .* Point3f(clip) ./ clip[4] .+ offset
+                    output[i] = pvm * to_ndim(Point4f, to_ndim(Point3f, transformed[i], 0f0), 1f0)
                 end
                 output
             end

--- a/GLMakie/src/glshaders/lines.jl
+++ b/GLMakie/src/glshaders/lines.jl
@@ -1,4 +1,4 @@
-function sumlengths(points)
+function sumlengths(points, resolution)
     T = eltype(eltype(typeof(points)))
     result = zeros(T, length(points))
     i12 = Vec(1, 2)
@@ -6,7 +6,7 @@ function sumlengths(points)
         i0 = max(i-1, 1)
         p1, p2 = points[i0], points[i]
         if !(any(map(isnan, p1)) || any(map(isnan, p2)))
-            result[i] = result[i0] + norm(p1[i12] - p2[i12])
+            result[i] = result[i0] + norm(resolution .* (p1[i12] - p2[i12]))
         else
             result[i] = 0f0
         end
@@ -32,6 +32,7 @@ function draw_lines(screen, position::Union{VectorTypes{T}, MatTypes{T}}, data::
     end
 
     color_type = gl_color_type_annotation(data[:color])
+    resolution = data[:resolution]
 
     @gen_defaults! data begin
         total_length::Int32 = const_lift(x-> Int32(length(x)), position)
@@ -66,7 +67,7 @@ function draw_lines(screen, position::Union{VectorTypes{T}, MatTypes{T}}, data::
         valid_vertex        = const_lift(p_vec) do points
             map(p-> Float32(all(isfinite, p)), points)
         end => GLBuffer
-        lastlen             = const_lift(sumlengths, p_vec) => GLBuffer
+        lastlen             = const_lift(sumlengths, p_vec, resolution) => GLBuffer
         pattern_length      = 1f0 # we divide by pattern_length a lot.
         debug               = false
     end

--- a/GLMakie/src/glshaders/lines.jl
+++ b/GLMakie/src/glshaders/lines.jl
@@ -1,14 +1,20 @@
 function sumlengths(points, resolution)
+    # normalize w component if availabke
+    f(p::VecTypes{4}) = p[Vec(1, 2)] / p[4]
+    f(p::VecTypes) = p[Vec(1, 2)]
+
+    invalid(p::VecTypes{4}) = p[4] <= 1e-6
+    invalid(p::VecTypes) = false
+
     T = eltype(eltype(typeof(points)))
     result = zeros(T, length(points))
-    i12 = Vec(1, 2)
     for i in eachindex(points)
         i0 = max(i-1, 1)
         p1, p2 = points[i0], points[i]
-        if !(any(map(isnan, p1)) || any(map(isnan, p2)))
-            result[i] = result[i0] + norm(resolution .* (p1[i12] - p2[i12]))
-        else
+        if any(map(isnan, p1)) || any(map(isnan, p2)) || invalid(p1) || invalid(p2)
             result[i] = 0f0
+        else
+            result[i] = result[i0] + 0.5 * norm(resolution .* (f(p1) - f(p2)))
         end
     end
     result

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -59,6 +59,31 @@ end
     scene
 end
 
+@reference_test "Lines from outside" begin
+    # This tests that lines that start or end in clipped regions are still
+    # rendered correctly. For perspective projections this can be tricky as
+    # points behind the camera get projected beyond far.
+    lps = let
+        ps1 = [Point3f(x, 0.2 * (z+1), z) for x in (-8, 0, 8) for z in (-9, -1, -1, 7)]
+        ps2 = [Point3f(x, 0.2 * (z+1), z) for z in (-9, -1, 7) for x in (-8, 0, 0, 8)]
+        vcat(ps1, ps2)
+    end
+    cs = [i for i in (1, 12, 2, 11, 3, 10, 4, 9, 5, 8, 6, 7) for _ in 1:2]
+
+    fig = Figure()
+
+    for (i, func) in enumerate((lines, linesegments))
+        for (j, ls) in enumerate((:solid, :dot))
+            a, p = func(fig[i, j], lps, color = cs, linewidth = 5, linestyle = ls)
+            cameracontrols(a).settings.center[] = false # avoid recenter on display
+            a.show_axis[] = false
+            update_cam!(a.scene, Vec3f(-0.2, 0.5, 0), Vec3f(-0.2, 0.2, -1), Vec3f(0, 1, 0))
+        end
+    end
+
+    fig
+end
+
 @reference_test "scatters" begin
     s = Scene(size = (800, 800), camera = campixel!)
 

--- a/WGLMakie/src/Lines.js
+++ b/WGLMakie/src/Lines.js
@@ -364,11 +364,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 float width = px_per_unit * (is_end ? linewidth_end : linewidth_start);
                 float halfwidth = 0.5 * max(AA_RADIUS, width);
 
-                bool[4] isvalid = bool[4](
-                    linepoint_prev != linepoint_start,
-                    true, true,
-                    linepoint_end != linepoint_next
-                );
+                bool[4] isvalid = bool[4](true, true, true, true);
 
                 // To apply pixel space linewidths we transform line vertices to pixel space
                 // here. This is dangerous with perspective projection as p.xyz / p.w sends
@@ -410,6 +406,10 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                     p2 = screen_space(clip_p2); // end of current segment, start of next segment
                     p3 = screen_space(clip_p3); // end of next segment
                 }
+
+                // doesn't work correctly with linepoint_x...
+                isvalid[0] = p0 != p1;
+                isvalid[3] = p2 != p3;
 
                 // line vectors (xy-normalized vectors in line direction)
                 // Need z component here for correct depth order

--- a/WGLMakie/src/lines.jl
+++ b/WGLMakie/src/lines.jl
@@ -71,6 +71,8 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
     attributes = Dict{Symbol, Any}(:linepoint => positions)
 
     # TODO: in Javascript
+    # NOTE: clip.w needs to be available in shaders to avoid line inversion problems
+    #       if transformations are done on the CPU (compare with GLMakie)
     # This calculates the cumulative pixel-space distance of each point from the
     # last start point of a line. (I.e. from either the first point or the first
     # point after the last NaN)

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -21627,11 +21627,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 float width = px_per_unit * (is_end ? linewidth_end : linewidth_start);
                 float halfwidth = 0.5 * max(AA_RADIUS, width);
 
-                bool[4] isvalid = bool[4](
-                    linepoint_prev != linepoint_start,
-                    true, true,
-                    linepoint_end != linepoint_next
-                );
+                bool[4] isvalid = bool[4](true, true, true, true);
 
                 // To apply pixel space linewidths we transform line vertices to pixel space
                 // here. This is dangerous with perspective projection as p.xyz / p.w sends
@@ -21673,6 +21669,10 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                     p2 = screen_space(clip_p2); // end of current segment, start of next segment
                     p3 = screen_space(clip_p3); // end of next segment
                 }
+
+                // doesn't work correctly with linepoint_x...
+                isvalid[0] = p0 != p1;
+                isvalid[3] = p2 != p3;
 
                 // line vectors (xy-normalized vectors in line direction)
                 // Need z component here for correct depth order

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -21355,17 +21355,16 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
             // Geometry/Position Utils
             ////////////////////////////////////////////////////////////////////////
 
+            vec4 clip_space(vec3 point) {
+                return projectionview * model * vec4(point, 1);
+            }
+            vec4 clip_space(vec2 point) { return clip_space(vec3(point, 0)); }
 
-            vec3 screen_space(vec3 point) {
-                vec4 vertex = projectionview * model * vec4(point, 1);
+            vec3 screen_space(vec4 vertex) {
                 return vec3(
                     (0.5 * vertex.xy / vertex.w + 0.5) * px_per_unit * resolution,
                     vertex.z / vertex.w + depth_shift
                 );
-            }
-
-            vec3 screen_space(vec2 point) {
-                return screen_space(vec3(point, 0));
             }
 
             vec2 normal_vector(in vec2 v) { return vec2(-v.y, v.x); }
@@ -21388,8 +21387,20 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 float width = px_per_unit * (is_end ? linewidth_end : linewidth_start);
                 float halfwidth = 0.5 * max(AA_RADIUS, width);
 
-                vec3 p1 = screen_space(linepoint_start);
-                vec3 p2 = screen_space(linepoint_end);
+                // restrict to visible area (see other shader)
+                vec3 p1, p2;
+                {
+                    vec4 _p1 = clip_space(linepoint_start), _p2 = clip_space(linepoint_end);
+                    vec4 v1 = _p2 - _p1;
+
+                    if (_p1.w < 0.0)
+                        _p1 = _p1 + (-_p1.w - _p1.z) / (v1.z + v1.w) * v1;
+                    if (_p2.w < 0.0)
+                        _p2 = _p2 + (-_p2.w - _p2.z) / (v1.z + v1.w) * v1;
+
+                    p1 = screen_space(_p1);
+                    p2 = screen_space(_p2);
+                }
 
                 // line vector (xy-normalized vectors in line direction)
                 // Need z component for correct depth order
@@ -21501,13 +21512,13 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
             ////////////////////////////////////////////////////////////////////////
 
 
-            vec2 process_pattern(bool pattern, bool[4] isvalid, vec2 extrusion, float halfwidth) {
+            vec2 process_pattern(bool pattern, bool[4] isvalid, vec2 extrusion, float segment_length, float halfwidth) {
                 // do not adjust stuff
                 f_pattern_overwrite = vec4(-1e12, 1.0, 1e12, 1.0);
                 return vec2(0);
             }
 
-            vec2 process_pattern(sampler2D pattern, bool[4] isvalid, vec2 extrusion, float halfwidth) {
+            vec2 process_pattern(sampler2D pattern, bool[4] isvalid, vec2 extrusion, float segment_length, float halfwidth) {
                 // samples:
                 //   -ext1  p1 ext1    -ext2 p2 ext2
                 //      1   2   3        4   5   6
@@ -21554,13 +21565,13 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
 
                 if (isvalid[3]) {
                     float offset = abs(extrusion[1]);
-                    left   = width * texture(pattern, vec2(uv_scale * (lastlen_end - offset), 0.0)).x;
-                    center = width * texture(pattern, vec2(uv_scale * (lastlen_end         ), 0.0)).x;
-                    right  = width * texture(pattern, vec2(uv_scale * (lastlen_end + offset), 0.0)).x;
+                    left   = width * texture(pattern, vec2(uv_scale * (lastlen_start + segment_length - offset), 0.0)).x;
+                    center = width * texture(pattern, vec2(uv_scale * (lastlen_start + segment_length         ), 0.0)).x;
+                    right  = width * texture(pattern, vec2(uv_scale * (lastlen_start + segment_length + offset), 0.0)).x;
 
                     if ((left > 0.0 && center > 0.0 && right > 0.0) || (left < 0.0 && right < 0.0)) {
                         // default/freeze
-                        f_pattern_overwrite.z = uv_scale * (lastlen_end - abs(extrusion[1]) - AA_RADIUS);
+                        f_pattern_overwrite.z = uv_scale * (lastlen_start + segment_length - abs(extrusion[1]) - AA_RADIUS);
                         f_pattern_overwrite.w = sign(center);
                     } else if (left > 0.0) {
                         // shrink backwards
@@ -21570,7 +21581,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                         adjust.y = 1.0;
                     } else {
                         // default - see above
-                        f_pattern_overwrite.z = uv_scale * (lastlen_end - abs(extrusion[1]) - AA_RADIUS);
+                        f_pattern_overwrite.z = uv_scale * (lastlen_start + segment_length - abs(extrusion[1]) - AA_RADIUS);
                         f_pattern_overwrite.w = sign(center);
                     }
                 }
@@ -21583,17 +21594,16 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
             // Geometry/Position Utils
             ////////////////////////////////////////////////////////////////////////
 
+            vec4 clip_space(vec3 point) {
+                return projectionview * model * vec4(point, 1);
+            }
+            vec4 clip_space(vec2 point) { return clip_space(vec3(point, 0)); }
 
-            vec3 screen_space(vec3 point) {
-                vec4 vertex = projectionview * model * vec4(point, 1);
+            vec3 screen_space(vec4 vertex) {
                 return vec3(
                     (0.5 * vertex.xy / vertex.w + 0.5) * px_per_unit * resolution,
                     vertex.z / vertex.w + depth_shift
                 );
-            }
-
-            vec3 screen_space(vec2 point) {
-                return screen_space(vec3(point, 0));
             }
 
             vec2 normal_vector(in vec2 v) { return vec2(-v.y, v.x); }
@@ -21617,12 +21627,52 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 float width = px_per_unit * (is_end ? linewidth_end : linewidth_start);
                 float halfwidth = 0.5 * max(AA_RADIUS, width);
 
-                vec3 p0 = screen_space(linepoint_prev);
-                vec3 p1 = screen_space(linepoint_start);
-                vec3 p2 = screen_space(linepoint_end);
-                vec3 p3 = screen_space(linepoint_next);
+                bool[4] isvalid = bool[4](
+                    linepoint_prev != linepoint_start,
+                    true, true,
+                    linepoint_end != linepoint_next
+                );
 
-                bool[4] isvalid = bool[4](p0 != p1, true, true, p2 != p3);
+                // To apply pixel space linewidths we transform line vertices to pixel space
+                // here. This is dangerous with perspective projection as p.xyz / p.w sends
+                // points from behind the camera to beyond far (clip z > 1), causing lines
+                // to invert. To avoid this we translate points along the line direction,
+                // moving them to the edge of the visible area.
+                vec3 p0, p1, p2, p3;
+                {
+                    // All in clip space
+                    vec4 clip_p0 = clip_space(linepoint_prev);
+                    vec4 clip_p1 = clip_space(linepoint_start);
+                    vec4 clip_p2 = clip_space(linepoint_end);
+                    vec4 clip_p3 = clip_space(linepoint_next);
+
+                    vec4 v1 = clip_p2 - clip_p1;
+
+                    // With our perspective projection matrix clip.w = -view.z with
+                    // clip.w < 0.0 being behind the camera.
+                    // Note that if the signs in the projectionmatrix change, this may become wrong.
+                    if (clip_p1.w < 0.0) {
+                        // the line connects outside the visible area so we may consider it disconnected
+                        isvalid[0] = false;
+                        // A clip position is visible if -w <= z <= w. To move the line along
+                        // the line direction v to the start of the visible area, we solve:
+                        //   p.z + t * v.z = +-(p.w + t * v.w)
+                        // where (-) gives us the result for the near clipping plane as p.z
+                        // and p.w share the same sign and p.z/p.w = -1.0 is the near plane.
+                        clip_p1 = clip_p1 + (-clip_p1.w - clip_p1.z) / (v1.z + v1.w) * v1;
+                    }
+                    if (clip_p2.w < 0.0) {
+                        isvalid[3] = false;
+                        clip_p2 = clip_p2 + (-clip_p2.w - clip_p2.z) / (v1.z + v1.w) * v1;
+                    }
+
+                    // transform clip -> screen space, applying xyz / w normalization (which
+                    // is now save as all vertices are in front of the camera)
+                    p0 = screen_space(clip_p0); // start of previous segment
+                    p1 = screen_space(clip_p1); // end of previous segment, start of current segment
+                    p2 = screen_space(clip_p2); // end of current segment, start of next segment
+                    p3 = screen_space(clip_p3); // end of next segment
+                }
 
                 // line vectors (xy-normalized vectors in line direction)
                 // Need z component here for correct depth order
@@ -21724,7 +21774,9 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 //   on straight line quad (adjustment becomes +1.0 or -1.0)
                 // - or adjust the pattern to start/stop outside of the joint
                 //   (f_pattern_overwrite is set, adjustment is 0.0)
-                vec2 adjustment = process_pattern(pattern, isvalid, halfwidth * extrusion, halfwidth);
+                vec2 adjustment = process_pattern(
+                    pattern, isvalid, halfwidth * extrusion, segment_length, halfwidth
+                );
 
                 // If adjustment != 0.0 we replace a joint by an extruded line,
                 // so we no longer need to shrink the line for the joint to fit.


### PR DESCRIPTION
# Description

Fixes #3544 and #3584.

~~Still need to understand what exactly is wrong here...~~

#### What's wrong?

The problem here was with what perspective projection does with points behind the camera. We can investigate with a simplified perspective projection matrix:

```julia
near = 1.0
far = 9.0
proj = Makie.Mat2f(
    -(far + near) / (far - near),       -1.0,
    -2.0 * near * far / (far - near),    0.0
)
```

This mirrors Makies implementation with `-1.0 >= p[1] >= -9.0` being the visible area in front of the camera (p[1] matching z). Some results:
- `proj * Point2f(-10, 1) = (10.25, 10.0) -> (1.025, 1)` clipped beyond far (> 1)
- `proj * Point2f(-4, 1) = (2.75, 4.0) -> (0.6875, 1)` visible (-1 <= z <= 1)
- `proj * Point2f(-0.5, 1) = (-1.625, 0.5) -> (-3.25, 1)` clipped before near (< -1)
- `proj * Point2f(0, 1) = (-2.25, 0.0) -> (-Inf, NaN)` singularity, clipped before near (< -1)
- `proj * Point2f(1, 1) = (-3.5, -1.0) -> (3.5, 1)` clipped beyond far (> 1)

As the last example suggests anything behind the camera/viewer ends up beyond the far plane in clip space with a perspective projection matrix. This is why lines and linesegments start going the other direction in the issues linked above. This is usually avoided by clipping before applying the w-normalization using `-w <= xyz <= w` to identify valid point.

#### What's the fix?

Since our linewidths are in pixel space we need to go pixel space before opengl (etc) does clipping. So we need to do a w normalization to get the correct coordinates. The solution I ended up going with is doing the clipping manually, in some sense.

The problematic case here is just "vertex behind camera". If that case arises (`clip.w = -1.0 * view.z > 0.0`) the shaders are now moving vertices along line direction towards the near plane.  In clip space the near plane is at `z / w = -1` so we can get the appropriate scaling from 
$$\frac{p_z + t v_z}{p_w + t v_w} = -1$$


TODO:
- [x] fix missing line segments in WGLMakie (poly refimg)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- ~~Added or changed relevant sections in the documentation~~
- ~~Added unit tests for new algorithms, conversion methods, etc.~~
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
