### PR TITLE
Fix texture atlas updates in WGLMakie

### DIFF
--- a/WGLMakie/src/WGLMakie.jl
+++ b/WGLMakie/src/WGLMakie.jl
@@ -80,7 +80,7 @@ function __init__()
     atlas = wgl_texture_atlas()
     TEXTURE_ATLAS[] = convert(Vector{Float32}, vec(atlas.data))
     Makie.font_render_callback!(atlas) do sd, uv
-        TEXTURE_ATLAS[] = convert(Vector{Float32}, vec(wgl_texture_atlas().data))
+        TEXTURE_ATLAS[] = convert(Vector{Float32}, vec(sd))
     end
     DISABLE_JS_FINALZING[] = false
     return

--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -181,7 +181,8 @@ function scatter_shader(scene::Scene, attributes, plot)
 
     if uniform_dict[:shape_type][] == 3
         atlas = wgl_texture_atlas()
-        uniform_dict[:distancefield] = NoDataTextureAtlas(size(atlas.data))
+        # uniform_dict[:distancefield] = NoDataTextureAtlas(size(atlas.data))
+        uniform_dict[:distancefield] = Sampler(map(x -> wgl_texture_atlas().data, TEXTURE_ATLAS))
         uniform_dict[:atlas_texture_size] = Float32(size(atlas.data, 1)) # Texture must be quadratic
     else
         uniform_dict[:atlas_texture_size] = 0f0


### PR DESCRIPTION
# Description

Fixes #3232

The centralized texture atlas that WGLMakie uses doesn't forward updates to js. Not on observable updates, not on plot insertion and not on scene insertion.

```julia
using WGLMakie
f, a, p = text("test!") # ! shows up. I assume it's inserted before the js side gets initialized

p[1][] = "test!?°ħ▒-" # ?°ħ▒ do not show up
text!(a, Point2f(0.1), text = "test") # adding plot doesn't update js texture atlas
Label(current_figure()[1, 2], "waa") # scene insertion doesn't either
```

As a test I switched to handling the texture atlas per plot like a normal texture. That fixes the issue. We should fix this by making the centralized texture atlas update though, to avoid creating duplicates for every text and most scatter plots.

I have no knowledge of Bonito but I assume this is wrong:

https://github.com/MakieOrg/Makie.jl/blob/d50dad0a2340c24b84ffce172037bf615506f3d3/WGLMakie/src/three_plot.jl#L41

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
