### PR TITLE
Unexport geometry types by default

### DIFF
--- a/CairoMakie/test/rasterization_tests.jl
+++ b/CairoMakie/test/rasterization_tests.jl
@@ -14,8 +14,8 @@ end
     fig = Figure()
     ax = Axis(fig[1,1])
     lp = lines!(ax, vcat(1:10, 10:-1:1))
-    pts = Makie.GeometryBasics.Point2f[(0,0), (1,0), (0,1)]
-    pl = poly!(ax, Makie.GeometryBasics.Polygon(pts))
+    pts = Makie.Geom.Point2f[(0,0), (1,0), (0,1)]
+    pl = poly!(ax, Makie.Geom.Polygon(pts))
 
     @testset "Unrasterized SVG" begin
         @test !svg_has_image(fig)

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -1,6 +1,7 @@
 using Test
 using CairoMakie
 using Makie.FileIO
+using Makie.Geom
 using ReferenceTests
 
 # Before changing Pkg environment, try the test in #864

--- a/CairoMakie/test/svg_tests.jl
+++ b/CairoMakie/test/svg_tests.jl
@@ -21,8 +21,8 @@ end
     @test svg_isnt_rasterized(begin
         fig = Figure()
         ax = Axis(fig[1,1])
-        poly!(ax, Makie.GeometryBasics.Polygon(Point2.([[0,0],[1,0],[0,1],[0,0]])), color = ("#FF0000", 0.7), label = "foo")
-        poly!(ax, Makie.GeometryBasics.Polygon(Point2.([[0,0],[1,0],[0,1],[0,0]])), color = (:blue, 0.7), label = "bar")
+        poly!(ax, Makie.Geom.Polygon(Point2.([[0,0],[1,0],[0,1],[0,0]])), color = ("#FF0000", 0.7), label = "foo")
+        poly!(ax, Makie.Geom.Polygon(Point2.([[0,0],[1,0],[0,1],[0,0]])), color = (:blue, 0.7), label = "bar")
         fig[1, 2] = Legend(fig, ax, "Bar")
         fig
     end)
@@ -32,10 +32,10 @@ end
     ])))
     @test !svg_isnt_rasterized(poly(rand(Point2f, 10); color = rand(RGBAf, 10)))
 
-    poly1 = Makie.GeometryBasics.Polygon(rand(Point2f, 10))
-    @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1])))
-    @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1]), color = :red))
-    @test svg_isnt_rasterized(poly(Makie.GeometryBasics.MultiPolygon([poly1, poly1]), color = [:red, :blue]))
+    poly1 = Makie.Geom.Polygon(rand(Point2f, 10))
+    @test svg_isnt_rasterized(poly(Makie.Geom.MultiPolygon([poly1, poly1])))
+    @test svg_isnt_rasterized(poly(Makie.Geom.MultiPolygon([poly1, poly1]), color = :red))
+    @test svg_isnt_rasterized(poly(Makie.Geom.MultiPolygon([poly1, poly1]), color = [:red, :blue]))
 
     @testset "GeoInterface polygons" begin
         using GeoInterface, GeoInterfaceMakie

--- a/GLMakie/experiments/shaderabstr.jl
+++ b/GLMakie/experiments/shaderabstr.jl
@@ -1,5 +1,7 @@
 using ShaderAbstractions: Buffer, Sampler, VertexArray
 
+using Makie.Geom
+
 # Mesh
 mesh(Sphere(Point3f(0), 1f0)) |> display
 mesh(Sphere(Point3f(0), 1f0), color=:red, ambient=Vec3f(0.9))

--- a/GLMakie/test/runtests.jl
+++ b/GLMakie/test/runtests.jl
@@ -1,7 +1,7 @@
 using Makie
 using GLMakie, Test
 using FileIO
-using GeometryBasics
+using Makie.Geom
 using GeometryBasics: origin
 using Random
 using ReferenceTests

--- a/RPRMakie/examples/makie_example.jl
+++ b/RPRMakie/examples/makie_example.jl
@@ -1,4 +1,4 @@
-using GeometryBasics, Makie
+using Makie, Makie.Geom
 using FileIO, Colors
 using RPRMakie
 RPRMakie.activate!(iterations=200)

--- a/RPRMakie/test/lines.jl
+++ b/RPRMakie/test/lines.jl
@@ -1,4 +1,5 @@
-using GLMakie, GeometryBasics, RPRMakie, RadeonProRender
+using GLMakie, RPRMakie, RadeonProRender
+using Makie.Geom
 using Colors, FileIO
 using Colors: N0f8
 RPR = RadeonProRender

