### PR TITLE
Use label formatter in barplot.

### DIFF
--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -226,7 +226,7 @@ function barplot_labels(xpositions, ypositions, bar_labels, in_y_direction, flip
             attributes = text_attributes(ypositions, in_y_direction, flip_labels_at, color_over_background,
                                          color_over_bar, label_offset, label_rotation, label_align)
             label_pos = map(xpositions, ypositions, bar_labels) do x, y, l
-                return (string(l), in_y_direction ? Point2f(x, y) : Point2f(y, x))
+                return (label_formatter(l), in_y_direction ? Point2f(x, y) : Point2f(y, x))
             end
             return (label_pos, attributes...)
         else

--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -1,6 +1,6 @@
-function bar_label_formatter(value::Number)
-    return string(round(value; digits=3))
-end
+bar_label_formatter(value::Number) = string(round(value; digits=3))
+bar_label_formatter(label::String) = label
+bar_label_formatter(label::LaTeXString) = label
 
 """
     bar_default_fillto(tf, ys, offset)::(ys, offset)


### PR DESCRIPTION
# Description
Before, when the labels were not just the `:x` or `:y` symbols, the label formatter wasn't applied.
Now we apply it, but have to be careful to dispatch the default formatter depending on the input type.
In the PR I define new dispatches for `::String` and `::LaTeXString` types (basically the identity function), which should also fix the failing tests.

## Type of change
Basically just change a typo and add two dispatches.

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

Fixes #3720.