### PR TITLE
Clarify that behavior of markersize defines the size in one dimension.

### DIFF
--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -383,7 +383,7 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
   Otherwise, one can set one color per point by passing a `Vector{<:Colorant}`, or one colorant for the whole scatterplot. If color is a vector of numbers, the colormap args are used to map the numbers to colors.
 - `cycle::Vector{Symbol} = [:color]` sets which attributes to cycle when creating multiple plots.
 - `marker::Union{Symbol, Char, Matrix{<:Colorant}, BezierPath, Polygon}` sets the scatter marker.
-- `markersize::Union{<:Real, Vec2f} = 9` sets the size of the marker.
+- `markersize::Union{<:Real, Vec2f} = 9` sets the size of the marker (twice the `markersize` is approximately four times as large).
 - `markerspace::Symbol = :pixel` sets the space in which `markersize` is given. See `Makie.spaces()` for possible inputs.
 - `strokewidth::Real = 0` sets the width of the outline around a marker.
 - `strokecolor::Union{Symbol, <:Colorant} = :black` sets the color of the outline around a marker.

--- a/docs/reference/plots/scatter.md
+++ b/docs/reference/plots/scatter.md
@@ -109,8 +109,10 @@ f
 
 #### Markersize
 
-The `markersize` attribute scales the scatter size relative to the scatter marker's base size.
-Therefore, `markersize` cannot be directly understood in terms of a unit like `px`, it depends on _what_ is scaled.
+The `markersize` attribute scales the scatter size relative to the scatter marker's base size along one of its dimensions. Two things to note as a result:
+
+1. `markersize` cannot be directly understood in terms of a unit like `px`, it depends on _what_ is scaled.
+2. A `markersize` of, e.g. `20` will appear to have roughly four times as much area as a markersize of `10` (since the `20` will be twice as large as `10` in two dimensions).
 
 For `Char` markers, `markersize` is equivalent to the font size when displaying the same characters using `text`.
 


### PR DESCRIPTION
# Description

Fixes # (issue)

The existing docs were not clear to me how `markersize` behaved - i.e. if I doubled the size `x` would I get something akin to `x^2` times larger? Based on experimentation, I think that's true and I tried to make the docs unambiguous and concise (but would be happy to take suggested changes). 

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
