### PR TITLE
Add precompile used in ttf benchmark

### DIFF
--- a/.github/workflows/compilation-benchmark.yaml
+++ b/.github/workflows/compilation-benchmark.yaml
@@ -28,7 +28,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-          include-all-prereleases: true
           arch: x64
       - uses: julia-actions/cache@v1
       - name: Benchmark

--- a/precompile/shared-precompile.jl
+++ b/precompile/shared-precompile.jl
@@ -1,5 +1,8 @@
 # File to run to snoop/trace all functions to compile
 using GeometryBasics
+
+@compile scatter(1:4; color=1:4, colormap=:turbo, markersize=20, visible=true)
+
 @compile poly(Recti(0, 0, 200, 200), strokewidth=20, strokecolor=:red, color=(:black, 0.4))
 
 @compile scatter(0..1, rand(10), markersize=rand(10) .* 20)


### PR DESCRIPTION
I noticed in #3681, that we dont actually have the exact statement from ttf precompile in here. This should be in here, since it should test if everything is cached and precompiled correctly. If we want to benchmark compile speed in general without caching, we would need to add some other benchmark, since without this statement, this is neither benchmarking pure precompiled performance, nor pure compilation time.
