### PR TITLE
Streamline data_limits and boundingbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 - Add axis converts, enabling unit/categorical support and more [#3226](https://github.com/MakieOrg/Makie.jl/pull/3226).
+- **Breaking** Streamline `data_limits` and `boundingbox` [#3671](https://github.com/MakieOrg/Makie.jl/pull/3671)
+  - `data_limits` now only considers plot positions, completely ignoring transformations
+  - `boundingbox(::Text)` is deprecated in favor of `text_boundingbox(::Text)`
+  - `boundingbox` now always consider `transform_func` and `model` (except for Text for the time being)
 - **Breaking** Reworked line shaders in GLMakie and WGLMakie [#3558](https://github.com/MakieOrg/Makie.jl/pull/3558)
   - GLMakie: Removed support for per point linewidths
   - GLMakie: Adjusted dots (e.g. with `linestyle = :dot`) to bend across a joint
@@ -12,6 +16,7 @@
   - WGLMakie: Added line joints
   - WGLMakie: Added native anti-aliasing which generally improves quality but introduces outline artifacts in some cases (same as GLMakie)
   - Both: Adjusted handling of thin lines which may result in different color intensities
+
 
 ## [0.20.8] - 2024-02-22
 

--- a/ReferenceTests/src/tests/text.jl
+++ b/ReferenceTests/src/tests/text.jl
@@ -90,7 +90,7 @@ end
             align = (halign, :center),
             justification = justification)
 
-        bb = boundingbox(t)
+        bb = Makie.text_boundingbox(t)
         wireframe!(scene, bb, color = (:red, 0.2))
     end
 
@@ -119,7 +119,7 @@ end
         markerspace = :data
     )
 
-    wireframe!(scene, boundingbox(t1), color = (:blue, 0.3))
+    wireframe!(scene, Makie.text_boundingbox(t1), color = (:blue, 0.3))
 
     t2 = text!(scene,
         fill("makie", 4),
@@ -130,7 +130,7 @@ end
         markerspace = :pixel
     )
 
-    wireframe!(scene, boundingbox(t2), color = (:red, 0.3))
+    wireframe!(scene, Makie.text_boundingbox(t2), color = (:red, 0.3))
 
     scene
 end
@@ -149,7 +149,7 @@ end
             markerspace = :data
         )
 
-        wireframe!(scene, boundingbox(t), color = (:blue, 0.3))
+        wireframe!(scene, Makie.text_boundingbox(t), color = (:blue, 0.3))
 
         t2 = text!(scene,
             "makie",
@@ -161,7 +161,7 @@ end
         )
 
         # these boundingboxes should be invisible because they only enclose the anchor
-        wireframe!(scene, boundingbox(t2), color = (:red, 0.3))
+        wireframe!(scene, Makie.text_boundingbox(t2), color = (:red, 0.3))
 
     end
     scene
@@ -186,12 +186,12 @@ end
     t1 = text!(scene, "Line1\nLine 2\n\nLine4",
         position = (200, 400), align = (:center, :center), markerspace = :data)
 
-    wireframe!(scene, boundingbox(t1), color = (:red, 0.3))
+    wireframe!(scene, Makie.text_boundingbox(t1), color = (:red, 0.3))
 
     t2 = text!(scene, "\nLine 2\nLine 3\n\n\nLine6\n\n",
         position = (400, 400), align = (:center, :center), markerspace = :data)
 
-    wireframe!(scene, boundingbox(t2), color = (:blue, 0.3))
+    wireframe!(scene, Makie.text_boundingbox(t2), color = (:blue, 0.3))
 
     scene
 end
@@ -283,7 +283,7 @@ end
         position = Point2f(50, 50),
         rotation = 0.0,
         markerspace = :data)
-    wireframe!(s, boundingbox(t), color=:black)
+    wireframe!(s, Makie.text_boundingbox(t), color=:black)
     s
 end
 

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -209,6 +209,8 @@ include("layouting/transformation.jl")
 include("layouting/data_limits.jl")
 include("layouting/layouting.jl")
 include("layouting/boundingbox.jl")
+include("layouting/text_boundingbox.jl")
+include("layouting/maybe_unused.jl")
 
 # Declaritive SpecApi
 include("specapi.jl")

--- a/src/basic_recipes/axis.jl
+++ b/src/basic_recipes/axis.jl
@@ -342,6 +342,6 @@ function plot!(axis::Axis3D)
     return axis
 end
 
-function axis3d!(scene::Scene, lims = data_limits(scene, p -> isaxis(p) || not_in_data_space(p)); kw...)
+function axis3d!(scene::Scene, lims = boundingbox(scene, p -> isaxis(p) || not_in_data_space(p)); kw...)
     axis3d!(scene, Attributes(), lims; ticks = (ranges = automatic, labels = automatic), kw...)
 end

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -112,7 +112,7 @@ function Makie.plot!(pl::Bracket)
 end
 
 data_limits(pl::Bracket) = mapreduce(ps -> Rect3f([ps...]), union, pl[1][])
-boundingbox(pl::Bracket) = _boundingbox(pl, data_limits(pl))
+boundingbox(pl::Bracket) = transform_bbox(pl, data_limits(pl))
 
 bracket_bezierpath(style::Symbol, args...) = bracket_bezierpath(Val(style), args...)
 

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -111,7 +111,7 @@ function Makie.plot!(pl::Bracket)
     pl
 end
 
-data_limits(pl::Bracket) = mapreduce(ps -> Rect3f([ps...]), union, pl[1][])
+data_limits(pl::Bracket) = mapreduce(ps -> Rect3d([ps...]), union, pl[1][])
 boundingbox(pl::Bracket) = transform_bbox(pl, data_limits(pl))
 
 bracket_bezierpath(style::Symbol, args...) = bracket_bezierpath(Val(style), args...)

--- a/src/basic_recipes/bracket.jl
+++ b/src/basic_recipes/bracket.jl
@@ -112,6 +112,7 @@ function Makie.plot!(pl::Bracket)
 end
 
 data_limits(pl::Bracket) = mapreduce(ps -> Rect3f([ps...]), union, pl[1][])
