### PR TITLE
Fix docstring typos

### DIFF
--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -181,7 +181,7 @@ end
 
 * categorical: there are n categories, and n colors are assigned to each category
 * banded: there are ranges edge_start..edge_end, inside which values are mapped to one color
-* continous: colors are mapped continuously to values
+* continuous: colors are mapped continuously to values
 """
 @enum ColorMappingType categorical banded continuous
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -447,7 +447,7 @@ end
 """
     convert_arguments(P, Matrix)::Tuple{ClosedInterval, ClosedInterval, ClosedInterval, Matrix}
 
-Takes an array of `{T, 3} where T`, converts the dimesions `n`, `m` and `k` into `ClosedInterval`,
+Takes an array of `{T, 3} where T`, converts the dimensions `n`, `m` and `k` into `ClosedInterval`,
 and stores the `ClosedInterval` to `n`, `m` and `k`, plus the original array in a Tuple.
 
 `P` is the plot Type (it is optional).
@@ -709,7 +709,7 @@ end
 to_linspace(interval, N) = range(minimum(interval), stop = maximum(interval), length = N)
 
 """
-Converts the elemen array type to `T1` without making a copy if the element type matches
+Converts the element array type to `T1` without making a copy if the element type matches
 """
 elconvert(::Type{T1}, x::AbstractArray{T2, N}) where {T1, T2, N} = convert(AbstractArray{T1, N}, x)
 float32type(x::Type) = Float32
@@ -766,7 +766,7 @@ Converts a representation of vertices `v` to its canonical representation as a
 
 - An `AbstractVector` of 3-element `Tuple`s or `StaticVector`s,
 
-- An `AbstractVector` of `Tuple`s or `StaticVector`s, in which case exta dimensions will
+- An `AbstractVector` of `Tuple`s or `StaticVector`s, in which case extra dimensions will
   be either truncated or padded with zeros as required,
 
 - An `AbstractMatrix`"
