### PR TITLE
[Docs] add wrap/redirect recipe tutorial

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -58,6 +58,19 @@
     @@
     ~~~</a>~~~
   @@
+  @@box
+    ~~~<a class="boxlink" href="wrap-existing-recipe/">~~~
+    @@title Wrapping Recipe Tutorial @@
+    @@box-content
+      @@description
+      How to reuse existing recipes in non-trivial ways.
+      @@
+      ~~~
+      <img src="/assets/tutorials/wrap-existing-recipe/code/output/final_result.png">
+      ~~~
+    @@
+    ~~~</a>~~~
+  @@
 @@
 
 ## Videos

--- a/docs/tutorials/wrap-existing-recipe.md
+++ b/docs/tutorials/wrap-existing-recipe.md
@@ -69,8 +69,8 @@ hist(h; color=:red, direction=:x)
 \end{examplefigure}
 
 This almost works, but we see that the keyword arguments are not passed to the `barplot!` function.
-To handle these attributes properly, we need to override/merge the user-passed attributes with the
-default attributes of the underlying plot type (in this case, `BarPlot`):
+To handle these attributes properly, we need to override/merge the
+default attributes of the underlying plot type (in this case, `BarPlot`) with the user-passed attributes:
 
 \begin{examplefigure}{name = "final_result"}
 ```julia

--- a/docs/tutorials/wrap-existing-recipe.md
+++ b/docs/tutorials/wrap-existing-recipe.md
@@ -57,7 +57,7 @@ data as input, but we already have the binned data in our `MyHist` type.
 
 The first thing one might try is to override the `plot!` method for `Hist` recipe:
 
-\begin{examplefigure}
+\begin{examplefigure}{svg}
 ```julia
 function Makie.plot!(plot::Hist{<:Tuple{<:MyHist}})
     barplot!(plot, plot[1])

--- a/docs/tutorials/wrap-existing-recipe.md
+++ b/docs/tutorials/wrap-existing-recipe.md
@@ -1,0 +1,89 @@
+@def description = "Learn how to extend existing plot types on user-defined data types."
+
+# Wrap Existing Recipe on New Types
+
+## Introduction
+
+There are multiple ways one can extend the functionalities of Makie, for example, user can define a
+totally new plot type from scratch. Another common use case is to "teach" Makie how to draw
+user-defined data structure for different existing recipes.
+
+In this tutorial, we will show you how to teach Makie to plot our custom data type `MyHist` that is
+a simplified histogram type.
+
+To define recipes, one only needs to use `MakieCore.jl`, this is especially handy when you're a package
+developer and want to avoid depend on the full Makie.jl. For demonstration purpose, this tutorial
+will use `CairoMakie.jl` to visualize things as we go.
+
+```julia:setup
+using MakieCore, CairoMakie
+CairoMakie.activate!() # hide
+
+struct MyHist
+    bincounts
+    bincenters
+end
+
+nothing # hide
+```
+
+Our target type is the `MyHist`, which has two fields, as defined above. Roughly speaking, when we
+plot a histograms, we're talking about drawing a bar plot, where `barcenters` tells us where to draw
+these bars and `barcounts` tells us how high each bar is.
+
+## BarPlot recipe -- extend `Makie.convert_arguments`
+
+The first recipe we want to teach Makie to draw is `BarPlot()`. As we allured to before, the two
+fields we have in the `MyHist` type basically tell us how to draw it as a BarPlot. Makie exposes the
+following method for this type of customization:
+
+```julia:setup
+Makie.convert_arguments(P::Type{<:BarPlot}, h::MyHist) = convert_arguments(P, h.bincenters, h.bincounts)
+```
+
+\begin{examplefigure}
+```julia
+h = MyHist([1, 10, 100], 1:3)
+
+barplot(h)
+```
+\end{examplefigure}
+
+## Hist recipe -- override `Makie.plot!`
+
+The second recipe we want to customize for our `MyHist` type is the `Hist()` recipe. This cannot be
+achieved by `convert_arguments` as we did for `BarPlot()`, because normally `Makie.hist()` takes raw
+data as input, but we already have the binned data in our `MyHist` type.
+
+The first thing one might try is to override the `plot!` method for `Hist` recipe:
+
+\begin{examplefigure}
+```julia
+function Makie.plot!(plot::Hist{<:Tuple{<:MyHist}})
+    barplot!(plot, plot[1])
+    plot
+end
+h = MyHist([1, 10, 100], 1:3)
+hist(h; color=:red, direction=:x)
+```
+\end{examplefigure}
+
+This almost works, but we see that the keyword arguments are not passed to the `barplot!` function.
+To handle these attributes properly, we need to override/merge the user-passed attributes with the
+default attributes of the underlying plot type (in this case, `BarPlot`):
+
+\begin{examplefigure}{name = "final_result"}
+```julia
+function Makie.plot!(plot::Hist{<:Tuple{<:MyHist}})
+    scene = Makie.parent_scene(plot)
+    attributes = Makie.default_theme(scene, Makie.BarPlot)
+    for key in keys(attributes)
+        attributes[key] = get(plot.attributes, key, attributes[key])
+    end
+    barplot!(plot, attributes, plot[1])
+    plot
+end
+h = MyHist([1, 10, 100], 1:3)
+hist(h; color=:red, direction=:x)
+```
+\end{examplefigure}

--- a/docs/tutorials/wrap-existing-recipe.md
+++ b/docs/tutorials/wrap-existing-recipe.md
@@ -70,17 +70,13 @@ hist(h; color=:red, direction=:x)
 
 This almost works, but we see that the keyword arguments are not passed to the `barplot!` function.
 To handle these attributes properly, we need to override/merge the
-default attributes of the underlying plot type (in this case, `BarPlot`) with the user-passed attributes:
+default attributes of the underlying plot type (in this case, `BarPlot`) with the user-passed attributes, since Makie 0.21, it is handled automatically:
 
 \begin{examplefigure}{name = "final_result"}
 ```julia
 function Makie.plot!(plot::Hist{<:Tuple{<:MyHist}})
     scene = Makie.parent_scene(plot)
-    attributes = Makie.default_theme(scene, Makie.BarPlot)
-    for key in keys(attributes)
-        attributes[key] = get(plot.attributes, key, attributes[key])
-    end
-    barplot!(plot, attributes, plot[1])
+    barplot!(plot, plot.attributes, plot[1])
     plot
 end
 h = MyHist([1, 10, 100], 1:3)


### PR DESCRIPTION
# Description
Adding a new tutorial, as discussed in https://discourse.julialang.org/t/redirect-a-plot-type-in-makie-while-keeping-color-consistent/111975 with @asinghvi17  


## Type of change

Delete options that do not apply:

- [x] Documentation

## Checklist

- [x] Added or changed relevant sections in the documentation
