### PR TITLE
Fix CairoMakie line color bug #3704

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## [Unreleased]
-- Added supported markers hint to unsupported marker warn message.
-
+- Added supported markers hint to unsupported marker warn message [#3666](https://github.com/MakieOrg/Makie.jl/pull/3666).
+- Fixed bug in CairoMakie line drawing when multiple successive points had the same color [#3712](https://github.com/MakieOrg/Makie.jl/pull/3712).
 - Remove StableHashTraits in favor of calculating hashes directly with CRC32c [#3667](https://github.com/MakieOrg/Makie.jl/pull/3667).
 
 ## [0.20.8] - 2024-02-22

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -257,6 +257,13 @@ function draw_multi(primitive::Lines, ctx, positions, colors::AbstractArray, lin
                 end
             else
                 prev_continued = false
+
+                # finish previous line segment
+                Cairo.set_line_width(ctx, prev_linewidth)
+                !isnothing(dash) && Cairo.set_dash(ctx, dash .* prev_linewidth)
+                Cairo.set_source_rgba(ctx, red(prev_color), green(prev_color), blue(prev_color), alpha(prev_color))
+                Cairo.stroke(ctx)
+
                 if !this_nan
                     this_linewidth != prev_linewidth && error("Encountered two different linewidth values $prev_linewidth and $this_linewidth in `lines` at index $(i-1). Different linewidths in one line are only permitted in CairoMakie when separated by a NaN point.")
                     # this is not nan

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -36,6 +36,10 @@ end
     s
 end
 
+@reference_test "lines issue #3704" begin
+    lines(1:10, sin, color = [fill(0, 9); fill(1, 1)], linewidth = 3, colormap = [:red, :cyan])
+end
+
 @reference_test "scatters" begin
     s = Scene(size = (800, 800), camera = campixel!)
 


### PR DESCRIPTION
Fix #3704, a logic bug for the case where a line contains the same color multiple times. In this case, the drawing should be delayed to have as few separate draw calls as possible, but of course the whole line should not be drawn with the following color gradient. Curious that this didn't come up earlier because it's very obviously wrong.

```julia
lines(1:10, sin, color = [fill(0, 9); fill(1, 1)], linewidth = 3, colormap = [:red, :cyan])
```

Before:

![image](https://github.com/MakieOrg/Makie.jl/assets/22495855/4402e8c7-7ee3-4ea3-ab0e-130ec28c83db)

After:

![image](https://github.com/MakieOrg/Makie.jl/assets/22495855/5af0d81f-5365-4bb5-97a7-0f19c9b9ded4)

