### PR TITLE
Change how boundingbox(::Text) is deprecated

### DIFF
--- a/src/basic_recipes/barplot.jl
+++ b/src/basic_recipes/barplot.jl
@@ -227,8 +227,6 @@ function barplot_labels(xpositions, ypositions, bar_labels, in_y_direction, flip
             label_pos = map(xpositions, ypositions, bar_labels) do x, y, l
                 return (string(l), in_y_direction ? Point2d(x, y) : Point2d(y, x))
             end
-            @info xpositions, ypositions
-            @info label_pos
             return (label_pos, attributes...)
         else
             error("Labels and bars need to have same length. Found: $(length(xpositions)) bars with these labels: $(bar_labels)")

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -139,7 +139,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     bbox = map(
             p, px_pos, p.text, text_align, text_offset, textpadding, p.align
         ) do p, s, _, o, pad, align
-        bb = text_boundingbox(tp) + to_ndim(Vec3f, o, 0)
+        bb = boundingbox(tp, :pixel) + to_ndim(Vec3f, o, 0)
         l, r, b, t = pad
         return Rect3f(origin(bb) .- (l, b, 0), widths(bb) .+ (l+r, b+t, 0))
     end

--- a/src/layouting/text_boundingbox.jl
+++ b/src/layouting/text_boundingbox.jl
@@ -1,19 +1,33 @@
-function boundingbox(plot::Text)
-    @warn """
-    `boundingbox(::Text)` has been deprecated in favor of `Makie.text_boundingbox(::Text)`.
-    In the future `boundingbox(::Text)` will be adjusted to match the other
-    `boundingbox(plot)` functions. The new functionality is currently available
-    as `Makie._boundingbox(plot::Text)`.
-    """
-    Base.show_backtrace(stderr, backtrace())
-    return text_boundingbox(plot)
+@deprecate boundingbox(plot::Text) boundingbox(plot, plot.markerspace[])
+
+function boundingbox(plot::Text, target_space::Symbol)
+    # TODO:
+    # This is temporary prep work for the future. We should actually consider
+    # plot.space, markerspace, textsize, etc when computing the boundingbox in
+    # the target_space given to the function.
+    # We may also want a cheap version that only considers forward
+    # transformations (i.e. drops textsize etc when markerspace is not part of
+    # the plot.space -> target_space conversion chain)
+    if target_space == :world
+        if plot.space[] == plot.markerspace[]
+            # probably shouldn't transform...
+            return transform_bbox(plot, string_boundingbox(plot))
+        else
+            return Rect3d(iterate_transformed(plot))
+        end
+    elseif target_space == plot.markerspace[]
+        return string_boundingbox(plot)
+    else
+        error("$target_space must be either :world or markerspace = $(plot.markerspace[])")
+    end
 end
 
+
 # TODO: Naming: not px, it's whatever markerspace is...
-function text_boundingbox(plot::Text)
+function string_boundingbox(plot::Text)
     bb = Rect3d()
     for p in plot.plots
-        _bb = text_boundingbox(p)
+        _bb = string_boundingbox(p)
         if !isfinite_rect(bb)
             bb = _bb
         elseif isfinite_rect(_bb)
@@ -25,9 +39,9 @@ end
 
 # Text can contain linesegments. Use data_limits to avoid transformations as
 # they are already in markerspace
-text_boundingbox(x::LineSegments) = data_limits(x)
+string_boundingbox(x::LineSegments) = data_limits(x)
 
-function text_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
+function string_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
     if x.space[] == x.markerspace[]
         pos = to_ndim(Point3d, x.position[], 0)
     else
@@ -35,10 +49,10 @@ function text_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
         transformed = apply_transform(x.transformation.transform_func[], x.position[])
         pos = Makie.project(cam, x.space[], x.markerspace[], transformed)
     end
-    return text_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+    return string_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
 end
 
-function text_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
+function string_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
     if x.space[] == x.markerspace[]
         pos = to_ndim.(Point3d, x.position[], 0)
     else
@@ -46,10 +60,10 @@ function text_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
         transformed = apply_transform(x.transformation.transform_func[], x.position[])
         pos = Makie.project.(cam, x.space[], x.markerspace[], transformed) # TODO: vectorized project
     end
-    return text_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
+    return string_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
 end
 
-function text_boundingbox(x::Union{GlyphCollection,AbstractArray{<:GlyphCollection}}, args...)
+function string_boundingbox(x::Union{GlyphCollection,AbstractArray{<:GlyphCollection}}, args...)
     bb = unchecked_boundingbox(x, args...)
     isfinite_rect(bb) || error("Invalid text boundingbox")
     return bb
@@ -62,7 +76,7 @@ function text_bb(str, font, size)
     layout = layout_text(
         str, size, font, fonts, Vec2f(0), rot, 0.5, 1.0,
         RGBAf(0, 0, 0, 0), RGBAf(0, 0, 0, 0), 0f0, 0f0)
-    return text_boundingbox(layout, Point3d(0), rot)
+    return string_boundingbox(layout, Point3d(0), rot)
 end
 
 
@@ -96,9 +110,9 @@ function unchecked_boundingbox(layouts::AbstractArray{<:GlyphCollection}, positi
     bb = Rect3d()
     broadcast_foreach(layouts, positions, rotations) do layout, pos, rot
         if !isfinite_rect(bb)
-            bb = text_boundingbox(layout, pos, rot)
+            bb = string_boundingbox(layout, pos, rot)
         else
-            bb = union(bb, text_boundingbox(layout, pos, rot))
+            bb = union(bb, string_boundingbox(layout, pos, rot))
         end
     end
     return bb

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -110,7 +110,7 @@ function calculate_title_position(area, titlegap, subtitlegap, align, xaxisposit
     end
 
     local subtitlespace::Float32 = if ax.subtitlevisible[] && !iswhitespace(ax.subtitle[])
-        text_boundingbox(subtitlet).widths[2] + subtitlegap
+        boundingbox(subtitlet, :data).widths[2] + subtitlegap
     else
         0f0
     end
@@ -135,8 +135,8 @@ function compute_protrusions(title, titlesize, titlegap, titlevisible, spinewidt
         top = xaxisprotrusion
     end
 
-    titleheight = text_boundingbox(titlet).widths[2] + titlegap
-    subtitleheight = text_boundingbox(subtitlet).widths[2] + subtitlegap
+    titleheight = boundingbox(titlet, :data).widths[2] + titlegap
+    subtitleheight = boundingbox(subtitlet, :data).widths[2] + subtitlegap
 
     titlespace = if !titlevisible || iswhitespace(title)
         0f0

--- a/src/makielayout/blocks/button.jl
+++ b/src/makielayout/blocks/button.jl
@@ -40,7 +40,7 @@ function initialize_block!(b::Button)
     translate!(labeltext, 0, 0, 1)
 
     onany(scene, b.label, b.fontsize, b.font, b.padding) do label, fontsize, font, padding
-        textbb = Rect2f(text_boundingbox(labeltext))
+        textbb = Rect2f(boundingbox(labeltext, :data))
         autowidth = width(textbb) + padding[1] + padding[2]
         autoheight = height(textbb) + padding[3] + padding[4]
         b.layoutobservables.autosize[] = (autowidth, autoheight)

--- a/src/makielayout/blocks/label.jl
+++ b/src/makielayout/blocks/label.jl
@@ -18,7 +18,7 @@ function initialize_block!(l::Label)
 
     onany(topscene, l.text, l.fontsize, l.font, l.rotation, word_wrap_width,
           l.padding) do _, _, _, _, _, padding
-        textbb[] = Rect2f(text_boundingbox(t))
+        textbb[] = Rect2f(boundingbox(t, :data))
         autowidth = width(textbb[]) + padding[1] + padding[2]
         autoheight = height(textbb[]) + padding[3] + padding[4]
         if l.word_wrap[]

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -118,7 +118,7 @@ function initialize_block!(m::Menu; default = 1)
     )
 
     onany(blockscene, selected_text, m.fontsize, m.textpadding) do _, _, (l, r, b, t)
-        bb = text_boundingbox(selectiontext)
+        bb = boundingbox(selectiontext, :data)
         m.layoutobservables.autosize[] = width(bb) + l + r, height(bb) + b + t
     end
     notify(selected_text)
@@ -162,7 +162,7 @@ function initialize_block!(m::Menu; default = 1)
 
     onany(blockscene, optionstrings, m.textpadding, m.layoutobservables.computedbbox) do _, pad, bbox
         gcs = optiontexts.plots[1][1][]::Vector{GlyphCollection}
-        bbs = map(x -> text_boundingbox(x, zero(Point3f), Quaternion(0, 0, 0, 0)), gcs)
+        bbs = map(x -> string_boundingbox(x, zero(Point3f), Quaternion(0, 0, 0, 0)), gcs)
         heights = map(bb -> height(bb) + pad[3] + pad[4], bbs)
         heights_cumsum = [zero(eltype(heights)); cumsum(heights)]
         h = sum(heights)

--- a/src/makielayout/blocks/polaraxis.jl
+++ b/src/makielayout/blocks/polaraxis.jl
@@ -60,11 +60,11 @@ function initialize_block!(po::PolarAxis; palette=nothing)
         # (each boundingbox represents a string without text.position applied)
         max_widths = Vec2f(0)
         for gc in thetaticklabelplot.plots[1].plots[1][1][]
-            bbox = text_boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
+            bbox = string_boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
             max_widths = max.(max_widths, widths(bbox)[Vec(1,2)])
         end
         for gc in rticklabelplot.plots[1].plots[1][1][]
-            bbox = text_boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
+            bbox = string_boundingbox(gc, Quaternionf(0, 0, 0, 1)) # no rotation
             max_widths = max.(max_widths, widths(bbox)[Vec(1,2)])
         end
 

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -37,7 +37,7 @@ function calculate_protrusion(
     real_labelsize::Float32 = if label_is_empty
         0f0
     else
-        text_boundingbox(labeltext).widths[horizontal[] ? 2 : 1]
+        boundingbox(labeltext, :pixel).widths[horizontal[] ? 2 : 1]
     end
 
     labelspace::Float32 = (labelvisible && !label_is_empty) ? real_labelsize + labelpadding : 0f0
@@ -300,10 +300,10 @@ function LineAxis(parent::Scene, attrs::Attributes)
     map!(parent, ticklabel_ideal_space, ticklabel_annotation_obs, ticklabelalign, ticklabelrotation, ticklabelfont, ticklabelsvisible) do args...
         maxwidth = if pos_extents_horizontal[][3]
                 # height
-                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : height(Rect2f(text_boundingbox(ticklabels)))) : 0f0
+                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : height(Rect2f(boundingbox(ticklabels, :data)))) : 0f0
             else
                 # width
-                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : width(Rect2f(text_boundingbox(ticklabels)))) : 0f0
+                ticklabelsvisible[] ? (ticklabels === nothing ? 0f0 : width(Rect2f(boundingbox(ticklabels, :data)))) : 0f0
         end
         # in case there is no string in the annotations and the boundingbox comes back all NaN
         if !isfinite(maxwidth)
@@ -401,7 +401,7 @@ function LineAxis(parent::Scene, attrs::Attributes)
         xs::Float32, ys::Float32 = if labelrotation isa Automatic
             0f0, 0f0
         else
-            wx, wy = widths(text_boundingbox(labeltext))
+            wx, wy = widths(boundingbox(labeltext, :data))
             sign::Int = flipped ? 1 : -1
             if horizontal
                 0f0, Float32(sign * 0.5f0 * wy)
@@ -519,10 +519,10 @@ function tight_ticklabel_spacing!(la::LineAxis)
     tls = la.elements[:ticklabels]
     maxwidth = if horizontal
             # height
-            tls.visible[] ? height(Rect2f(text_boundingbox(tls))) : 0f0
+            tls.visible[] ? height(Rect2f(boundingbox(tls, :data))) : 0f0
         else
             # width
-            tls.visible[] ? width(Rect2f(text_boundingbox(tls))) : 0f0
+            tls.visible[] ? width(Rect2f(boundingbox(tls, :data))) : 0f0
     end
     la.attributes.ticklabelspace = maxwidth
     return Float64(maxwidth)

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -96,10 +96,10 @@ end
     fig = Figure(size = (400, 400))
     ax = Axis(fig[1, 1])
     p = text!(ax, Point2f(10), text = "test", fontsize = 20)
-    bb = Makie.text_boundingbox(p)
+    bb = boundingbox(p, :pixel)
     @test bb.origin ≈ Point3f(343.0, 345.0, 0)
     @test bb.widths ≈ Vec3f(32.24, 23.3, 0)
-    bb = Makie._boundingbox(p)
+    bb = boundingbox(p, :world)
     @test bb.origin ≈ Point3f(10, 10, 0)
     @test bb.widths ≈ Vec3f(0)
 end


### PR DESCRIPTION
Adjusts the `boundingbox(p::Text)` deprecation to `@deprecate boundingbox(p) boundingbox(p, p.markerspace[])`, renames `text_boundingbox()` to `string_boundingbox()` (partially to find calls that need to be updated) and cleans up some of roundabout boundingbox logic used for old deprecation