@@ -1634,13 +1634,13 @@ Use
 scatter(..., marker=FastPixel())
 ```
 
-For significant faster plotting times for large amount of points.
+For significantly faster plotting times for large amount of points.
 Note, that this will draw markers always as 1 pixel.
 """
 struct FastPixel end
 
 """
-Vector of anything that is accepted as a single marker will give each point it's own marker.
+Vector of anything that is accepted as a single marker will give each point its own marker.
 Note that it needs to be a uniform vector with the same element type!
 """
 to_spritemarker(marker::AbstractVector) = map(to_spritemarker, marker)

--- a/src/display.jl
+++ b/src/display.jl
@@ -122,7 +122,7 @@ end
 
 Displays the figurelike in a window or the browser, depending on the backend.
 
-The parameters for `screen_config` are backend dependend,
+The parameters for `screen_config` are backend dependent,
 see `?Backend.Screen` or `Base.doc(Backend.Screen)` for applicable options.
 
 `backend` accepts Makie backend modules, e.g.: `backend = GLMakie`, `backend = CairoMakie`, etc.
@@ -451,7 +451,7 @@ or RGBA.
 - `format = JuliaNative` : Returns a buffer in the format of standard julia images (dims permuted and one reversed)
 - `format = GLNative` : Returns a more efficient format buffer for GLMakie which can be directly
                         used in FFMPEG without conversion
-- `screen_config`: Backend dependend, look up via `?Backend.Screen`/`Base.doc(Backend.Screen)`
+- `screen_config`: Backend dependent, look up via `?Backend.Screen`/`Base.doc(Backend.Screen)`
 - `update=true`: resets/updates limits. Set to false, if you want to preserver camera movements.
 """
 function colorbuffer(fig::FigureLike, format::ImageStorageFormat = JuliaNative; update=true, backend = current_backend(), screen_config...)

--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -1,7 +1,7 @@
 # TODO move to something like FFMPEGUtil.jl ?
 
 """
-- `format = "mkv"`: The format of the video. If a path is present, will be inferred form the file extension.
+- `format = "mkv"`: The format of the video. If a path is present, will be inferred from the file extension.
     Can be one of the following:
     * `"mkv"`  (open standard, the default)
     * `"mp4"`  (good for Web, most supported format)
@@ -13,7 +13,7 @@
     as a last resort, for playing in a context where videos aren't supported.
 - `framerate = 24`: The target framerate.
 - `compression = 20`: Controls the video compression via `ffmpeg`'s `-crf` option, with
-    smaller numbers giving higher quality and larger file sizes (lower compression), and and
+    smaller numbers giving higher quality and larger file sizes (lower compression), and
     higher numbers giving lower quality and smaller file sizes (higher compression). The
     minimum value is `0` (lossless encoding).
     - For `mp4`, `51` is the maximum. Note that `compression = 0` only works with `mp4` if

--- a/src/figureplotting.jl
+++ b/src/figureplotting.jl
@@ -266,7 +266,7 @@ end
         end
         if args[1] isa AxisPlot
             throw(ArgumentError("""
-            Tried plotting with `$(F)!` into a `AxisPlot` object, this is not allowed.
+            Tried plotting with `$(F)!` into an `AxisPlot` object, this is not allowed.
 
             The `AxisPlot` object is returned by plotting functions not ending in `!` with
             a `GridPosition` as the first argument, like `lines(fig[1, 2], ...)` or `scatter(fig[1, 2], ...)`.

--- a/src/lighting.jl
+++ b/src/lighting.jl
@@ -149,7 +149,7 @@ end
     RectLight(color, center::Point3f, b1::Vec3f, b2::Vec3f[, direction = -normal])
 
 Creates a RectLight with a given color. The first constructor derives the light
-from a `Rect2` extending in x and y direction. The second specifies the `center`
+from a `Rect2` extending in x and y directions. The second specifies the `center`
 of the rect (or more accurately parallelogram) with `b1` and `b2` specifying the
 width and height vectors (including scale).
 

--- a/src/shorthands.jl
+++ b/src/shorthands.jl
@@ -54,7 +54,7 @@ end
 """
     ticklabels(scene)
 
-Returns the all the axis tick labels.
+Returns all the axis tick labels.
 """
 function ticklabels(scene)
     axis = scene[OldAxis]
@@ -65,21 +65,21 @@ end
 """
     xticklabels(scene)
 
-Returns the all the x-axis tick labels. See also `ticklabels`.
+Returns all the x-axis tick labels. See also `ticklabels`.
 """
 xticklabels(scene) = ticklabels(scene)[1]
 
 """
     yticklabels(scene)
 
-Returns the all the y-axis tick labels. See also `ticklabels`.
+Returns all the y-axis tick labels. See also `ticklabels`.
 """
 yticklabels(scene) = ticklabels(scene)[2]
 
 """
     zticklabels(scene)
 
-Returns the all the z-axis tick labels. See also `ticklabels`.
+Returns all the z-axis tick labels. See also `ticklabels`.
 """
 function zticklabels(scene)
     @assert !is2d(scene)  "The Scene does not have a z-axis!"
@@ -141,7 +141,7 @@ end
 """
     xticks!([scene,]; xtickrange=xtickrange(scene), xticklabels=xticklabel(scene))
 
-Set the tick labels and range along the x-axes. See also `ticks!`.
+Set the tick labels and range along the x-axis. See also `ticks!`.
 """
 function xticks!(scene::Scene; xtickrange=xtickrange(scene), xticklabels=xticklabels(scene))
     ticks!(scene, tickranges=(xtickrange, tickranges(scene)[2:end]...), ticklabels=(xticklabels, ticklabels(scene)[2:end]...))

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,9 +21,9 @@ include("interaction/iodevices.jl")
 This struct provides accessible `Observable`s to monitor the events
 associated with a Scene.
 
-Functions that act on a `Observable` must return `Consume()` if the function
+Functions that act on an `Observable` must return `Consume()` if the function
 consumes an event. When an event is consumed it does
-not trigger other observer functions. The order in which functions are exectued
+not trigger other observer functions. The order in which functions are executed
 can be controlled via the `priority` keyword (default 0) in `on`.
 
 Example:


### PR DESCRIPTION
# Description

Fix docstring typos, mostly misspellings.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added or changed relevant sections in the documentation
