### PR TITLE
Add `__wgl_session` to the WGLMakie ignore set when generating uniforms

### DIFF
--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -40,7 +40,7 @@ const IGNORE_KEYS = Set([
     :visible, :transformation, :alpha, :linewidth, :transparency, :marker,
     :light_direction, :light_color,
     :cycle, :label, :inspector_clear, :inspector_hover,
-    :inspector_label, :axis_cycler
+    :inspector_label, :axis_cycler, :__wgl_session,
 ])
 
 function create_shader(scene::Scene, plot::MeshScatter)


### PR DESCRIPTION
The inclusion of this attribute caused the Bonito session to be passed as a uniform, causing an error in ShaderAbstractions when it tried to test for `isbits` code.

Fixes #3751

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
