### PR TITLE
Move Arc to MakieCore

### DIFF
--- a/MakieCore/Project.toml
+++ b/MakieCore/Project.toml
@@ -1,7 +1,7 @@
 name = "MakieCore"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 authors = ["Simon Danisch"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Observables = "510215fc-4207-5dde-b226-833fc4488ee2"

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -609,3 +609,10 @@ end
     get!(attr, :arrowcolor, attr[:linecolor])
     return attr
 end
+
+@recipe(Arc, origin, radius, start_angle, stop_angle) do scene
+    Attributes(;
+        default_theme(scene, Lines)...,
+        resolution = 361,
+    )
+end

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Makie"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 authors = ["Simon Danisch", "Julius Krumbiegel"]
-version = "0.20.8"
+version = "0.20.9"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
@@ -89,7 +89,7 @@ KernelDensity = "0.5, 0.6"
 LaTeXStrings = "1.2"
 LinearAlgebra = "1.0, 1.6"
 MacroTools = "0.5"
-MakieCore = "=0.7.3"
+MakieCore = "=0.7.4"
 Markdown = "1.0, 1.6"
 MathTeXEngine = "0.5"
 Observables = "0.5.5"

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -79,7 +79,7 @@ import Base: getindex, setindex!, push!, append!, parent, get, get!, delete!, ha
 using Observables: listeners, to_value, notify
 
 using MakieCore: SceneLike, MakieScreen, ScenePlot, AbstractScene, AbstractPlot, Transformable, Attributes, Plot, Theme, Plot
-using MakieCore: Arrows, Heatmap, Image, Lines, LineSegments, Mesh, MeshScatter, Poly, Scatter, Surface, Text, Volume, Wireframe
+using MakieCore: Arc, Arrows, Heatmap, Image, Lines, LineSegments, Mesh, MeshScatter, Poly, Scatter, Surface, Text, Volume, Wireframe
 using MakieCore: ConversionTrait, NoConversion, PointBased, GridBased, VertexGrid, CellGrid, ImageLike, VolumeLike
 using MakieCore: Key, @key_str, Automatic, automatic, @recipe
 using MakieCore: Pixel, px, Unit, Billboard
@@ -88,8 +88,8 @@ using MakieCore: not_implemented_for
 import MakieCore: plot, plot!, theme, plotfunc, plottype, merge_attributes!, calculated_attributes!,
                   get_attribute, plotsym, plotkey, attributes, used_attributes
 import MakieCore: create_axis_like, create_axis_like!, figurelike_return, figurelike_return!
-import MakieCore: arrows, heatmap, image, lines, linesegments, mesh, meshscatter, poly, scatter, surface, text, volume
-import MakieCore: arrows!, heatmap!, image!, lines!, linesegments!, mesh!, meshscatter!, poly!, scatter!, surface!, text!, volume!
+import MakieCore: arc, arrows, heatmap, image, lines, linesegments, mesh, meshscatter, poly, scatter, surface, text, volume
+import MakieCore: arc!, arrows!, heatmap!, image!, lines!, linesegments!, mesh!, meshscatter!, poly!, scatter!, surface!, text!, volume!
 import MakieCore: convert_arguments, convert_attribute, default_theme, conversion_trait
 
 export @L_str, @colorant_str

--- a/src/basic_recipes/arc.jl
+++ b/src/basic_recipes/arc.jl
@@ -14,12 +14,7 @@ Examples:
 ## Attributes
 $(ATTRIBUTES)
 """
-@recipe(Arc, origin, radius, start_angle, stop_angle) do scene
-    Attributes(;
-        default_theme(scene, Lines)...,
-        resolution = 361,
-    )
-end
+Arc
 
 function plot!(p::Arc)
     args = getindex.(p, (:origin, :radius, :start_angle, :stop_angle, :resolution))


### PR DESCRIPTION
# Description

This moves an Arc stub to MakieCore, so it can be used without depending on Makie.jl. Personally I think almost all 
recipes defined in Makie.jl should be made available in MakieCore.jl. If there is interest, I will move more recipes over. 
