### PR TITLE
fix `contourf` `Inf` value on non-extended case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## [Unreleased]
-- Added supported markers hint to unsupported marker warn message.
 
+- Fix contourf color in non-extended band [#3684](https://github.com/MakieOrg/Makie.jl/pull/3684).
+- Added supported markers hint to unsupported marker warn message.
 - Remove StableHashTraits in favor of calculating hashes directly with CRC32c [#3667](https://github.com/MakieOrg/Makie.jl/pull/3667).
 
 ## [0.20.8] - 2024-02-22

--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -84,12 +84,12 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
     lowcolor = Observable{RGBAf}()
     map!(compute_lowcolor, c, lowcolor, c.extendlow, c.colormap)
     c.attributes[:_computed_extendlow] = lowcolor
-    is_extended_low = lift(!is_zero_color, c, lowcolor)
+    is_extended_low = lift(!isnothing, c, c.extendlow)
 
     highcolor = Observable{RGBAf}()
     map!(compute_highcolor, c, highcolor, c.extendhigh, c.colormap)
     c.attributes[:_computed_extendhigh] = highcolor
-    is_extended_high = lift(!is_zero_color, c, highcolor)
+    is_extended_high = lift(!isnothing, c, c.extendhigh)
     PolyType = typeof(Polygon(Point2f[], [Point2f[]]))
 
     polys = Observable(PolyType[])
@@ -114,7 +114,6 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
         for (i, (center, group)) in enumerate(zip(levelcenters, isos))
             points = Point2f.(group.x, group.y)
             polygroups = _group_polys(points, group.id)
-            @show center length(polygroups)
             for polygroup in polygroups
                 outline = polygroup[1]
                 holes = polygroup[2:end]
@@ -171,7 +170,6 @@ function _group_polys(points, ids)
         for p1 in polys_lastdouble, p2 in polys_lastdouble]
 
     unclassified_polyindices = collect(1:size(containment_matrix, 1))
-    # @show unclassified_polyindices
 
     # each group has first an outer polygon, and then its holes
     # TODO: don't specifically type this 2f0?

--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -84,12 +84,12 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
     lowcolor = Observable{RGBAf}()
     map!(compute_lowcolor, c, lowcolor, c.extendlow, c.colormap)
     c.attributes[:_computed_extendlow] = lowcolor
-    is_extended_low = lift(!isnothing, c, lowcolor)
+    is_extended_low = lift(!is_zero_color, c, lowcolor)
 
     highcolor = Observable{RGBAf}()
     map!(compute_highcolor, c, highcolor, c.extendhigh, c.colormap)
     c.attributes[:_computed_extendhigh] = highcolor
-    is_extended_high = lift(!isnothing, c, highcolor)
+    is_extended_high = lift(!is_zero_color, c, highcolor)
     PolyType = typeof(Polygon(Point2f[], [Point2f[]]))
 
     polys = Observable(PolyType[])
@@ -111,9 +111,13 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
 
         levelcenters = (highs .+ lows) ./ 2
 
+        @show levels c lowcolor highcolor levelcenters is_extended_low is_extended_high
+
         for (i, (center, group)) in enumerate(zip(levelcenters, isos))
             points = Point2f.(group.x, group.y)
             polygroups = _group_polys(points, group.id)
+            @show points center length(polygroups)
+            # length(polygroups) < 2 && continue
             for polygroup in polygroups
                 outline = polygroup[1]
                 holes = polygroup[2:end]
@@ -122,7 +126,7 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
                 push!(colors[], center)
             end
         end
-        polys[] = polys[]
+        # polys[] = polys[]
         return
     end
 

--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -111,13 +111,10 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
 
         levelcenters = (highs .+ lows) ./ 2
 
-        @show levels c lowcolor highcolor levelcenters is_extended_low is_extended_high
-
         for (i, (center, group)) in enumerate(zip(levelcenters, isos))
             points = Point2f.(group.x, group.y)
             polygroups = _group_polys(points, group.id)
-            @show points center length(polygroups)
-            # length(polygroups) < 2 && continue
+            @show center length(polygroups)
             for polygroup in polygroups
                 outline = polygroup[1]
                 holes = polygroup[2:end]
@@ -126,7 +123,6 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
                 push!(colors[], center)
             end
         end
-        # polys[] = polys[]
         return
     end
 

--- a/src/basic_recipes/tricontourf.jl
+++ b/src/basic_recipes/tricontourf.jl
@@ -95,6 +95,8 @@ function compute_contourf_colormap(levels, cmap, elow, ehigh)
     return cm
 end
 
+is_zero_color(x) = x == RGBAf(0, 0, 0, 0)
+
 function compute_lowcolor(el, cmap)
     if isnothing(el)
         return RGBAf(0, 0, 0, 0)
@@ -130,12 +132,12 @@ function Makie.plot!(c::Tricontourf{<:Tuple{<:DelTri.Triangulation, <:AbstractVe
     lowcolor = Observable{RGBAf}()
     map!(compute_lowcolor, lowcolor, c.extendlow, c.colormap)
     c.attributes[:_computed_extendlow] = lowcolor
-    is_extended_low = lift(!isnothing, c, c.extendlow)
+    is_extended_low = lift(!is_zero_color, c, c.extendlow)
 
     highcolor = Observable{RGBAf}()
     map!(compute_highcolor, highcolor, c.extendhigh, c.colormap)
     c.attributes[:_computed_extendhigh] = highcolor
-    is_extended_high = lift(!isnothing, c, c.extendhigh)
+    is_extended_high = lift(!is_zero_color, c, c.extendhigh)
 
     PolyType = typeof(Polygon(Point2f[], [Point2f[]]))
 

--- a/src/basic_recipes/tricontourf.jl
+++ b/src/basic_recipes/tricontourf.jl
@@ -95,8 +95,6 @@ function compute_contourf_colormap(levels, cmap, elow, ehigh)
     return cm
 end
 
-is_zero_color(x) = x == RGBAf(0, 0, 0, 0)
-
 function compute_lowcolor(el, cmap)
     if isnothing(el)
         return RGBAf(0, 0, 0, 0)
@@ -132,12 +130,12 @@ function Makie.plot!(c::Tricontourf{<:Tuple{<:DelTri.Triangulation, <:AbstractVe
     lowcolor = Observable{RGBAf}()
     map!(compute_lowcolor, lowcolor, c.extendlow, c.colormap)
     c.attributes[:_computed_extendlow] = lowcolor
-    is_extended_low = lift(!is_zero_color, c, c.extendlow)
+    is_extended_low = lift(!isnothing, c, c.extendlow)
 
     highcolor = Observable{RGBAf}()
     map!(compute_highcolor, highcolor, c.extendhigh, c.colormap)
     c.attributes[:_computed_extendhigh] = highcolor
-    is_extended_high = lift(!is_zero_color, c, c.extendhigh)
+    is_extended_high = lift(!isnothing, c, c.extendhigh)
 
     PolyType = typeof(Polygon(Point2f[], [Point2f[]]))
 

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -504,3 +504,17 @@ end
     end
     @test isempty(limits.listeners)
 end
+
+@testset "Contourf" begin
+    x = y = LinRange(0, 1, 10)
+    ymin, ymax = 0.4, 0.6
+    steepness = 0.1
+    f(x, y) = (tanh((y - ymin) / steepness) - tanh((y - ymax) / steepness) - 1)
+    z = [f(_x, _y) for _x in x, _y in y]
+
+    fig, ax, cof = contourf(x, y, z)
+    @test isfinite(cof.plots[1].color[][end])
+
+    fig, ax, cof = contourf(x, y, z; extendhigh = :auto)
+    @test isinf(cof.plots[1].color[][end])
+end


### PR DESCRIPTION
# Description

Fix https://github.com/MakieOrg/Makie.jl/issues/3683.


```julia

x = y = LinRange(0, 1, 10)
ymin, ymax = 0.4, 0.6
steepness = 0.1
f(x, y) = (tanh((y - ymin) / steepness) - tanh((y - ymax) / steepness) - 1)
z = [f(_x, _y) for _x in x, _y in y]

fig, ax, cof = contourf(x, y, z)
Colorbar(fig[1, 2], cof)
save("noext.png", fig)

fig, ax, cof = contourf(x, y, z; extendhigh=:auto)
Colorbar(fig[1, 2], cof)
save("ext.png", fig)
```

**noext**
![noext](https://github.com/MakieOrg/Makie.jl/assets/13423344/ceb3d03c-fd00-45fa-8817-391fa86744cc)

**ext**
![ext](https://github.com/MakieOrg/Makie.jl/assets/13423344/e93d20b5-8c0c-439f-a839-5386ac842c4c)

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