--- a/ReferenceTests/src/tests/attributes.jl
+++ b/ReferenceTests/src/tests/attributes.jl
@@ -1,3 +1,5 @@
+using Makie.Geom
+
 @reference_test "glowcolor, glowwidth" begin
     scatter(RNG.randn(10), color=:blue, glowcolor=:orange, glowwidth=10)
 end

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1,3 +1,4 @@
+using Makie.Geom
 
 @reference_test "Test heatmap + image overlap" begin
     heatmap(RNG.rand(32, 32))

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -1,3 +1,4 @@
+using Makie.Geom
 
 @reference_test "Image on Geometry (Moon)" begin
     moon = loadasset("moon.png")

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -1,3 +1,5 @@
+using Makie.Geom
+
 @reference_test "lines and linestyles" begin
     # For now disabled until we fix GLMakie linestyle
     s = Scene(size = (800, 800), camera = campixel!)

--- a/ReferenceTests/src/tests/short_tests.jl
+++ b/ReferenceTests/src/tests/short_tests.jl
@@ -1,3 +1,5 @@
+using Makie.Geom
+
 @reference_test "thick arc" arc(Point2f(0), 10f0, 0f0, pi, linewidth=20)
 
 @reference_test "stroked rect poly" poly(Recti(0, 0, 200, 200), strokewidth=20, strokecolor=:red, color=(:black, 0.4))

--- a/ReferenceTests/src/tests/updating.jl
+++ b/ReferenceTests/src/tests/updating.jl
@@ -1,3 +1,5 @@
+using Makie.Geom
+
 @reference_test "updating 2d primitives" begin
     fig = Figure()
     t = Observable(1)

--- a/precompile/shared-precompile.jl
+++ b/precompile/shared-precompile.jl
@@ -1,5 +1,5 @@
 # File to run to snoop/trace all functions to compile
-using GeometryBasics
+using Makie.Geom
 
 @compile scatter(1:4; color=1:4, colormap=:turbo, markersize=20, visible=true)
 

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -23,7 +23,6 @@ using MathTeXEngine
 using Random
 using FFMPEG_jll # get FFMPEG on any system!
 using Observables
-using GeometryBasics
 using PlotUtils
 using ColorBrewer
 using ColorTypes
@@ -96,6 +95,40 @@ export @L_str, @colorant_str
 export ConversionTrait, NoConversion, PointBased, GridBased, VertexGrid, CellGrid, ImageLike, VolumeLike
 export Pixel, px, Unit, plotkey, attributes, used_attributes
 export Linestyle
+
+# Place geometry types in a dedicated module to
+# avoid namespace pollution and name conflicts
+# with other geometry/plotting packages
+"""
+    Makie.Geom
+    
+Module with all geometry types used internally by Makie, currently developed in
+[`GeometryBasics.jl`](https://github.com/JuliaGeometry/GeometryBasics.jl)
+
+Advanced users can load the module explicitly to get access to these geometries
+like in newer versions of Makie:
+
+```julia
+using Makie.Geom
+
+Point, Rect, Sphere
+```
+"""
+module Geom
+    using GeometryBasics
+    export Vec4f, Vec3f, Vec2f, Point4f, Point3f, Point2f
+    export Vec, Vec2, Vec3, Vec4, Point, Point2, Point3, Point4
+    export Rect, Rectf, Rect2f, Rect2i, Rect3f, Rect3i, Rect3, Recti, Rect2
+    export Sphere, Circle, Pyramid, Polygon
+    export Mesh
+end
+
+# Load GeometryBasics as a temporary workaround.
+# Ideally, Makie would only depend on the .Geom
+# module above, which encapsulates internal
+# geometries for developers
+using GeometryBasics
+# using .Geom
 
 const RealVector{T} = AbstractVector{T} where T <: Number
 const RGBAf = RGBA{Float32}
@@ -281,11 +314,7 @@ export NoShading, FastShading, MultiLightShading
 export Quaternion, Quaternionf, qrotation
 export RGBAf, RGBf, VecTypes, RealVector
 export Transformation
-export Sphere, Circle
-export Vec4f, Vec3f, Vec2f, Point4f, Point3f, Point2f
-export Vec, Vec2, Vec3, Vec4, Point, Point2, Point3, Point4
 export (..)
-export Rect, Rectf, Rect2f, Rect2i, Rect3f, Rect3i, Rect3, Recti, Rect2
 export widths, decompose
 
 # building blocks for series recipes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Makie.GeometryBasics
 using Makie.PlotUtils
 using Makie.FileIO
 using Makie.IntervalSets
-using GeometryBasics: Pyramid
+using Makie.Geom
 
 using Makie: volume
 


### PR DESCRIPTION
# Description

Fixes #3610 

This PR is a work in progress for assessment by the Makie team. The change consists in introducing a local module named `Geom` that users can import explicitly to get access to internal geometry types used by the project. The name `Geom` follows from the Gadfly.jl package, which handles geometries as `Gadfly.Geom.point` for example.

If the PR is welcome, we can continue working on it. All tests already pass because we are still loading GeometryBasics.jl explicitly as a temporary workaround. Hopefully one day, someone with more knowledge of the internals can refactor the codebase to really only depend on the `.Geom` module. This should also help in the future in case the internal geometry types need to be replaced.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
