### PR TITLE
If running under VSCode, automatically set `resize_to = :body`

### DIFF
--- a/WGLMakie/src/WGLMakie.jl
+++ b/WGLMakie/src/WGLMakie.jl
@@ -59,6 +59,12 @@ function activate!(; inline::Union{Automatic,Bool}=LAST_INLINE[], screen_config.
     Makie.inline!(inline)
     LAST_INLINE[] = inline
     Makie.set_active_backend!(WGLMakie)
+
+    # If we are inside of VSCode, default `resize_to` to `:body`
+    screen_config = Dict(screen_config...)
+    if !isempty(filter(m -> m.name == "VSCodeServer", keys(Base.loaded_modules)))
+        screen_config[:resize_to] = get(screen_config, :resize_to, :body)
+    end
     Makie.set_screen_config!(WGLMakie, screen_config)
     if !Bonito.has_html_display()
         Bonito.browser_display()


### PR DESCRIPTION
This gives a better default experience for users plotting inside of VSCode.  It detects the presence of VSCode by looking to see if `VSCodeServer` is in `Base.loaded_modules`, which it should never be unless we're running inside the language server.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)