### PR TITLE
Unsupported marker warn message hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Added supported markers hint to unsupported marker warn message.
 
 ## [0.20.8] - 2024-02-22
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1683,7 +1683,7 @@ function to_spritemarker(marker::Symbol)
     if haskey(default_marker_map(), marker)
         return to_spritemarker(default_marker_map()[marker])
     else
-        @warn("Unsupported marker: $marker, using ● instead")
+        @warn("Unsupported marker: $marker, using ● instead. Available options can be printed with available_marker_symbols()")
         return '●'
     end
 end


### PR DESCRIPTION
# Description

When trying to use an unsupported marker, it would be nice to get a hint about (or at least how to find out) which markers are supported.
This just adds this hint to the warn message.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
