### PR TITLE
add recipes for intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 - Added supported markers hint to unsupported marker warn message.
 - Remove StableHashTraits in favor of calculating hashes directly with CRC32c [#3667](https://github.com/MakieOrg/Makie.jl/pull/3667).
-- Add recipes for plotting intervals to `PointBased`, `Band`, `Rangebars`, `H/VSpan` [3695](https://github.com/MakieOrg/Makie.jl/pull/3695)
+- Add recipes for plotting intervals to `Band`, `Rangebars`, `H/VSpan` [3695](https://github.com/MakieOrg/Makie.jl/pull/3695)
 
 ## [0.20.8] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 - Added supported markers hint to unsupported marker warn message.
-
 - Remove StableHashTraits in favor of calculating hashes directly with CRC32c [#3667](https://github.com/MakieOrg/Makie.jl/pull/3667).
+- Add recipes for plotting intervals to `PointBased`, `Band`, `Rangebars`, `H/VSpan` [3695](https://github.com/MakieOrg/Makie.jl/pull/3695)
 
 ## [0.20.8] - 2024-02-22
 

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -62,7 +62,7 @@ import DelaunayTriangulation as DelTri
 import REPL
 import MacroTools
 
-using IntervalSets: IntervalSets, (..), OpenInterval, ClosedInterval, AbstractInterval, Interval, endpoints
+using IntervalSets: IntervalSets, (..), OpenInterval, ClosedInterval, AbstractInterval, Interval, endpoints, leftendpoint, rightendpoint
 using FixedPointNumbers: N0f8
 
 using GeometryBasics: width, widths, height, positive_widths, VecTypes, AbstractPolygon, value, StaticVector

--- a/src/basic_recipes/band.jl
+++ b/src/basic_recipes/band.jl
@@ -1,9 +1,11 @@
 """
     band(x, ylower, yupper; kwargs...)
     band(lower, upper; kwargs...)
+    band(x, lowerupper; kwargs...)
 
 Plots a band from `ylower` to `yupper` along `x`. The form `band(lower, upper)` plots a [ruled surface](https://en.wikipedia.org/wiki/Ruled_surface)
 between the points in `lower` and `upper`.
+Both bounds can be passed together as `lowerupper`, a vector of intervals.
 
 ## Attributes
 $(ATTRIBUTES)

--- a/src/basic_recipes/band.jl
+++ b/src/basic_recipes/band.jl
@@ -19,6 +19,9 @@ end
 
 convert_arguments(::Type{<: Band}, x, ylower, yupper) = (Point2f.(x, ylower), Point2f.(x, yupper))
 
+convert_arguments(P::Type{<: Band}, x::AbstractVector{<:Number}, y::AbstractVector{<:Interval}) =
+    convert_arguments(P, x, leftendpoint.(y), rightendpoint.(y))
+
 function band_connect(n)
     ns = 1:n-1
     ns2 = n+1:2n-1

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -127,6 +127,9 @@ function Makie.convert_arguments(::Type{<:Rangebars}, val, low_high)
     (val_low_high,)
 end
 
+Makie.convert_arguments(P::Type{<:Rangebars}, x::AbstractVector{<:Number}, y::AbstractVector{<:Interval}) =
+    convert_arguments(P, x, endpoints.(y))
+
 ### the two plotting functions create linesegpairs in two different ways
 ### and then hit the same underlying implementation in `_plot_bars!`
 

--- a/src/basic_recipes/error_and_rangebars.jl
+++ b/src/basic_recipes/error_and_rangebars.jl
@@ -41,6 +41,7 @@ end
 
 Plots rangebars at `val` in one dimension, extending from `low` to `high` in the other dimension
 given the chosen `direction`.
+The `low_high` argument can be a vector of tuples or intervals.
 
 If you want to plot errors relative to a reference value, use `errorbars`.
 

--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -109,3 +109,6 @@ function data_limits(p::VSpan)
     ymin, ymax = apply_transform.(itf[2], getindex.(extrema(limits), 2))
     return Rect3f(Point3f(xmin, ymin, 0), Vec3f(xmax - xmin, ymax - ymin, 0))
 end
+
+convert_arguments(P::Type{<:Union{HSpan, VSpan}}, x::Interval) =
+    convert_arguments(P, endpoints(x)...)

--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -1,10 +1,12 @@
 """
     hspan(ys_low, ys_high; xmin = 0.0, xmax = 1.0, attrs...)
+    hspan(ys_lowhigh; xmin = 0.0, xmax = 1.0, attrs...)
 
 Create horizontal bands spanning across a `Scene` with 2D projection.
 The bands will be placed from `ys_low` to `ys_high` in data coordinates and `xmin` to `xmax`
 in scene coordinates (0 to 1). All four of these can have single or multiple values because
 they are broadcast to calculate the final spans.
+Both bounds can be passed together as an interval `ys_lowhigh`.
 
 All style attributes are the same as for `Poly`.
 """
@@ -20,11 +22,13 @@ All style attributes are the same as for `Poly`.
 
 """
     vspan(xs_low, xs_high; ymin = 0.0, ymax = 1.0, attrs...)
+    vspan(xs_lowhigh; ymin = 0.0, ymax = 1.0, attrs...)
 
 Create vertical bands spanning across a `Scene` with 2D projection.
 The bands will be placed from `xs_low` to `xs_high` in data coordinates and `ymin` to `ymax`
 in scene coordinates (0 to 1). All four of these can have single or multiple values because
 they are broadcast to calculate the final spans.
+Both bounds can be passed together as an interval `xs_lowhigh`.
 
 All style attributes are the same as for `Poly`.
 """

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -146,14 +146,6 @@ convert_arguments(P::PointBased, x::AbstractVector{<:Real}, y::AbstractVector{<:
 
 convert_arguments(P::PointBased, x::AbstractVector{<:Real}, y::AbstractVector{<:Real}, z::AbstractVector{<:Real}) = (Point3f.(x, y, z),)
 
-
-convert_arguments(P::PointBased, x::AbstractVector{<:Number}, y::AbstractVector{<:Interval}) =
-    convert_arguments(P, x, mean.(y))
-
-convert_arguments(P::PointBased, x::AbstractVector{<:Interval}, y::AbstractVector{<:Number}) =
-    convert_arguments(P, mean.(x), y)
-
-
 """
     convert_arguments(P, y)::Vector
 Takes vector `y` and generates a range from 1 to the length of `y`, for plotting on

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -146,6 +146,14 @@ convert_arguments(P::PointBased, x::AbstractVector{<:Real}, y::AbstractVector{<:
 
 convert_arguments(P::PointBased, x::AbstractVector{<:Real}, y::AbstractVector{<:Real}, z::AbstractVector{<:Real}) = (Point3f.(x, y, z),)
 
+
+convert_arguments(P::PointBased, x::AbstractVector{<:Number}, y::AbstractVector{<:Interval}) =
+    convert_arguments(P, x, mean.(y))
+
+convert_arguments(P::PointBased, x::AbstractVector{<:Interval}, y::AbstractVector{<:Number}) =
+    convert_arguments(P, mean.(x), y)
+
+
 """
     convert_arguments(P, y)::Vector
 Takes vector `y` and generates a range from 1 to the length of `y`, for plotting on

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -4,7 +4,9 @@ using Makie:
     conversion_trait,
     convert_single_argument,
     to_vertices,
-    categorical_colors
+    categorical_colors,
+    PointBased,
+    (..)
 
 @testset "Conversions" begin
     # NoConversion
@@ -111,6 +113,17 @@ end
     mpol_emtpy = MultiPolygon(typeof(pol_emtpy)[])
     p_empty = convert_arguments(Makie.PointBased(), mpol_emtpy)
     @test p_empty[1] == pts_empty
+end
+
+@testset "intervals" begin
+    x = [1, 5, 10]
+    y = [1..2, 1..3, 2..3]
+    @test convert_arguments(PointBased(), x, y) == (Point2f.(x, [1.5, 2, 2.5]),)
+    @test convert_arguments(PointBased(), y, x) == (Point2f.([1.5, 2, 2.5], x),)
+    @test convert_arguments(Band, x, y) == (Point2f.([1, 5, 10], [1, 1, 2]), Point2f.([1, 5, 10], [2, 3, 3]))
+    @test convert_arguments(Rangebars, x, y) == (Vec3f.([1,5,10], [1,1,2], [2,3,3]),)
+    @test convert_arguments(HSpan, 1..2) == (1f0, 2f0)
+    @test convert_arguments(VSpan, 1..2) == (1f0, 2f0)
 end
 
 @testset "functions" begin

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -5,7 +5,6 @@ using Makie:
     convert_single_argument,
     to_vertices,
     categorical_colors,
-    PointBased,
     (..)
 
 @testset "Conversions" begin
@@ -118,8 +117,6 @@ end
 @testset "intervals" begin
     x = [1, 5, 10]
     y = [1..2, 1..3, 2..3]
-    @test convert_arguments(PointBased(), x, y) == (Point2f.(x, [1.5, 2, 2.5]),)
-    @test convert_arguments(PointBased(), y, x) == (Point2f.([1.5, 2, 2.5], x),)
     @test convert_arguments(Band, x, y) == (Point2f.([1, 5, 10], [1, 1, 2]), Point2f.([1, 5, 10], [2, 3, 3]))
     @test convert_arguments(Rangebars, x, y) == (Vec3f.([1,5,10], [1,1,2], [2,3,3]),)
     @test convert_arguments(HSpan, 1..2) == (1f0, 2f0)


### PR DESCRIPTION
# Description

Add a few natural recipes for intervals that make plotting them much more convenient.
Partially closes https://github.com/MakieOrg/Makie.jl/issues/1995.


Only implementation code for now. Should I create complete end-to-end tests with these arguments, or test the `convert_arguments` methods by themselves?

Examples:
![image](https://github.com/MakieOrg/Makie.jl/assets/687995/41a994c5-d548-4645-af6b-fa4e16db1c6f)
![image](https://github.com/MakieOrg/Makie.jl/assets/687995/439af477-aff4-4c62-abb2-39f68cf833e4)



## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.