+boundingbox(pl::Bracket) = _boundingbox(pl, data_limits(pl))
 
 bracket_bezierpath(style::Symbol, args...) = bracket_bezierpath(Val(style), args...)
 

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -337,7 +337,7 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
 end
 
 function data_limits(plot::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
-    mini_maxi = extrema_nan.((plot.x[], plot.y[]))
+    mini_maxi = extrema_nan.((plot[1][], plot[2][]))
     mini = Vec3d(first.(mini_maxi)..., 0)
     maxi = Vec3d(last.(mini_maxi)..., 0)
     return Rect3d(mini, maxi .- mini)

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -343,5 +343,5 @@ function data_limits(plot::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
     return Rect3d(mini, maxi .- mini)
 end
 function boundingbox(plot::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
-    return _boundingbox(plot, data_limits(plot))
+    return transform_bbox(plot, data_limits(plot))
 end

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -336,11 +336,12 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
     plot
 end
 
-function point_iterator(x::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
-    axes = (x[1], x[2])
-    extremata = map(extrema∘to_value, axes)
-    minpoint = Point2f(first.(extremata)...)
-    widths = last.(extremata) .- first.(extremata)
-    rect = Rect2f(minpoint, Vec2f(widths))
-    return unique(decompose(Point, rect))
+function data_limits(plot::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
+    mini_maxi = extrema_nan.((plot.x[], plot.y[]))
+    mini = Vec3d(first.(mini_maxi)..., 0)
+    maxi = Vec3d(last.(mini_maxi)..., 0)
+    return Rect3d(mini, maxi .- mini)
+end
+function boundingbox(plot::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
+    return _boundingbox(plot, data_limits(plot))
 end

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -345,3 +345,7 @@ end
 function boundingbox(plot::Contour{<: Tuple{X, Y, Z}}) where {X, Y, Z}
     return transform_bbox(plot, data_limits(plot))
 end
+# TODO: should this have a data_limits overload?
+function boundingbox(plot::Contour3d)
+    return transform_bbox(plot, data_limits(plot))
+end

--- a/src/basic_recipes/datashader.jl
+++ b/src/basic_recipes/datashader.jl
@@ -467,7 +467,7 @@ function Makie.plot!(p::DataShader{<:Tuple{Dict{String, Vector{Point{2, Float32}
 end
 
 data_limits(p::DataShader) =  p._boundingbox[]
-boundingbox(p::DataShader) =  _boundingbox(p, p._boundingbox[])
+boundingbox(p::DataShader) =  transform_bbox(p, p._boundingbox[])
 
 used_attributes(::Canvas) = (:operation, :local_operation)
 

--- a/src/basic_recipes/datashader.jl
+++ b/src/basic_recipes/datashader.jl
@@ -467,6 +467,7 @@ function Makie.plot!(p::DataShader{<:Tuple{Dict{String, Vector{Point{2, Float32}
 end
 
 data_limits(p::DataShader) =  p._boundingbox[]
+boundingbox(p::DataShader) =  _boundingbox(p, p._boundingbox[])
 
 used_attributes(::Canvas) = (:operation, :local_operation)
 

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -290,4 +290,4 @@ end
 
 # ignore whiskers when determining data limits
 data_limits(bars::Union{Errorbars, Rangebars}) = data_limits(bars.plots[1])
-boundingbox(bars::Union{Errorbars, Rangebars}) = _boundingbox(bars, data_limits(bars))
+boundingbox(bars::Union{Errorbars, Rangebars}) = transform_bbox(bars, data_limits(bars))

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -289,6 +289,5 @@ function screen_to_plot(plot, p::VecTypes)
 end
 
 # ignore whiskers when determining data limits
-function data_limits(bars::Union{Errorbars, Rangebars})
-    data_limits(bars.plots[1])
-end
+data_limits(bars::Union{Errorbars, Rangebars}) = data_limits(bars.plots[1])
+boundingbox(bars::Union{Errorbars, Rangebars}) = _boundingbox(bars, data_limits(bars))

--- a/src/basic_recipes/hvlines.jl
+++ b/src/basic_recipes/hvlines.jl
@@ -106,4 +106,4 @@ function data_limits(p::VLines)
     return Rect3d(Point3d(xmin, ymin, 0), Vec3d(xmax - xmin, ymax - ymin, 0))
 end
 
-boundingbox(p::Union{HLines, VLines}) = _boundingbox(p, data_limits(p))
+boundingbox(p::Union{HLines, VLines}) = transform_bbox(p, data_limits(p))

--- a/src/basic_recipes/hvlines.jl
+++ b/src/basic_recipes/hvlines.jl
@@ -94,7 +94,7 @@ function data_limits(p::HLines)
     itf = inverse_transform(p.transformation.transform_func[])
     xmin, xmax = apply_transform.(itf[1], first.(extrema(limits)))
     ymin, ymax = extrema(p[1][])
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
+    return Rect3d(Point3d(xmin, ymin, 0), Vec3d(xmax - xmin, ymax - ymin, 0))
 end
 
 function data_limits(p::VLines)
@@ -103,5 +103,7 @@ function data_limits(p::VLines)
     itf = inverse_transform(p.transformation.transform_func[])
     xmin, xmax = extrema(p[1][])
     ymin, ymax = apply_transform.(itf[2], getindex.(extrema(limits), 2))
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
+    return Rect3d(Point3d(xmin, ymin, 0), Vec3d(xmax - xmin, ymax - ymin, 0))
 end
+
+boundingbox(p::Union{HLines, VLines}) = _boundingbox(p, data_limits(p))

--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -110,4 +110,4 @@ function data_limits(p::VSpan)
     return Rect3d(Point3d(xmin, ymin, 0), Vec3d(xmax - xmin, ymax - ymin, 0))
 end
 
-boundingbox(p::Union{HSpan, VSpan}) = _boundingbox(p, data_limits(p))
+boundingbox(p::Union{HSpan, VSpan}) = transform_bbox(p, data_limits(p))

--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -97,7 +97,7 @@ function data_limits(p::HSpan)
     xmin, xmax = apply_transform.(itf[1], first.(extrema(limits)))
     ymin = minimum(p[1][])
     ymax = maximum(p[2][])
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
+    return Rect3d(Point3d(xmin, ymin, 0), Vec3d(xmax - xmin, ymax - ymin, 0))
 end
 
 function data_limits(p::VSpan)
@@ -107,5 +107,7 @@ function data_limits(p::VSpan)
     xmin = minimum(p[1][])
     xmax = maximum(p[2][])
     ymin, ymax = apply_transform.(itf[2], getindex.(extrema(limits), 2))
-    return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
+    return Rect3d(Point3d(xmin, ymin, 0), Vec3d(xmax - xmin, ymax - ymin, 0))
 end
+
+boundingbox(p::Union{HSpan, VSpan}) = _boundingbox(p, data_limits(p))

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -154,7 +154,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     bbox = map(
             p, px_pos, p.text, text_align, text_offset, textpadding, p.align
         ) do p, s, _, o, pad, align
-        bb = px_boundingbox(tp) + to_ndim(Vec3f, o, 0)
+        bb = text_boundingbox(tp) + to_ndim(Vec3f, o, 0)
         l, r, b, t = pad
         return Rect3f(origin(bb) .- (l, b, 0), widths(bb) .+ (l+r, b+t, 0))
     end

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -154,7 +154,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     bbox = map(
             p, px_pos, p.text, text_align, text_offset, textpadding, p.align
         ) do p, s, _, o, pad, align
-        bb = boundingbox(tp) + to_ndim(Vec3f, o, 0)
+        bb = px_boundingbox(tp) + to_ndim(Vec3f, o, 0)
         l, r, b, t = pad
         return Rect3f(origin(bb) .- (l, b, 0), widths(bb) .+ (l+r, b+t, 0))
     end

--- a/src/basic_recipes/triplot.jl
+++ b/src/basic_recipes/triplot.jl
@@ -245,11 +245,11 @@ function data_limits(p::Triplot{<:Tuple{<:Vector{<:Point}}})
     if transform_func(p) isa Polar
         # Because the Polar transform is handled explicitly we cannot rely
         # on the default data_limits. (data limits are pre transform)
-        iter = (to_ndim(Point3f, p, 0f0) for p in p.converted[1][])
-        limits_from_transformed_points(iter)
+        return Rect3d(p.converted[1][])
     else
-        # First component is either another Voronoiplot or a poly plot. Both
+        # First component is either another Triplot or a poly plot. Both
         # cases span the full limits of the plot
-        data_limits(p.plots[1])
+        return data_limits(p.plots[1])
     end
 end
+boundingbox(p::Triplot{<:Tuple{<:Vector{<:Point}}}) = _boundingbox(p, data_limits(p))

--- a/src/basic_recipes/triplot.jl
+++ b/src/basic_recipes/triplot.jl
@@ -252,4 +252,4 @@ function data_limits(p::Triplot{<:Tuple{<:Vector{<:Point}}})
         return data_limits(p.plots[1])
     end
 end
-boundingbox(p::Triplot{<:Tuple{<:Vector{<:Point}}}) = _boundingbox(p, data_limits(p))
+boundingbox(p::Triplot{<:Tuple{<:Vector{<:Point}}}) = transform_bbox(p, data_limits(p))

--- a/src/basic_recipes/voronoiplot.jl
+++ b/src/basic_recipes/voronoiplot.jl
@@ -167,18 +167,18 @@ function plot!(p::Voronoiplot{<:Tuple{<:Vector{<:Point{N}}}}) where {N}
     return voronoiplot!(p, attr, vorn)
 end
 
-function data_limits(p::Voronoiplot{<:Tuple{<:Vector{<:Point{N}}}}) where {N}
+function data_limits(p::Voronoiplot{<:Tuple{<:Vector{<:Point}}})
     if transform_func(p) isa Polar
         # Because the Polar transform is handled explicitly we cannot rely
         # on the default data_limits. (data limits are pre transform)
-        iter = (to_ndim(Point3f, p, 0f0) for p in p.converted[1][])
-        limits_from_transformed_points(iter)
+        return Rect3d(p.converted[1][])
     else
         # First component is either another Voronoiplot or a poly plot. Both
         # cases span the full limits of the plot
-        data_limits(p.plots[1])
+        return data_limits(p.plots[1])
     end
 end
+boundingbox(p::Voronoiplot{<:Tuple{<:Vector{<:Point}}}) = _boundingbox(p, data_limits(p))
 
 function plot!(p::Voronoiplot{<:Tuple{<:DelTri.VoronoiTessellation}})
     generators_2f = Observable(Point2f[])

--- a/src/basic_recipes/voronoiplot.jl
+++ b/src/basic_recipes/voronoiplot.jl
@@ -178,7 +178,7 @@ function data_limits(p::Voronoiplot{<:Tuple{<:Vector{<:Point}}})
         return data_limits(p.plots[1])
     end
 end
-boundingbox(p::Voronoiplot{<:Tuple{<:Vector{<:Point}}}) = _boundingbox(p, data_limits(p))
+boundingbox(p::Voronoiplot{<:Tuple{<:Vector{<:Point}}}) = transform_bbox(p, data_limits(p))
 
 function plot!(p::Voronoiplot{<:Tuple{<:DelTri.VoronoiTessellation}})
     generators_2f = Observable(Point2f[])

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -210,9 +210,9 @@ Takes an input `Rect` `x` and decomposes it to points.
 
 `P` is the plot Type (it is optional).
 """
-function convert_arguments(P::PointBased, x::Rect2)
+function convert_arguments(P::PointBased, x::Rect2{T}) where T
     # TODO fix the order of decompose
-    return convert_arguments(P, decompose(Point2, x)[[1, 2, 4, 3]])
+    return convert_arguments(P, decompose(Point2{promote_type(Float32, T)}, x)[[1, 2, 4, 3]])
 end
 
 function convert_arguments(P::PointBased, mesh::AbstractMesh)

--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -53,7 +53,14 @@ end
 # no longer in pixel space
 @inline future_boundingbox(plot::AbstractPlot) = boundingbox(plot)
 @inline future_boundingbox(plot::Text) = _boundingbox(plot)
-_boundingbox(plot::Text) = Rect3d(iterate_transformed(plot))
+
+function _boundingbox(plot::Text)
+    if plot.space[] == plot.markerspace[]
+        return transform_bbox(plot, text_boundingbox(plot))
+    else
+        return Rect3d(iterate_transformed(plot))
+    end
+end
 
 # for convenience
 function transform_bbox(scenelike, lims::Rect)

--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -47,7 +47,7 @@ function _boundingbox(plot::AbstractPlot)
         update_boundingbox!(bb_ref, future_boundingbox(plot.plots[i]))
     end
 
-    return
+    return bb_ref[]
 end
 # Replace future_boundingbox with just boundingbox once boundingbox(::Text) is
 # no longer in pixel space
@@ -66,12 +66,13 @@ end
 ### transformed point iterator
 ################################################################################
 
+# TODO should Float32 conversions apply here?
 
 @inline iterate_transformed(plot) = iterate_transformed(plot, point_iterator(plot))
 
 function iterate_transformed(plot, points)
     t = transformation(plot)
-    model = Mat4d(model_transform(t)) # TODO: make model matrix Float64?
+    model = model_transform(t)
     trans_func = transform_func(t)
     return iterate_transformed(points, model, to_value(get(plot, :space, :data)), trans_func)
 end

--- a/src/layouting/boundingbox.jl
+++ b/src/layouting/boundingbox.jl
@@ -67,6 +67,25 @@ function transform_bbox(scenelike, lims::Rect)
     return Rect3d(iterate_transformed(scenelike, point_iterator(lims)))
 end
 
+# same as data_limits except using iterate_transformed
+function boundingbox(plot::MeshScatter)
+    # TODO: avoid mesh generation here if possible
+    @get_attribute plot (marker, markersize, rotations)
+    marker_bb = Rect3d(marker)
+    positions = iterate_transformed(plot)
+    scales = markersize
+    # fast path for constant markersize
+    if scales isa VecTypes{3} && rotations isa Quaternion
+        bb = Rect3d(positions)
+        marker_bb = rotations * (marker_bb * scales)
+        return Rect3d(minimum(bb) + minimum(marker_bb), widths(bb) + widths(marker_bb))
+    else
+        # TODO: optimize const scale, var rot and var scale, const rot
+        return limits_with_marker_transforms(positions, scales, rotations, marker_bb)
+    end
+end
+
+
 
 ################################################################################
 ### transformed point iterator
@@ -88,44 +107,4 @@ function iterate_transformed(plot, points::T) where T
     model = model_transform(t) # will auto-promote if points if Float64
     trans_func = transform_func(t)
     [to_ndim(Point3d, project(model, apply_transform(trans_func, point, space))) for point in points]
-end
-
-
-################################################################################
-### Special cases
-################################################################################
-
-
-# includes markersize and rotation
-function boundingbox(plot::MeshScatter)
-    # TODO: avoid mesh generation here if possible
-    @get_attribute plot (marker, markersize, rotations)
-    marker_bb = Rect3d(marker)
-    positions = iterate_transformed(plot)
-    scales = markersize
-    # fast path for constant markersize
-    if scales isa VecTypes{3} && rotations isa Quaternion
-        bb = Rect3d(positions)
-        marker_bb = rotations * (marker_bb * scales)
-        return Rect3d(minimum(bb) + minimum(marker_bb), widths(bb) + widths(marker_bb))
-    else
-        # TODO: optimize const scale, var rot and var scale, const rot
-        return limits_from_transformed_points(positions, scales, rotations, marker_bb)
-    end
-end
-
-# include bbox from scaled markers
-function limits_from_transformed_points(positions, scales, rotations, element_bbox)
-    isempty(positions) && return Rect3d()
-
-    first_scale = attr_broadcast_getindex(scales, 1)
-    first_rot = attr_broadcast_getindex(rotations, 1)
-    full_bbox = Ref(first_rot * (element_bbox * first_scale) + first(positions))
-    for (i, pos) in enumerate(positions)
-        scale, rot = attr_broadcast_getindex(scales, i), attr_broadcast_getindex(rotations, i)
-        transformed_bbox = rot * (element_bbox * scale) + pos
-        update_boundingbox!(full_bbox, transformed_bbox)
-    end
-
-    return full_bbox[]
 end

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -106,10 +106,15 @@ point_iterator(bbox::Rect) = unique(decompose(Point3d, bbox))
 
 
 isfinite_rect(x::Rect) = all(isfinite, x.origin) &&  all(isfinite, x.widths)
+_isfinite(x) = isfinite(x)
+_isfinite(x::VecTypes) = all(isfinite, x)
+scalarmax(x::Union{Tuple, AbstractArray}, y::Union{Tuple, AbstractArray}) = max.(x, y)
+scalarmax(x, y) = max(x, y)
+scalarmin(x::Union{Tuple, AbstractArray}, y::Union{Tuple, AbstractArray}) = min.(x, y)
+scalarmin(x, y) = min(x, y)
 
 extrema_nan(itr::Pair) = (itr[1], itr[2])
 extrema_nan(itr::ClosedInterval) = (minimum(itr), maximum(itr))
-
 function extrema_nan(itr)
     vs = iterate(itr)
     vs === nothing && return (NaN, NaN)
@@ -129,6 +134,12 @@ function extrema_nan(itr)
         vmin = scalarmin(x, vmin)
     end
     return (vmin, vmax)
+end
+
+# used in colorsampler.jl, datashader.jl
+function distinct_extrema_nan(x)
+    lo, hi = extrema_nan(x)
+    lo == hi ? (lo - 0.5f0, hi + 0.5f0) : (lo, hi)
 end
 
 function update_boundingbox!(bb_ref, point)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -162,6 +162,20 @@ function update_boundingbox!(bb_ref, bb::Rect)
     return
 end
 
+# used in PolarAxis
+function _update_rect(rect::Rect{N, T}, point::VecTypes{N, T}) where {N, T}
+    mi = minimum(rect)
+    ma = maximum(rect)
+    mis_mas = map(mi, ma, point) do _mi, _ma, _p
+        (isnan(_mi) ? _p : _p < _mi ? _p : _mi), (isnan(_ma) ? _p : _p > _ma ? _p : _ma)
+    end
+    new_o = map(first, mis_mas)
+    new_w = map(mis_mas) do (mi, ma)
+        ma - mi
+    end
+    typeof(rect)(new_o, new_w)
+end
+
 
 foreach_plot(f, s::Scene) = foreach_plot(f, s.plots)
 # foreach_plot(f, s::Figure) = foreach_plot(f, s.scene)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -84,8 +84,43 @@ function data_limits(plot::Text)
     end
 end
 
+# includes markersize and rotation
+function data_limits(plot::MeshScatter)
+    # TODO: avoid mesh generation here if possible
+    @get_attribute plot (marker, markersize, rotations)
+    marker_bb = Rect3d(marker)
+    positions = point_iterator(plot)
+    scales = markersize
+    # fast path for constant markersize
+    if scales isa VecTypes{3} && rotations isa Quaternion
+        bb = Rect3d(positions)
+        marker_bb = rotations * (marker_bb * scales)
+        return Rect3d(minimum(bb) + minimum(marker_bb), widths(bb) + widths(marker_bb))
+    else
+        # TODO: optimize const scale, var rot and var scale, const rot
+        return limits_with_marker_transforms(positions, scales, rotations, marker_bb)
+    end
+end
+
+# include bbox from scaled markers
+function limits_with_marker_transforms(positions, scales, rotations, element_bbox)
+    isempty(positions) && return Rect3d()
+
+    first_scale = attr_broadcast_getindex(scales, 1)
+    first_rot = attr_broadcast_getindex(rotations, 1)
+    full_bbox = Ref(first_rot * (element_bbox * first_scale) + first(positions))
+    for (i, pos) in enumerate(positions)
+        scale, rot = attr_broadcast_getindex(scales, i), attr_broadcast_getindex(rotations, i)
+        transformed_bbox = rot * (element_bbox * scale) + pos
+        update_boundingbox!(full_bbox, transformed_bbox)
+    end
+
+    return full_bbox[]
+end
+
+
 ################################################################################
-### point_iterator & data_limits
+### point_iterator
 ################################################################################
 
 

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -152,13 +152,9 @@ function update_boundingbox!(bb_ref, bb::Rect)
 end
 
 
-function foreach_plot(f, s::Scene)
-    foreach_plot(f, s.plots)
-    foreach(sub-> foreach_plot(f, sub), s.children)
-end
-
-foreach_plot(f, s::Figure) = foreach_plot(f, s.scene)
-foreach_plot(f, s::FigureAxisPlot) = foreach_plot(f, s.figure)
+foreach_plot(f, s::Scene) = foreach_plot(f, s.plots)
+# foreach_plot(f, s::Figure) = foreach_plot(f, s.scene)
+# foreach_plot(f, s::FigureAxisPlot) = foreach_plot(f, s.figure)
 foreach_plot(f, list::AbstractVector) = foreach(f, list)
 function foreach_plot(f, plot::Plot)
     if isempty(plot.plots)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -75,6 +75,8 @@ function data_limits(x::Volume)
     return Rect3d(first.(extremata), last.(extremata) .- first.(extremata))
 end
 
+# We don't want pixel space line segments to be considered...
+data_limits(plot::Text) = Rect3d(point_iterator(plot))
 
 ################################################################################
 ### point_iterator & data_limits
@@ -87,7 +89,7 @@ end
 
 point_iterator(plot::Text) = point_iterator(plot.plots[1])
 function point_iterator(plot::Text{<: Tuple{<: Union{GlyphCollection, AbstractVector{GlyphCollection}}}})
-    return plot.positions[]
+    return plot.position[]
 end
 
 point_iterator(mesh::GeometryBasics.Mesh) = decompose(Point, mesh)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -76,7 +76,13 @@ function data_limits(x::Volume)
 end
 
 # We don't want pixel space line segments to be considered...
-data_limits(plot::Text) = Rect3d(point_iterator(plot))
+function data_limits(plot::Text)
+    if plot.space[] == plot.markerspace[]
+        return text_boundingbox(plot)
+    else
+        return Rect3d(point_iterator(plot))
+    end
+end
 
 ################################################################################
 ### point_iterator & data_limits

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -96,7 +96,7 @@ point_iterator(mesh::GeometryBasics.Mesh) = decompose(Point, mesh)
 point_iterator(plot::Mesh) = point_iterator(plot.mesh[])
 
 # Fallback for other primitive plots, used in boundingbox
-point_iterator(plot::AbstractPlot) = points_iterator(data_limits(plot))
+point_iterator(plot::AbstractPlot) = point_iterator(data_limits(plot))
 
 # For generic usage
 point_iterator(bbox::Rect) = unique(decompose(Point3d, bbox))

--- a/src/layouting/maybe_unused.jl
+++ b/src/layouting/maybe_unused.jl
@@ -66,32 +66,6 @@
 
 
 ################################################################################
-# Utilities
-################################################################################
-
-# unused
-
-#=
-
-function _update_rect(rect::Rect{N, T}, point::VecTypes{N, T}) where {N, T}
-    mi = minimum(rect)
-    ma = maximum(rect)
-    mis_mas = map(mi, ma, point) do _mi, _ma, _p
-        (isnan(_mi) ? _p : _p < _mi ? _p : _mi), (isnan(_ma) ? _p : _p > _ma ? _p : _ma)
-    end
-    new_o = map(first, mis_mas)
-    new_w = map(mis_mas) do (mi, ma)
-        ma - mi
-    end
-    typeof(rect)(new_o, new_w)
-end
-
-=#
-
-
-
-
-################################################################################
 ### from boundingboxes/text
 ################################################################################
 

--- a/src/layouting/maybe_unused.jl
+++ b/src/layouting/maybe_unused.jl
@@ -72,19 +72,6 @@
 # unused
 
 #=
-_isfinite(x) = isfinite(x)
-_isfinite(x::VecTypes) = all(isfinite, x)
-scalarmax(x::Union{Tuple, AbstractArray}, y::Union{Tuple, AbstractArray}) = max.(x, y)
-scalarmax(x, y) = max(x, y)
-scalarmin(x::Union{Tuple, AbstractArray}, y::Union{Tuple, AbstractArray}) = min.(x, y)
-scalarmin(x, y) = min(x, y)
-
-
-function distinct_extrema_nan(x)
-    lo, hi = extrema_nan(x)
-    lo == hi ? (lo - 0.5f0, hi + 0.5f0) : (lo, hi)
-end
-
 
 function _update_rect(rect::Rect{N, T}, point::VecTypes{N, T}) where {N, T}
     mi = minimum(rect)

--- a/src/layouting/maybe_unused.jl
+++ b/src/layouting/maybe_unused.jl
@@ -1,0 +1,157 @@
+################################################################################
+### from data_limits
+################################################################################
+
+# TODO: boundingbox
+# function data_limits(text::Text{<: Tuple{<: Union{GlyphCollection, AbstractVector{GlyphCollection}}}})
+#     if is_data_space(text.markerspace[])
+#         return boundingbox(text)
+#     else
+#         if text.position[] isa VecTypes
+#             return Rect3d(text.position[])
+#         else
+#             # TODO: is this branch necessary?
+#             return Rect3d(convert_arguments(PointBased(), text.position[])[1])
+#         end
+#     end
+# end
+# function data_limits(text::Text)
+    # return data_limits(text.plots[1])
+# end
+
+# TODO: unused?
+# function br_getindex(vector::AbstractVector, idx::CartesianIndex, dim::Int)
+#     return vector[Tuple(idx)[dim]]
+# end
+# function br_getindex(matrix::AbstractMatrix, idx::CartesianIndex, dim::Int)
+#     return matrix[idx]
+# end
+
+# TODO: boundingbox
+
+# function foreach_transformed(f, point_iterator, model, trans_func)
+#     for point in point_iterator
+#         point_t = apply_transform(trans_func, point)
+#         point_m = project(model, point_t)
+#         f(point_m)
+#     end
+#     return
+# end
+
+# function foreach_transformed(f, plot)
+#     points = point_iterator(plot)
+#     t = transformation(plot)
+#     model = model_transform(t)
+#     trans_func = t.transform_func[]
+#     # use function barrier since trans_func is Any
+#     foreach_transformed(f, points, model, identity)
+# end
+
+
+# # TODO: What's your purpose?
+# function point_iterator(list::AbstractVector)
+#     if length(list) == 1
+#         # save a copy!
+#         return point_iterator(list[1])
+#     else
+#         points = Point3d[]
+#         for elem in list
+#             for point in point_iterator(elem)
+#                 push!(points, to_ndim(Point3d, point, 0))
+#             end
+#         end
+#         return points
+#     end
+# end
+
+
+################################################################################
+# Utilities
+################################################################################
+
+# unused
+
+#=
+_isfinite(x) = isfinite(x)
+_isfinite(x::VecTypes) = all(isfinite, x)
+scalarmax(x::Union{Tuple, AbstractArray}, y::Union{Tuple, AbstractArray}) = max.(x, y)
+scalarmax(x, y) = max(x, y)
+scalarmin(x::Union{Tuple, AbstractArray}, y::Union{Tuple, AbstractArray}) = min.(x, y)
+scalarmin(x, y) = min(x, y)
+
+
+function distinct_extrema_nan(x)
+    lo, hi = extrema_nan(x)
+    lo == hi ? (lo - 0.5f0, hi + 0.5f0) : (lo, hi)
+end
+
+
+function _update_rect(rect::Rect{N, T}, point::VecTypes{N, T}) where {N, T}
+    mi = minimum(rect)
+    ma = maximum(rect)
+    mis_mas = map(mi, ma, point) do _mi, _ma, _p
+        (isnan(_mi) ? _p : _p < _mi ? _p : _mi), (isnan(_ma) ? _p : _p > _ma ? _p : _ma)
+    end
+    new_o = map(first, mis_mas)
+    new_w = map(mis_mas) do (mi, ma)
+        ma - mi
+    end
+    typeof(rect)(new_o, new_w)
+end
+
+=#
+
+
+
+
+################################################################################
+### from boundingboxes/text
+################################################################################
+
+#=
+function project_widths(matrix, vec)
+    pr = project(matrix, vec)
+    zero = project(matrix, zeros(typeof(vec)))
+    return pr - zero
+end
+
+function height_insensitive_boundingbox(ext::GlyphExtent)
+    l = ext.ink_bounding_box.origin[1]
+    w = ext.ink_bounding_box.widths[1]
+    b = ext.descender
+    h = ext.ascender
+    return Rect2d((l, b), (w, h - b))
+end
+
+_inkboundingbox(ext::GlyphExtent) = ext.ink_bounding_box
+
+_is_latex_string(x::AbstractVector{<:LaTeXString}) = true
+_is_latex_string(x::LaTeXString) = true
+_is_latex_string(other) = false
+
+"""
+Calculate an approximation of a tight rectangle around a 2D rectangle rotated by `angle` radians.
+This is not perfect but works well enough. Check an A vs X to see the difference.
+"""
+function rotatedrect(rect::Rect{2, T}, angle)::Rect{2, T} where T
+    ox, oy = rect.origin
+    wx, wy = rect.widths
+    points = Mat{2, 4, T}(
+        ox, oy,
+        ox, oy+wy,
+        ox+wx, oy,
+        ox+wx, oy+wy
+    )
+    mrot = Mat{2, 2, T}(
+        cos(angle), -sin(angle),
+        sin(angle), cos(angle)
+    )
+    rotated = mrot * points
+
+    rmins = minimum(rotated; dims=2)
+    rmaxs = maximum(rotated; dims=2)
+
+    return Rect2(rmins..., (rmaxs .- rmins)...)
+end
+
+=#

--- a/src/layouting/text_boundingbox.jl
+++ b/src/layouting/text_boundingbox.jl
@@ -1,18 +1,18 @@
 function boundingbox(plot::Text)
     @warn """
-    `boundingbox(::Text)` has been deprecated in favor of `px_boundingbox(::Text)`.
+    `boundingbox(::Text)` has been deprecated in favor of `Makie.text_boundingbox(::Text)`.
     In the future `boundingbox(::Text)` will be adjusted to match the other
     `boundingbox(plot)` functions. The new functionality is currently available
     as `Makie._boundingbox(plot::Text)`.
     """
-    return px_boundingbox(plot)
+    return text_boundingbox(plot)
 end
 
 # TODO: Naming: not px, it's whatever markerspace is...
-function px_boundingbox(plot::Text)
+function text_boundingbox(plot::Text)
     bb = Rect3d()
     for p in plot.plots
-        _bb = px_boundingbox(p)
+        _bb = text_boundingbox(p)
         if !isfinite_rect(bb)
             bb = _bb
         elseif isfinite_rect(_bb)
@@ -22,7 +22,7 @@ function px_boundingbox(plot::Text)
     return bb
 end
 
-function px_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
+function text_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
     if x.space[] == x.markerspace[]
         pos = to_ndim(Point3d, x.position[], 0)
     else
@@ -30,10 +30,10 @@ function px_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
         transformed = apply_transform(x.transformation.transform_func[], x.position[])
         pos = Makie.project(cam, x.space[], x.markerspace[], transformed)
     end
-    return px_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+    return text_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
 end
 
-function px_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
+function text_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
     if x.space[] == x.markerspace[]
         pos = to_ndim.(Point3d, x.position[], 0)
     else
@@ -41,10 +41,10 @@ function px_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
         transformed = apply_transform(x.transformation.transform_func[], x.position[])
         pos = Makie.project.(cam, x.space[], x.markerspace[], transformed) # TODO: vectorized project
     end
-    return px_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+    return text_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
 end
 
-function px_boundingbox(x::Union{GlyphCollection,AbstractArray{<:GlyphCollection}}, args...)
+function text_boundingbox(x::Union{GlyphCollection,AbstractArray{<:GlyphCollection}}, args...)
     bb = unchecked_boundingbox(x, args...)
     isfinite_rect(bb) || error("Invalid text boundingbox")
     return bb
@@ -57,7 +57,7 @@ function text_bb(str, font, size)
     layout = layout_text(
         str, size, font, fonts, Vec2f(0), rot, 0.5, 1.0,
         RGBAf(0, 0, 0, 0), RGBAf(0, 0, 0, 0), 0f0, 0f0)
-    return px_boundingbox(layout, Point3d(0), rot)
+    return text_boundingbox(layout, Point3d(0), rot)
 end
 
 
@@ -91,9 +91,9 @@ function unchecked_boundingbox(layouts::AbstractArray{<:GlyphCollection}, positi
     bb = Rect3d()
     broadcast_foreach(layouts, positions, rotations) do layout, pos, rot
         if !isfinite_rect(bb)
-            bb = px_boundingbox(layout, pos, rot)
+            bb = text_boundingbox(layout, pos, rot)
         else
-            bb = union(bb, px_boundingbox(layout, pos, rot))
+            bb = union(bb, text_boundingbox(layout, pos, rot))
         end
     end
     return bb

--- a/src/layouting/text_boundingbox.jl
+++ b/src/layouting/text_boundingbox.jl
@@ -1,0 +1,127 @@
+function boundingbox(plot::Text)
+    @warn """
+    `boundingbox(::Text)` has been deprecated in favor of `px_boundingbox(::Text)`.
+    In the future `boundingbox(::Text)` will be adjusted to match the other
+    `boundingbox(plot)` functions. The new functionality is currently available
+    as `Makie._boundingbox(plot::Text)`.
+    """
+    return px_boundingbox(plot)
+end
+
+# TODO: Naming: not px, it's whatever markerspace is...
+function px_boundingbox(plot::Text)
+    bb = Rect3d()
+    for p in plot.plots
+        _bb = px_boundingbox(p)
+        if !isfinite_rect(bb)
+            bb = _bb
+        elseif isfinite_rect(_bb)
+            bb = union(bb, _bb)
+        end
+    end
+    return bb
+end
+
+function px_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
+    if x.space[] == x.markerspace[]
+        pos = to_ndim(Point3d, x.position[], 0)
+    else
+        cam = parent_scene(x).camera
+        transformed = apply_transform(x.transformation.transform_func[], x.position[])
+        pos = Makie.project(cam, x.space[], x.markerspace[], transformed)
+    end
+    return px_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+end
+
+function px_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
+    if x.space[] == x.markerspace[]
+        pos = to_ndim.(Point3d, x.position[], 0)
+    else
+        cam = (parent_scene(x).camera,)
+        transformed = apply_transform(x.transformation.transform_func[], x.position[])
+        pos = Makie.project.(cam, x.space[], x.markerspace[], transformed) # TODO: vectorized project
+    end
+    return px_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+end
+
+function px_boundingbox(x::Union{GlyphCollection,AbstractArray{<:GlyphCollection}}, args...)
+    bb = unchecked_boundingbox(x, args...)
+    isfinite_rect(bb) || error("Invalid text boundingbox")
+    return bb
+end
+
+# Utility
+function text_bb(str, font, size)
+    rot = Quaternionf(0,0,0,1)
+    fonts = nothing # TODO: remove the arg if possible
+    layout = layout_text(
+        str, size, font, fonts, Vec2f(0), rot, 0.5, 1.0,
+        RGBAf(0, 0, 0, 0), RGBAf(0, 0, 0, 0), 0f0, 0f0)
+    return px_boundingbox(layout, Point3d(0), rot)
+end
+
+
+################################################################################
+
+function unchecked_boundingbox(glyphcollection::GlyphCollection, position::Point3, rotation::Quaternion)
+    return unchecked_boundingbox(glyphcollection, rotation) + position
+end
+
+function unchecked_boundingbox(glyphcollection::GlyphCollection, rotation::Quaternion)
+    isempty(glyphcollection.glyphs) && return Rect3d(Point3d(0), Vec3d(0))
+
+    glyphorigins = glyphcollection.origins
+    glyphbbs = gl_bboxes(glyphcollection)
+
+    bb = Rect3d()
+    for (charo, glyphbb) in zip(glyphorigins, glyphbbs)
+        charbb = rotate_bbox(Rect3d(glyphbb), rotation) + charo
+        if !isfinite_rect(bb)
+            bb = charbb
+        else
+            bb = union(bb, charbb)
+        end
+    end
+    return bb
+end
+
+function unchecked_boundingbox(layouts::AbstractArray{<:GlyphCollection}, positions, rotations)
+    isempty(layouts) && return Rect3d((0, 0, 0), (0, 0, 0))
+
+    bb = Rect3d()
+    broadcast_foreach(layouts, positions, rotations) do layout, pos, rot
+        if !isfinite_rect(bb)
+            bb = px_boundingbox(layout, pos, rot)
+        else
+            bb = union(bb, px_boundingbox(layout, pos, rot))
+        end
+    end
+    return bb
+end
+
+
+################################################################################
+
+# used
+
+function gl_bboxes(gl::GlyphCollection)
+    scales = gl.scales.sv isa Vec2 ? (gl.scales.sv for _ in gl.extents) : gl.scales.sv
+    map(gl.glyphs, gl.extents, scales) do c, ext, scale
+        hi_bb = height_insensitive_boundingbox_with_advance(ext)
+        # TODO c != 0 filters out all non renderables, which is not always desired
+        return Rect2d(origin(hi_bb) * scale, (c != 0) * widths(hi_bb) * scale)
+    end
+end
+
+function height_insensitive_boundingbox_with_advance(ext::GlyphExtent)
+    l = 0.0
+    r = ext.hadvance
+    b = ext.descender
+    h = ext.ascender
+    return Rect2d((l, b), (r - l, h - b))
+end
+
+function rotate_bbox(bb::Rect3{T}, rot) where {T <: Real}
+    points = decompose(Point3{T}, bb)
+    return Rect3{T}(Ref(rot) .* points)
+end

--- a/src/layouting/text_boundingbox.jl
+++ b/src/layouting/text_boundingbox.jl
@@ -22,6 +22,10 @@ function text_boundingbox(plot::Text)
     return bb
 end
 
+# Text can contain linesegments. Use data_limits to avoid transformations as
+# they are already in markerspace
+text_boundingbox(x::LineSegments) = data_limits(x)
+
 function text_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
     if x.space[] == x.markerspace[]
         pos = to_ndim(Point3d, x.position[], 0)

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -1,5 +1,10 @@
 Base.parent(t::Transformation) = isassigned(t.parent) ? t.parent[] : nothing
 
+function parent_transform(x)
+    p = parent(transformation(x))
+    return isnothing(p) ? Mat4f(I) : p.model[]
+end
+
 function Observables.connect!(parent::Transformation, child::Transformation; connect_func=true)
     tfuncs = []
     obsfunc = on(parent.model; update=true) do m

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -202,7 +202,7 @@ function apply_transform_and_model(model::Mat4, f, pos::VecTypes, space = :data,
         return transformed
     end
 end
-function apply_transform_and_model(model::Mat4, f, positions::Vector, space = :data, output_type = Point3d)
+function apply_transform_and_model(model::Mat4, f, positions::AbstractArray, space = :data, output_type = Point3d)
     return map(positions) do pos
         apply_transform_and_model(model, f, pos, space, output_type)
     end

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -193,10 +193,14 @@ function apply_transform_and_model(plot::AbstractPlot, pos, output_type = Point3
 end
 function apply_transform_and_model(model::Mat4, f, pos::VecTypes, space = :data, output_type = Point3d)
     transformed = apply_transform(f, pos, space)
-    p4d = to_ndim(Point4d, to_ndim(Point3d, transformed, 0), 1)
-    p4d = model * p4d
-    p4d = p4d ./ p4d[4]
-    return to_ndim(output_type, p4d, NaN)
+    if space in (:data, :transformed)
+        p4d = to_ndim(Point4d, to_ndim(Point3d, transformed, 0), 1)
+        p4d = model * p4d
+        p4d = p4d ./ p4d[4]
+        return to_ndim(output_type, p4d, NaN)
+    else
+        return transformed
+    end
 end
 function apply_transform_and_model(model::Mat4, f, positions::Vector, space = :data, output_type = Point3d)
     return map(positions) do pos

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -112,7 +112,7 @@ function calculate_title_position(area, titlegap, subtitlegap, align, xaxisposit
     end
 
     local subtitlespace::Float32 = if ax.subtitlevisible[] && !iswhitespace(ax.subtitle[])
-        boundingbox(subtitlet).widths[2] + subtitlegap
+        text_boundingbox(subtitlet).widths[2] + subtitlegap
     else
         0f0
     end
@@ -137,8 +137,8 @@ function compute_protrusions(title, titlesize, titlegap, titlevisible, spinewidt
         top = xaxisprotrusion
     end
 
-    titleheight = boundingbox(titlet).widths[2] + titlegap
-    subtitleheight = boundingbox(subtitlet).widths[2] + subtitlegap
+    titleheight = text_boundingbox(titlet).widths[2] + titlegap
+    subtitleheight = text_boundingbox(subtitlet).widths[2] + subtitlegap
 
     titlespace = if !titlevisible || iswhitespace(title)
         0f0

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -849,8 +849,24 @@ function getlimits(la::Axis, dim)
         # only use visible plots for limits
         return !to_value(get(plot, :visible, true))
     end
-    # get all data limits, minus the excluded plots
-    boundingbox = Makie.data_limits(la.scene, exclude)
+
+    # TODO:
+    # We used to include scale! and rotate! in data_limits. For compat we include
+    # them here again until we implement a full solution
+
+    # # get all data limits, minus the excluded plots
+    # boundingbox = Makie.data_limits(la.scene, exclude)
+    bb_ref = Base.RefValue(Rect3d())
+    for plot in la.scene
+        if !exclude(plot)
+            bb = data_limits(plot)
+            model = plot.model[][Vec(1,2,3), Vec(1,2,3)]
+            bb = Rect3d(map(p -> model * to_ndim(Point3d, p, 0), coordinates(bb)))
+            update_boundingbox!(bb_ref, bb)
+        end
+    end
+    boundingbox = bb_ref[]
+
     # if there are no bboxes remaining, `nothing` signals that no limits could be determined
     Makie.isfinite_rect(boundingbox) || return nothing
 

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -306,7 +306,7 @@ function getlimits(ax::Axis3, dim)
         ifelse(dim == 3, to_value(get(attr, :zautolimits, true)), true)
     end
 
-    bboxes = Makie.data_limits.(filtered_plots)
+    bboxes = Makie.data_limits.(filtered_plots) # TODO: use boundingbox to include transform_func and model?
     finite_bboxes = filter(Makie.isfinite_rect, bboxes)
 
     isempty(finite_bboxes) && return nothing

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -306,7 +306,7 @@ function getlimits(ax::Axis3, dim)
         ifelse(dim == 3, to_value(get(attr, :zautolimits, true)), true)
     end
 
-    bboxes = Makie.data_limits.(filtered_plots) # TODO: use boundingbox to include transform_func and model?
+    bboxes = Makie.data_limits.(filtered_plots)
     finite_bboxes = filter(Makie.isfinite_rect, bboxes)
 
     isempty(finite_bboxes) && return nothing

--- a/src/makielayout/blocks/button.jl
+++ b/src/makielayout/blocks/button.jl
@@ -40,7 +40,7 @@ function initialize_block!(b::Button)
     translate!(labeltext, 0, 0, 1)
 
     onany(scene, b.label, b.fontsize, b.font, b.padding) do label, fontsize, font, padding
-        textbb = Rect2f(boundingbox(labeltext))
+        textbb = Rect2f(text_boundingbox(labeltext))
         autowidth = width(textbb) + padding[1] + padding[2]
         autoheight = height(textbb) + padding[3] + padding[4]
         b.layoutobservables.autosize[] = (autowidth, autoheight)

--- a/src/makielayout/blocks/label.jl
+++ b/src/makielayout/blocks/label.jl
@@ -18,7 +18,7 @@ function initialize_block!(l::Label)
 
     onany(topscene, l.text, l.fontsize, l.font, l.rotation, word_wrap_width,
           l.padding) do _, _, _, _, _, padding
-        textbb[] = Rect2f(boundingbox(t))
+        textbb[] = Rect2f(text_boundingbox(t))
         autowidth = width(textbb[]) + padding[1] + padding[2]
         autoheight = height(textbb[]) + padding[3] + padding[4]
         if l.word_wrap[]

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -104,7 +104,7 @@ function initialize_block!(m::Menu; default = 1)
         end
     end
 
-    selectionarea = Observable(Rect2f(0, 0, 0, 0); ignore_equal_values=true)
+    selectionarea = Observable(Rect2d(0, 0, 0, 0); ignore_equal_values=true)
 
     selectionpoly = poly!(
         blockscene, selectionarea, color = m.selection_cell_color_inactive[];
@@ -124,14 +124,14 @@ function initialize_block!(m::Menu; default = 1)
     notify(selected_text)
 
     on(blockscene, m.layoutobservables.computedbbox) do cbb
-        selectionarea[] = cbb
+        selectionarea[] = Rect2d(origin(cbb), widths(cbb))
         ch = height(cbb)
         selectiontextpos[] = cbb.origin + Point2f(m.textpadding[][1], ch/2)
     end
 
     textpositions = Observable(zeros(Point2f, length(optionstrings[])); ignore_equal_values=true)
 
-    optionrects = Observable([BBox(0, 0, 0, 0)]; ignore_equal_values=true)
+    optionrects = Observable([Rect2d(0, 0, 0, 0)]; ignore_equal_values=true)
     optionpolycolors = Observable(RGBAf[RGBAf(0.5, 0.5, 0.5, 1)]; ignore_equal_values=true)
 
     function update_option_colors!(hovered)

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -131,7 +131,7 @@ function initialize_block!(m::Menu; default = 1)
 
     textpositions = Observable(zeros(Point2f, length(optionstrings[])); ignore_equal_values=true)
 
-    optionrects = Observable([Bbox(0, 0, 0, 0)]; ignore_equal_values=true)
+    optionrects = Observable([BBox(0, 0, 0, 0)]; ignore_equal_values=true)
     optionpolycolors = Observable(RGBAf[RGBAf(0.5, 0.5, 0.5, 1)]; ignore_equal_values=true)
 
     function update_option_colors!(hovered)

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -118,7 +118,7 @@ function initialize_block!(m::Menu; default = 1)
     )
 
     onany(blockscene, selected_text, m.fontsize, m.textpadding) do _, _, (l, r, b, t)
-        bb = boundingbox(selectiontext)
+        bb = text_boundingbox(selectiontext)
         m.layoutobservables.autosize[] = width(bb) + l + r, height(bb) + b + t
     end
     notify(selected_text)
@@ -162,7 +162,7 @@ function initialize_block!(m::Menu; default = 1)
 
     onany(blockscene, optionstrings, m.textpadding, m.layoutobservables.computedbbox) do _, pad, bbox
         gcs = optiontexts.plots[1][1][]::Vector{GlyphCollection}
-        bbs = map(x -> boundingbox(x, zero(Point3f), Quaternion(0, 0, 0, 0)), gcs)
+        bbs = map(x -> text_boundingbox(x, zero(Point3f), Quaternion(0, 0, 0, 0)), gcs)
         heights = map(bb -> height(bb) + pad[3] + pad[4], bbs)
         heights_cumsum = [zero(eltype(heights)); cumsum(heights)]
         h = sum(heights)

--- a/src/makielayout/blocks/polaraxis.jl
+++ b/src/makielayout/blocks/polaraxis.jl
@@ -60,11 +60,11 @@ function initialize_block!(po::PolarAxis; palette=nothing)
         # (each boundingbox represents a string without text.position applied)
         max_widths = Vec2f(0)
         for gc in thetaticklabelplot.plots[1].plots[1][1][]
-            bbox = boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
+            bbox = text_boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
             max_widths = max.(max_widths, widths(bbox)[Vec(1,2)])
         end
         for gc in rticklabelplot.plots[1].plots[1][1][]
-            bbox = boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
+            bbox = text_boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
             max_widths = max.(max_widths, widths(bbox)[Vec(1,2)])
         end
 

--- a/src/makielayout/blocks/scene.jl
+++ b/src/makielayout/blocks/scene.jl
@@ -19,6 +19,7 @@ function initialize_block!(ls::LScene; scenekw = NamedTuple())
                 # update limits when scene limits change
                 limits = lift(blockscene, ls.scene.theme.limits) do lims
                     if lims === automatic
+                        # TODO: probably boundingbox?
                         dl = data_limits(ls.scene, p -> Makie.isaxis(p) || Makie.not_in_data_space(p))
                         if any(isinf, widths(dl)) || any(isinf, Makie.origin(dl))
                             Rect3f((0f0, 0f0, 0f0), (1f0, 1f0, 1f0))

--- a/src/makielayout/blocks/scene.jl
+++ b/src/makielayout/blocks/scene.jl
@@ -19,8 +19,7 @@ function initialize_block!(ls::LScene; scenekw = NamedTuple())
                 # update limits when scene limits change
                 limits = lift(blockscene, ls.scene.theme.limits) do lims
                     if lims === automatic
-                        # TODO: probably boundingbox?
-                        dl = data_limits(ls.scene, p -> Makie.isaxis(p) || Makie.not_in_data_space(p))
+                        dl = boundingbox(ls.scene, p -> Makie.isaxis(p) || Makie.not_in_data_space(p))
                         if any(isinf, widths(dl)) || any(isinf, Makie.origin(dl))
                             Rect3d((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
                         else

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -37,7 +37,7 @@ function calculate_protrusion(
     real_labelsize::Float32 = if label_is_empty
         0f0
     else
-        boundingbox(labeltext).widths[horizontal[] ? 2 : 1]
+        text_boundingbox(labeltext).widths[horizontal[] ? 2 : 1]
     end
 
     labelspace::Float32 = (labelvisible && !label_is_empty) ? real_labelsize + labelpadding : 0f0
@@ -300,10 +300,10 @@ function LineAxis(parent::Scene, attrs::Attributes)
     map!(parent, ticklabel_ideal_space, ticklabel_annotation_obs, ticklabelalign, ticklabelrotation, ticklabelfont, ticklabelsvisible) do args...
         maxwidth = if pos_extents_horizontal[][3]
                 # height
-                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : height(Rect2f(boundingbox(ticklabels)))) : 0f0
+                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : height(Rect2f(text_boundingbox(ticklabels)))) : 0f0
             else
                 # width
-                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : width(Rect2f(boundingbox(ticklabels)))) : 0f0
+                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : width(Rect2f(text_boundingbox(ticklabels)))) : 0f0
         end
         # in case there is no string in the annotations and the boundingbox comes back all NaN
         if !isfinite(maxwidth)
@@ -401,7 +401,7 @@ function LineAxis(parent::Scene, attrs::Attributes)
         xs::Float32, ys::Float32 = if labelrotation isa Automatic
             0f0, 0f0
         else
-            wx, wy = widths(boundingbox(labeltext))
+            wx, wy = widths(text_boundingbox(labeltext))
             sign::Int = flipped ? 1 : -1
             if horizontal
                 0f0, Float32(sign * 0.5f0 * wy)
@@ -519,10 +519,10 @@ function tight_ticklabel_spacing!(la::LineAxis)
     tls = la.elements[:ticklabels]
     maxwidth = if horizontal
             # height
-            tls.visible[] ? height(Rect2f(boundingbox(tls))) : 0f0
+            tls.visible[] ? height(Rect2f(text_boundingbox(tls))) : 0f0
         else
             # width
-            tls.visible[] ? width(Rect2f(boundingbox(tls))) : 0f0
+            tls.visible[] ? width(Rect2f(text_boundingbox(tls))) : 0f0
     end
     la.attributes.ticklabelspace = maxwidth
     return Float64(maxwidth)

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -551,7 +551,6 @@ end
 
 function center!(scene::Scene, padding=0.01, exclude = not_in_data_space)
     bb = boundingbox(scene, exclude)
-    bb = transformationmatrix(scene)[] * bb
     w = widths(bb)
     padd = w .* padding
     bb = Rect3d(minimum(bb) .- padd, w .+ 2padd)
@@ -566,7 +565,7 @@ parent_scene(x::Scene) = x
 Base.isopen(x::SceneLike) = events(x).window_open[]
 
 function is2d(scene::SceneLike)
-    lims = data_limits(scene)
+    lims = boundingbox(scene)
     lims === nothing && return nothing
     return is2d(lims)
 end

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -73,7 +73,7 @@ function data_limits(hb::Hexbin)
 
     return Rect3f(no, nw)
 end
-boundingbox(p::Hexbin) = _boundingbox(p, data_limits(hb))
+boundingbox(p::Hexbin) = transform_bbox(p, data_limits(hb))
 
 get_weight(weights, i) = Float64(weights[i])
 get_weight(::StatsBase.UnitWeights, i) = 1e0

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -73,6 +73,7 @@ function data_limits(hb::Hexbin)
 
     return Rect3f(no, nw)
 end
+boundingbox(p::Hexbin) = _boundingbox(p, data_limits(hb))
 
 get_weight(weights, i) = Float64(weights[i])
 get_weight(::StatsBase.UnitWeights, i) = 1e0

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -71,7 +71,7 @@ function data_limits(hb::Hexbin)
     nw = widths(bb) .+ (ms..., 0.0f0)
     no = bb.origin .- ((ms ./ 2.0f0)..., 0.0f0)
 
-    return Rect3f(no, nw)
+    return Rect3d(no, nw)
 end
 boundingbox(p::Hexbin) = transform_bbox(p, data_limits(hb))
 


### PR DESCRIPTION
# Description

This adjusts data_limits and boundingbox to be more consistent and well defined:
- `data_limits` now only considers the raw positional data in plots. It never considers transform function, the model matrix, etc.
- `boundingbox` is now strictly in world space, i.e. it applies `transform_func` and `model` before generating a result

Note that this is based on a rather temporary state of #3663 so this pr is likely to fail for reasons not related to this pr.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
