### PR TITLE
[WIP] Customizable colorrange handling

### DIFF
--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -244,6 +244,28 @@ colormapping_type(@nospecialize(colormap)) = continuous
 colormapping_type(::PlotUtils.CategoricalColorGradient) = banded
 colormapping_type(::Categorical) = categorical
 
+"""
+    evaluate_colormap(colorrange, color)::Vec2{Float64}
+
+This function must return a `Vec2{Float64}` of the colorrange as `(low, high)`.
+Add additional dispatches to this function for your own custom colorrange objects!
+
+The catch-all definition for this function is to convert any provided `colorrange` into 
+a `Vec2{Float64}`.  By default, two more dispatches are defined for `Makie.automatic` 
+and for `Function`s (but not all callables, since that's not possible to define on).
+
+You can define your method like so:
+
+```julia
+Makie.evaluate_colorrange(colorrange::MyCustomType, color) = ...
+```
+
+and `color` is always an array of numbers.  Be warned that the vector may have only one element.
+"""
+evaluate_colorrange(colorrange, color) = Vec2{Float64}(colorrange)
+evaluate_colorrange(colorrange::Automatic, color) = Vec2{Float64}(Makie.distinct_extrema_nan(color))
+evaluate_colorrange(colorrange::Function, color) = Vec2{Float64}(colorrange(color))
+
 
 function _colormapping(
         color_tight::Observable{V},
@@ -292,7 +314,7 @@ function _colormapping(
     end
 
     colorrange = lift(color_tight, colorrange; ignore_equal_values=true) do color, crange
-        return crange isa Automatic ? Vec2{Float64}(distinct_extrema_nan(color)) : Vec2{Float64}(crange)
+        return evaluate_colorrange(crange, color)
     end
 
     colorrange_scaled = lift(colorrange, colorscale; ignore_equal_values=true) do range, scale


### PR DESCRIPTION
# Description

This PR introduces a function `evaluate_colorrange`, which can be extended by users for their own colorrange types.  It currently has dispatches for `Automatic` and `Function` input, with the default dispatch converting the given `colorrange` to `Vec2{Float64}`.

The objective here is to allow users to pass anything they want to determine the colorrange, so long as it returns appropriate output.  This is a completion of one of the points of discussion at MakieCon.

It should now be possible to implement structs for colorranges which must be centered about zero, quantile-based colorranges, and any other metric.  In addition, functions like `PlotUtils.zscale` can be passed freely, or any user-provided function that returns a 2-tuple or similar.

Unfortunately, _scaling_ colormaps about zero such that the center is at zero but the top and bottom halves have different scales is not possible to implement in the framework of this PR - that would have to be a separate colormap object and would involve a lot more handling.

Still needs tests and examples!

## Type of change

Delete options that do not apply:

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
