### PR TITLE
Fix contourf level calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added supported markers hint to unsupported marker warn message.
 
 - Remove StableHashTraits in favor of calculating hashes directly with CRC32c [#3667](https://github.com/MakieOrg/Makie.jl/pull/3667).
+- Fixed `contourf` bug where n levels would sometimes miss the uppermost value, causing gaps [#3713](https://github.com/MakieOrg/Makie.jl/pull/3713).
 
 ## [0.20.8] - 2024-02-22
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1392,3 +1392,15 @@ end
     ylims!(ax, 0, 1)
     fig
 end
+
+@reference_test "contourf bug #3683" begin
+    x = y = LinRange(0, 1, 4)
+    ymin, ymax = 0.4, 0.6
+    steepness = 0.1
+    f(x, y) = (tanh((y - ymin) / steepness) - tanh((y - ymax) / steepness) - 1)
+    z = [f(_x, _y) for _x in x, _y in y]
+
+    fig, ax, cof = contourf(x, y, z, levels = 2)
+    Colorbar(fig[1, 2], cof)
+    fig
+end

--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -48,7 +48,7 @@ end
 # _computed_extendlow
 # _computed_extendhigh
 
-_get_isoband_levels(levels::Int, mi, ma) = Float32.(LinRange(mi, ma, levels+1))
+_get_isoband_levels(levels::Int, mi, ma) = collect(range(Float32(mi), nextfloat(Float32(ma)), levels+1))
 
 function _get_isoband_levels(levels::AbstractVector{<:Real}, mi, ma)
     edges = Float32.(levels)
@@ -84,12 +84,12 @@ function Makie.plot!(c::Contourf{<:Tuple{<:AbstractVector{<:Real}, <:AbstractVec
     lowcolor = Observable{RGBAf}()
     map!(compute_lowcolor, c, lowcolor, c.extendlow, c.colormap)
     c.attributes[:_computed_extendlow] = lowcolor
-    is_extended_low = lift(!isnothing, c, lowcolor)
+    is_extended_low = lift(!isnothing, c, c.extendlow)
 
     highcolor = Observable{RGBAf}()
     map!(compute_highcolor, c, highcolor, c.extendhigh, c.colormap)
     c.attributes[:_computed_extendhigh] = highcolor
-    is_extended_high = lift(!isnothing, c, highcolor)
+    is_extended_high = lift(!isnothing, c, c.extendhigh)
     PolyType = typeof(Polygon(Point2f[], [Point2f[]]))
 
     polys = Observable(PolyType[])

--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -48,7 +48,7 @@ end
 # _computed_extendlow
 # _computed_extendhigh
 
-_get_isoband_levels(levels::Int, mi, ma) = collect(range(Float32(mi), nextfloat(Float32(ma)), levels+1))
+_get_isoband_levels(levels::Int, mi, ma) = collect(range(Float32(mi), nextfloat(Float32(ma)), length = levels+1))
 
 function _get_isoband_levels(levels::AbstractVector{<:Real}, mi, ma)
     edges = Float32.(levels)


### PR DESCRIPTION
- make upper band inclusive for n contourf limits
- add reftest

Isobands actually use an upper-exclusive interval:

https://github.com/r-lib/isoband/blob/f9cf8cea71741027ba137d7e2f9075a3680c59d9/vignettes/isoband2.Rmd#L101

So we need to push the upper boundary one float value higher when we pick n levels so all values are covered.

Fixes #3683

```julia
x = y = LinRange(0, 1, 4)
ymin, ymax = 0.4, 0.6
steepness = 0.1
f(x, y) = (tanh((y - ymin) / steepness) - tanh((y - ymax) / steepness) - 1)
z = [f(_x, _y) for _x in x, _y in y]

fig, ax, cof = contourf(x, y, z, levels = 2)
Colorbar(fig[1, 2], cof)
fig
```

Before:

<img width="518" alt="image" src="https://github.com/MakieOrg/Makie.jl/assets/22495855/fe824d21-db69-4e0c-b80e-52f72c6aff18">

After:

<img width="510" alt="image" src="https://github.com/MakieOrg/Makie.jl/assets/22495855/f214ace0-c338-40d7-b874-d8718e7dde6c">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
