### PR TITLE
Fix transforming surface normals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fixed `contourf` bug where n levels would sometimes miss the uppermost value, causing gaps [#3713](https://github.com/MakieOrg/Makie.jl/pull/3713).
 - Added `scale` attribute to `violin` [#3352](https://github.com/MakieOrg/Makie.jl/pull/3352).
 - Use label formatter in barplot [#3718](https://github.com/MakieOrg/Makie.jl/pull/3718).
-- Fix the incorrect shading of markers' ellipsoid surfaces [#3722](https://github.com/MakieOrg/Makie.jl/pull/3722)
+- Fix the incorrect shading with non uniform markerscale in meshscatter [#3722](https://github.com/MakieOrg/Makie.jl/pull/3722)
 
 ## [0.20.8] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `contourf` bug where n levels would sometimes miss the uppermost value, causing gaps [#3713](https://github.com/MakieOrg/Makie.jl/pull/3713).
 - Added `scale` attribute to `violin` [#3352](https://github.com/MakieOrg/Makie.jl/pull/3352).
 - Use label formatter in barplot [#3718](https://github.com/MakieOrg/Makie.jl/pull/3718).
+- Fix the incorrect shading of markers' ellipsoid surfaces [#3722](https://github.com/MakieOrg/Makie.jl/pull/3722)
 
 ## [0.20.8] - 2024-02-22
 

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -932,7 +932,7 @@ function draw_mesh3D(
     projectionview = Makie.space_to_clip(scene.camera, space, true)
     eyeposition = scene.camera.eyeposition[]
     i = Vec(1, 2, 3)
-    normalmatrix = transpose(inv(model[i, i]))
+    normalmatrix = transpose(inv(model[i, i] * Diagonal(Vec3f(scale)))) # see issue #3702
 
     local_model = rotation * Makie.scalematrix(Vec3f(scale))
     # pass transform_func as argument to function, so that we get a function barrier

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -931,10 +931,11 @@ function draw_mesh3D(
     ctx = screen.context
     projectionview = Makie.space_to_clip(scene.camera, space, true)
     eyeposition = scene.camera.eyeposition[]
-    i = Vec(1, 2, 3)
 
+    i = Vec(1, 2, 3)
     local_model = rotation * Makie.scalematrix(Vec3f(scale))
-    normalmatrix = transpose(inv(model[i, i] * local_model[1:3, 1:3])) # see issue #3702
+    normalmatrix = transpose(inv(model[i, i] * local_model[i, i])) # see issue #3702
+
     # pass transform_func as argument to function, so that we get a function barrier
     # and have `transform_func` be fully typed inside closure
     vs = broadcast(meshpoints, (transform_func,)) do v, f

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -932,9 +932,9 @@ function draw_mesh3D(
     projectionview = Makie.space_to_clip(scene.camera, space, true)
     eyeposition = scene.camera.eyeposition[]
     i = Vec(1, 2, 3)
-    normalmatrix = transpose(inv(model[i, i] * Diagonal(Vec3f(scale)))) # see issue #3702
 
     local_model = rotation * Makie.scalematrix(Vec3f(scale))
+    normalmatrix = transpose(inv(model[i, i] * local_model[1:3, 1:3])) # see issue #3702
     # pass transform_func as argument to function, so that we get a function barrier
     # and have `transform_func` be fully typed inside closure
     vs = broadcast(meshpoints, (transform_func,)) do v, f

--- a/GLMakie/assets/shader/particles.vert
+++ b/GLMakie/assets/shader/particles.vert
@@ -100,7 +100,7 @@ void main(){
     o_id = uvec2(objectid, index+1);
     vec3 s = _scale(scale, index);
     vec3 V = vertices * s;
-    vec3 N = normals;
+    vec3 N = normals / s; // see issue #3702
     vec3 pos;
     {{position_calc}}
     o_color = get_particle_color(color, intensity, color_map, color_norm, index, len);

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -128,6 +128,13 @@ end
     scatter(RNG.rand(20), RNG.rand(20), markersize=RNG.rand(20) .* 20, color=colors)
 end
 
+@reference_test "Ellipsoid marker sizes" begin # see PR #3722
+    pts = Point3f[[0, 0, 0], [1, 0, 0]]
+    markersize = Vec3f[[0.5, 0.2, 0.5], [0.5, 0.2, 0.5]]
+    rotations = [qrotation(Vec3f(1, 0, 0), 0), qrotation(Vec3f(1, 1, 0), π / 4)]
+    meshscatter(pts; markersize, rotations, color=:white, diffuse=Vec3f(-2, 0, 4), specular=Vec3f(4, 0, -2))
+end
+
 @reference_test "Record Video" begin
     f(t, v, s) = (sin(v + t) * s, cos(v + t) * s, (cos(v + t) + sin(v)) * s)
     t = Observable(0.0) # create a life signal

--- a/WGLMakie/assets/particles.vert
+++ b/WGLMakie/assets/particles.vert
@@ -30,7 +30,7 @@ void main(){
     // get_* gets the global inputs (uniform, sampler, position array)
     // those functions will get inserted by the shader creation pipeline
     vec3 vertex_position = get_markersize() * to_vec3(get_position());
-    vec3 N = get_normals();
+    vec3 N = get_normals() / get_markersize(); // see issue #3702
     rotate(get_rotations(), vertex_position, N);
     vertex_position = to_vec3(get_offset()) + vertex_position;
     vec4 position_world = model * vec4(vertex_position, 1);


### PR DESCRIPTION
# Description

Fixes #3702

As discussed in issue #3702, under the guidance of @kbarros, we made changes that solve the incorrect shading of ellipsoid surfaces of markers under light, displaying spherical reflections (mathematical formulae stated in #3702). The following figures show examples before and after this change. Please note that we are not experts in the GLSL language, so you may want to double-check whether this change may break some code. If you need changes to other backends, I am happy to help.

Testing code snippet:

```julia
using CairoMakie
# using GLMakie
# using WGLMakie
pts = Point3f[[0,0,0], [1,0,0]]
markersize = Vec3f[[0.5, 0.2, 0.5], [0.5, 0.2, 0.5]]
rotations = [qrotation(Vec3f(1,0,0), 0), qrotation(Vec3f(1,1,0), π/4)]
meshscatter(pts; markersize, rotations, color=:yellow)
```

## CairoMakie

### Before

<img alt="cairomakie_before" src="https://github.com/MakieOrg/Makie.jl/assets/25192197/1c30cbb5-5187-41c6-b377-7d51a4f2fa73" width=50% height=50%>

### After

<img alt="cairomakie_after" src="https://github.com/MakieOrg/Makie.jl/assets/25192197/c04b8123-98aa-4a58-9574-58911091d388" width=50% height=50%>

## GLMakie

### Before

<img alt="glmakie_before" src="https://github.com/MakieOrg/Makie.jl/assets/25192197/57ad138e-77ec-4f5e-a670-401452fd6a43" width=50% height=50%>

### After

<img alt="glmakie_after" src="https://github.com/MakieOrg/Makie.jl/assets/25192197/3cd2594c-f8f8-4698-8095-f2ff9fc33427" width=50% height=50%>

## WGLMakie

### Before

<img alt="wglmakie_before" src="https://github.com/MakieOrg/Makie.jl/assets/25192197/c7159425-1fea-4678-82b5-a802fcd1e3a6" width=50% height=50%>

### After

<img alt="wglmakie_after" src="https://github.com/MakieOrg/Makie.jl/assets/25192197/f5b6cf6b-a9a9-41f0-9c5f-1b3b779a485c" width=50% height=50%>

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
