### PR TITLE
Fix rare missing/duplicate pixels in truncated joint

### DIFF
--- a/GLMakie/assets/shader/line_segment.geom
+++ b/GLMakie/assets/shader/line_segment.geom
@@ -16,9 +16,7 @@ in {{stripped_color_type}} g_color[];
 in uvec2 g_id[];
 in float g_thickness[];
 
-out float f_quad_sdf0;
-out vec3 f_quad_sdf1;
-out float f_quad_sdf2;
+out vec3 f_quad_sdf;
 out vec2 f_truncation;
 out float f_linestart;
 out float f_linelength;
@@ -27,11 +25,12 @@ flat out float f_linewidth;
 flat out vec4 f_pattern_overwrite;
 flat out uvec2 f_id;
 flat out vec2 f_extrusion;
-flat out vec2 f_discard_limit;
 flat out {{stripped_color_type}} f_color1;
 flat out {{stripped_color_type}} f_color2;
 flat out float f_alpha_weight;
 flat out float f_cumulative_length;
+flat out vec4 f_linepoints;
+flat out vec4 f_miter_vecs;
 
 const float AA_RADIUS = 0.8;
 const float AA_THICKNESS = 2.0 * AA_RADIUS;
@@ -79,12 +78,11 @@ void main(void)
     vec2 n1 = normal_vector(v1);
 
     // Set invalid / ignored outputs
-    f_quad_sdf0 = 10.0;             // no joint to previous segment
-    f_quad_sdf2 = 10.0;             // not joint to next segment
     f_truncation = vec2(-10.0);     // no truncated joint
     f_pattern_overwrite = vec4(-1e12, 1.0, 1e12, 1.0); // no joints to overwrite
     f_extrusion = vec2(0.5);        // no joints needing extrusion
-    f_discard_limit = vec2(10.0);   // no joints needing discards
+    f_linepoints = vec4(-1e12);
+    f_miter_vecs = vec4(-1);
 
     // constants
     f_color1 = g_color[0];
@@ -118,9 +116,9 @@ void main(void)
             vec2 VP2 = position.xy - p2.xy;
 
             // sdf of this segment
-            f_quad_sdf1.x = dot(VP1, -v1.xy);
-            f_quad_sdf1.y = dot(VP2,  v1.xy);
-            f_quad_sdf1.z = n_offset;
+            f_quad_sdf.x = dot(VP1, -v1.xy);
+            f_quad_sdf.y = dot(VP2,  v1.xy);
+            f_quad_sdf.z = n_offset;
 
             // finalize vertex
             EmitVertex();

--- a/GLMakie/assets/shader/lines.frag
+++ b/GLMakie/assets/shader/lines.frag
@@ -139,8 +139,7 @@ void main(){
 
 // #ifndef DEBUG
 if (!debug) {
-    // discard fragments that are "more inside" the other segment to remove
-    // overlap between adjacent line segments. (truncated joints)
+    // discard fragments that are other side of the truncated joint
     float discard_sdf1 = dot(gl_FragCoord.xy - f_linepoints.xy, f_miter_vecs.xy);
     float discard_sdf2 = dot(gl_FragCoord.xy - f_linepoints.zw, f_miter_vecs.zw);
     if ((f_quad_sdf.x > 0.0 && discard_sdf1 > 0.0) ||
@@ -223,9 +222,9 @@ if (!debug) {
 
     // and inner truncation as softer green
     if (min(f_quad_sdf.x + 1.0, 100.0 * discard_sdf1 - 1.0) > 0.0)
-        color.g += 1.2;
+        color.g += 0.2;
     if (min(f_quad_sdf.y + 1.0, 100.0 * discard_sdf2 - 1.0) > 0.0)
-        color.g += 1.2;
+        color.g += 0.2;
 
     // mark pattern in white
     color.rgb += vec3(0.3) * step(0.0, get_pattern_sdf(pattern, uv));

--- a/GLMakie/assets/shader/lines.frag
+++ b/GLMakie/assets/shader/lines.frag
@@ -11,9 +11,7 @@ struct Nothing{ //Nothing type, to encode if some variable doesn't contain any d
     bool _; //empty structs are not allowed
 };
 
-in highp float f_quad_sdf0;
-in highp vec3 f_quad_sdf1;
-in highp float f_quad_sdf2;
+in highp vec3 f_quad_sdf;
 in vec2 f_truncation;
 in float f_linestart;
 in float f_linelength;
@@ -21,12 +19,13 @@ in float f_linelength;
 flat in float f_linewidth;
 flat in vec4 f_pattern_overwrite;
 flat in vec2 f_extrusion;
-flat in vec2 f_discard_limit;
 flat in {{stripped_color_type}} f_color1;
 flat in {{stripped_color_type}} f_color2;
 flat in float f_alpha_weight;
 flat in uvec2 f_id;
 flat in float f_cumulative_length;
+flat in vec4 f_linepoints;
+flat in vec4 f_miter_vecs;
 
 {{pattern_type}} pattern;
 uniform float pattern_length;
@@ -131,28 +130,29 @@ void write2framebuffer(vec4 color, uvec2 id);
 void main(){
     vec4 color;
 
-    // f_quad_sdf1.x is the negative distance from p1 in v1 direction
+    // f_quad_sdf.x is the negative distance from p1 in v1 direction
     // (where f_cumulative_length applies) so we need to subtract here
     vec2 uv = vec2(
-        (f_cumulative_length - f_quad_sdf1.x + 0.5) / (2.0 * f_linewidth * pattern_length),
-        0.5 + 0.5 * f_quad_sdf1.z / f_linewidth
+        (f_cumulative_length - f_quad_sdf.x + 0.5) / (2.0 * f_linewidth * pattern_length),
+        0.5 + 0.5 * f_quad_sdf.z / f_linewidth
     );
 
 // #ifndef DEBUG
 if (!debug) {
     // discard fragments that are "more inside" the other segment to remove
     // overlap between adjacent line segments. (truncated joints)
-    float dist_in_prev = max(f_quad_sdf0, - f_discard_limit.x);
-    float dist_in_next = max(f_quad_sdf2, - f_discard_limit.y);
-    if (dist_in_prev < f_quad_sdf1.x || dist_in_next < f_quad_sdf1.y)
+    float discard_sdf1 = dot(gl_FragCoord.xy - f_linepoints.xy, f_miter_vecs.xy);
+    float discard_sdf2 = dot(gl_FragCoord.xy - f_linepoints.zw, f_miter_vecs.zw);
+    if ((f_quad_sdf.x > 0.0 && discard_sdf1 > 0.0) ||
+        (f_quad_sdf.y > 0.0 && discard_sdf2 >= 0.0))
         discard;
 
     // SDF for inside vs outside along the line direction. extrusion adjusts
         // the distance from p1/p2 for joints etc
-    float sdf = max(f_quad_sdf1.x - f_extrusion.x, f_quad_sdf1.y - f_extrusion.y);
+    float sdf = max(f_quad_sdf.x - f_extrusion.x, f_quad_sdf.y - f_extrusion.y);
 
     // distance in linewidth direction
-    sdf = max(sdf, abs(f_quad_sdf1.z) - f_linewidth);
+    sdf = max(sdf, abs(f_quad_sdf.z) - f_linewidth);
 
     // outer truncation of truncated joints (smooth outside edge)
     sdf = max(sdf, f_truncation.x);
@@ -163,8 +163,8 @@ if (!debug) {
     // where a is the smoothly cut of part just before discard triggers (i.e. visible)
     // and b is the (smoothly) cut of part just after discard triggers (i.e not visible)
     // 100.0x sdf makes the sdf much more sharply, avoiding overdraw in the center
-    sdf = max(sdf, min(f_quad_sdf1.x + 1.0, 100.0 * (f_quad_sdf1.x - f_quad_sdf0) - 1.0));
-    sdf = max(sdf, min(f_quad_sdf1.y + 1.0, 100.0 * (f_quad_sdf1.y - f_quad_sdf2) - 1.0));
+    sdf = max(sdf, min(f_quad_sdf.x + 1.0, 100.0 * discard_sdf1 - 1.0));
+    sdf = max(sdf, min(f_quad_sdf.y + 1.0, 100.0 * discard_sdf2 - 1.0));
 
     // pattern application
     sdf = max(sdf, get_pattern_sdf(pattern, uv));
@@ -177,11 +177,11 @@ if (!debug) {
     //      p1      v1
     //        '.   --->
     //          '----------
-    // -f_quad_sdf1.x is the distance from p1, positive in v1 direction
+    // -f_quad_sdf.x is the distance from p1, positive in v1 direction
     // f_linestart is the distance between p1 and the left edge along v1 direction
     // f_start_length.y is the distance between the edges of this segment, in v1 direction
     // so this is 0 at the left edge and 1 at the right edge (with extrusion considered)
-    float factor = (-f_quad_sdf1.x - f_linestart) / f_linelength;
+    float factor = (-f_quad_sdf.x - f_linestart) / f_linelength;
     color = get_color(f_color1 + factor * (f_color2 - f_color1), color_map, color_norm);
     color.a *= f_alpha_weight;
 
@@ -200,33 +200,32 @@ if (!debug) {
     color.rgb += (2 * mod(f_id.y, 2) - 1) * 0.1;
 
     // mark "outside" define by quad_sdf in black
-    float sdf = max(f_quad_sdf1.x - f_extrusion.x, f_quad_sdf1.y - f_extrusion.y);
-    sdf = max(sdf, abs(f_quad_sdf1.z) - f_linewidth);
+    float sdf = max(f_quad_sdf.x - f_extrusion.x, f_quad_sdf.y - f_extrusion.y);
+    sdf = max(sdf, abs(f_quad_sdf.z) - f_linewidth);
     color.rgb -= vec3(0.4) * step(0.0, sdf);
 
     // Mark discarded space in red/blue
-    float dist_in_prev = max(f_quad_sdf0, - f_discard_limit.x);
-    float dist_in_next = max(f_quad_sdf2, - f_discard_limit.y);
-    if (dist_in_prev < f_quad_sdf1.x)
+    float discard_sdf1 = dot(gl_FragCoord.xy - f_linepoints.xy, f_miter_vecs.xy);
+    float discard_sdf2 = dot(gl_FragCoord.xy - f_linepoints.zw, f_miter_vecs.zw);
+    if (f_quad_sdf.x > 0.0 && discard_sdf1 > 0.0)
         color.r += 0.5;
-    if (dist_in_next <= f_quad_sdf1.y) {
+    if (f_quad_sdf.y > 0.0 && discard_sdf2 >= 0.0)
         color.b += 0.5;
-    }
 
     // remaining overlap as softer red/blue
-    if (f_quad_sdf1.x - f_quad_sdf0 - 1.0 > 0.0)
+    if (discard_sdf1 - 1.0 > 0.0)
         color.r += 0.2;
-    if (f_quad_sdf1.y - f_quad_sdf2 - 1.0 > 0.0)
+    if (discard_sdf2 - 1.0 > 0.0)
         color.b += 0.2;
 
     // Mark regions excluded via truncation in green
     color.g += 0.5 * step(0.0, max(f_truncation.x, f_truncation.y));
 
     // and inner truncation as softer green
-    if (min(f_quad_sdf1.x + 1.0, 100.0 * (f_quad_sdf1.x - f_quad_sdf0) - 1.0) > 0.0)
-        color.g += 0.2;
-    if (min(f_quad_sdf1.y + 1.0, 100.0 * (f_quad_sdf1.y - f_quad_sdf2) - 1.0) > 0.0)
-        color.g += 0.2;
+    if (min(f_quad_sdf.x + 1.0, 100.0 * discard_sdf1 - 1.0) > 0.0)
+        color.g += 1.2;
+    if (min(f_quad_sdf.y + 1.0, 100.0 * discard_sdf2 - 1.0) > 0.0)
+        color.g += 1.2;
 
     // mark pattern in white
     color.rgb += vec3(0.3) * step(0.0, get_pattern_sdf(pattern, uv));

--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -370,14 +370,14 @@ void main(void)
     // because both of these values come from the same calculation between the
     // two segments. I.e. (previous segment).p2 == (next segment).p1 and
     // (previous segment).miter_v2 == (next segment).miter_v1 should be the case.
-    if (isvalid[0] && is_truncated[0]) {
+    if (isvalid[0] && is_truncated[0] && (adjustment[0] == 0.0)) {
         f_linepoints.xy = p1.xy + scene_origin; // FragCoords are relative to the window
         f_miter_vecs.xy = -miter_v1.xy;         // but p1/p2 is relative to the scene origin
     } else {
         f_linepoints.xy = vec2(-1e12);          // FragCoord > 0
         f_miter_vecs.xy = normalize(vec2(-1));
     }
-    if (isvalid[3] && is_truncated[1]) {
+    if (isvalid[3] && is_truncated[1] && (adjustment[1] == 0.0)) {
         f_linepoints.zw = p2.xy + scene_origin;
         f_miter_vecs.zw = miter_v2.xy;
     } else {

--- a/GLMakie/assets/shader/lines.geom
+++ b/GLMakie/assets/shader/lines.geom
@@ -17,9 +17,7 @@ in uvec2 g_id[];
 in int g_valid_vertex[];
 in float g_thickness[];
 
-out highp float f_quad_sdf0;
-out highp vec3 f_quad_sdf1;
-out highp float f_quad_sdf2;
+out highp vec3 f_quad_sdf;
 out vec2 f_truncation;
 out float f_linestart;
 out float f_linelength;
@@ -33,6 +31,8 @@ flat out {{stripped_color_type}} f_color1;
 flat out {{stripped_color_type}} f_color2;
 flat out float f_alpha_weight;
 flat out float f_cumulative_length;
+flat out vec4 f_linepoints;
+flat out vec4 f_miter_vecs;
 
 out vec3 o_view_pos;
 out vec3 o_view_normal;
@@ -40,6 +40,7 @@ out vec3 o_view_normal;
 {{pattern_type}} pattern;
 uniform float pattern_length;
 uniform vec2 resolution;
+uniform vec2 scene_origin;
 
 // Constants
 const float MITER_LIMIT = -0.4;
@@ -55,9 +56,7 @@ struct LineVertex {
     vec3 position;
     int index;
 
-    float quad_sdf0;
-    vec3 quad_sdf1;
-    float quad_sdf2;
+    vec3 quad_sdf;
     vec2 truncation;
 
     float linestart;
@@ -66,9 +65,7 @@ struct LineVertex {
 
 void emit_vertex(LineVertex vertex) {
     gl_Position    = vec4((2.0 * vertex.position.xy / resolution) - 1.0, vertex.position.z, 1.0);
-    f_quad_sdf0    = vertex.quad_sdf0;
-    f_quad_sdf1    = vertex.quad_sdf1;
-    f_quad_sdf2    = vertex.quad_sdf2;
+    f_quad_sdf    = vertex.quad_sdf;
     f_truncation   = vertex.truncation;
     f_linestart    = vertex.linestart;
     f_linelength   = vertex.linelength;
@@ -291,8 +288,8 @@ void main(void)
     // Miter normals (normal of truncated edge / vector to sharp corner)
     // Note: n0 + n1 = vec(0) for a 180° change in direction. +-(v0 - v1) is the
     //       same direction, but becomes vec(0) at 0°, so we can use it instead
-    vec2 miter_n1 = is_truncated[0] ? normalize(v0.xy - v1.xy) : normalize(n0 + n1);
-    vec2 miter_n2 = is_truncated[1] ? normalize(v1.xy - v2.xy) : normalize(n1 + n2);
+    vec2 miter_n1 = is_truncated[0] ? sign(dot(v0.xy, n1)) * normalize(v0.xy - v1.xy) : normalize(n0 + n1);
+    vec2 miter_n2 = is_truncated[1] ? sign(dot(v1.xy, n2)) * normalize(v1.xy - v2.xy) : normalize(n1 + n2);
 
     // miter vectors (line vector matching miter normal)
     vec2 miter_v1 = -normal_vector(miter_n1);
@@ -358,14 +355,35 @@ void main(void)
     if (adjustment[0] != 0.0 || adjustment[1] != 0.0)
         shape_factor = vec2(1.0);
 
-    // For truncated miter joints we discard overlapping sections of
-    // the two involved line segments. To avoid discarding far into
-    // the line segment we limit the range here. (Without this short
-    // segments can cut holes into longer sections.)
-    f_discard_limit = vec2(
-        is_truncated[0] ? 0.0 : 1e12,
-        is_truncated[1] ? 0.0 : 1e12
-    );
+    // For truncated miter joints we discard overlapping sections of the two
+    // involved line segments. To identify which sections overlap we calculate
+    // the signed distance in +- miter vector direction from the shared line
+    // point in fragment shader. We pass the necessary data here. If we do not
+    // have a truncated joint we adjust the data here to never discard.
+    // Why not calculate the sdf here?
+    // If we calculate the sdf here and pass it as an interpolated vertex output
+    // the values we get between the two line segments will differ since the
+    // the vertices each segment interpolates from differ. This causes the
+    // discard check to rarely be true or false for both segments, resulting in
+    // duplicated or missing pixel/fragment draw.
+    // Passing the line point and miter vector instead should fix this issue,
+    // because both of these values come from the same calculation between the
+    // two segments. I.e. (previous segment).p2 == (next segment).p1 and
+    // (previous segment).miter_v2 == (next segment).miter_v1 should be the case.
+    if (isvalid[0] && is_truncated[0]) {
+        f_linepoints.xy = p1.xy + scene_origin; // FragCoords are relative to the window
+        f_miter_vecs.xy = -miter_v1.xy;         // but p1/p2 is relative to the scene origin
+    } else {
+        f_linepoints.xy = vec2(-1e12);          // FragCoord > 0
+        f_miter_vecs.xy = normalize(vec2(-1));
+    }
+    if (isvalid[3] && is_truncated[1]) {
+        f_linepoints.zw = p2.xy + scene_origin;
+        f_miter_vecs.zw = miter_v2.xy;
+    } else {
+        f_linepoints.zw = vec2(-1e12);
+        f_miter_vecs.zw = normalize(vec2(-1));
+    }
 
     // used to elongate sdf to include joints
     // if start/end       elongate slightly so that there is no AA gap in loops
@@ -429,24 +447,10 @@ void main(void)
             vec2 VP1 = vertex.position.xy - p1.xy;
             vec2 VP2 = vertex.position.xy - p2.xy;
 
-            // Signed distance of the previous segment from the shared point
-            // p1 in line direction. Used decide which segments renders
-            // which joint fragment/pixel for truncated joints.
-            if (isvalid[0] && (adjustment[0] == 0) && is_truncated[0])
-                vertex.quad_sdf0 = dot(VP1, v0.xy);
-            else
-                vertex.quad_sdf0 = 1e12;
-
             // sdf of this segment
-            vertex.quad_sdf1.x = dot(VP1, -v1.xy);
-            vertex.quad_sdf1.y = dot(VP2,  v1.xy);
-            vertex.quad_sdf1.z = dot(VP1,  n1);
-
-            // SDF for next segment, see quad_sdf0
-            if (isvalid[3] && (adjustment[1] == 0) && is_truncated[1])
-                vertex.quad_sdf2 = dot(VP2, -v2.xy);
-            else
-                vertex.quad_sdf2 = 1e12;
+            vertex.quad_sdf.x = dot(VP1, -v1.xy);
+            vertex.quad_sdf.y = dot(VP2,  v1.xy);
+            vertex.quad_sdf.z = dot(VP1,  n1);
 
             // sdf for creating a flat cap on truncated joints
             // (sign(dot(...)) detects if line bends left or right)

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -445,6 +445,9 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::Lines))
         linestyle = pop!(gl_attributes, :linestyle)
         data = Dict{Symbol, Any}(gl_attributes)
         positions = handle_view(plot[1], data)
+        data[:scene_origin] = map(plot, data[:px_per_unit], scene.viewport) do ppu, viewport
+            Vec2f(ppu * origin(viewport))
+        end
 
         space = plot.space
         if isnothing(to_value(linestyle))
@@ -483,6 +486,9 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::LineSegme
     return cached_robj!(screen, scene, plot) do gl_attributes
         data = Dict{Symbol, Any}(gl_attributes)
         data[:pattern] = pop!(data, :linestyle)
+        data[:scene_origin] = map(plot, data[:px_per_unit], scene.viewport) do ppu, viewport
+            Vec2f(ppu * origin(viewport))
+        end
 
         positions = handle_view(plot[1], data)
         # positions = lift(apply_transform, plot, transform_func_obs(plot), positions, plot.space)

--- a/WGLMakie/src/Lines.js
+++ b/WGLMakie/src/Lines.js
@@ -39,29 +39,13 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
         /// Linessegments
         ////////////////////////////////////////////////////////////////////////
 
-        // Note:
-        // If we run into problems with the number of varying vertex attributes
-        // used here, try splitting up f_quad_sdf1. The vec3 might be taking
-        // a full vec4 slot, while vec2 + float would not.
-        // Alternatively:
-        // - f_truncation could probably be traded for a float f_truncation_distance,
-        //   with truncation happening at something like
-        //   trunc_sdf = f_quad_sdf1.x - f_quad_sdf0 +- f_truncation_distance
-        // - f_quad_sdf1.x and .y could potentially be merged used abs like the
-        //   normal direction (f_quad_sdf1.z).
-        // If those are not possible without degrading line quality we could
-        // also generate a simplified fragment shader for linesegments which
-        // drops all the unnecessary attributes to enable that as a workaround.
-
         return `precision mediump int;
             precision highp float;
 
             ${attribute_decl}
 
 
-            out highp float f_quad_sdf0;        // invalid / not needed
-            out highp vec3 f_quad_sdf1;
-            out highp float f_quad_sdf2;        // invalid / not needed
+            out vec3 f_quad_sdf;
             out vec2 f_truncation;              // invalid / not needed
             out float f_linestart;              // constant
             out float f_linelength;
@@ -69,12 +53,13 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
             flat out vec2 f_extrusion;          // invalid / not needed
             flat out float f_linewidth;
             flat out vec4 f_pattern_overwrite;  // invalid / not needed
-            flat out vec2 f_discard_limit;      // invalid / not needed
             flat out uint f_instance_id;
             flat out ${color} f_color1;
             flat out ${color} f_color2;
             flat out float f_alpha_weight;
             flat out float f_cumulative_length;
+            flat out vec4 f_linepoints;         // invalid / not needed
+            flat out vec4 f_miter_vecs;         // invalid / not needed
 
             ${uniform_decl}
 
@@ -152,9 +137,6 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // invalid - no joints requiring pattern adjustments
                 f_pattern_overwrite = vec4(-1e12, 1.0, 1e12, 1.0);
 
-                // invalid - no joints that need pixels discarded
-                f_discard_limit = vec2(10.0);
-
                 // invalid - no joints requiring line sdfs to be extruded
                 f_extrusion = vec2(0.0);
 
@@ -165,6 +147,10 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
 
                 // we restart patterns for each segment
                 f_cumulative_length = 0.0;
+
+                // no joints means these should be set to a "never discard" state
+                f_linepoints = vec4(-1e12);
+                f_miter_vecs = vec4(-1);
 
 
                 ////////////////////////////////////////////////////////////////////
@@ -181,16 +167,10 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 vec2 VP1 = point.xy - p1.xy;
                 vec2 VP2 = point.xy - p2.xy;
 
-                // invalid - no joint to compute overlap with
-                f_quad_sdf0 = 10.0;
-
                 // sdf of this segment
-                f_quad_sdf1.x = dot(VP1, -v1.xy);
-                f_quad_sdf1.y = dot(VP2,  v1.xy);
-                f_quad_sdf1.z = dot(VP1,  n1);
-
-                // invalid - no joint to compute overlap with
-                f_quad_sdf2 = 10.0;
+                f_quad_sdf.x = dot(VP1, -v1.xy);
+                f_quad_sdf.y = dot(VP2,  v1.xy);
+                f_quad_sdf.z = dot(VP1,  n1);
 
                 // invalid - no joint to truncate
                 f_truncation = vec2(-10.0);
@@ -219,9 +199,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
 
             ${attribute_decl}
 
-            out highp float f_quad_sdf0;
-            out highp vec3 f_quad_sdf1;
-            out highp float f_quad_sdf2;
+            out vec3 f_quad_sdf;
             out vec2 f_truncation;
             out float f_linestart;
             out float f_linelength;
@@ -229,12 +207,13 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
             flat out vec2 f_extrusion;
             flat out float f_linewidth;
             flat out vec4 f_pattern_overwrite;
-            flat out vec2 f_discard_limit;
             flat out uint f_instance_id;
             flat out ${color} f_color1;
             flat out ${color} f_color2;
             flat out float f_alpha_weight;
             flat out float f_cumulative_length;
+            flat out vec4 f_linepoints;
+            flat out vec4 f_miter_vecs;
 
             ${uniform_decl}
 
@@ -447,8 +426,8 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // Miter normals (normal of truncated edge / vector to sharp corner)
                 // Note: n0 + n1 = vec(0) for a 180° change in direction. +-(v0 - v1) is the
                 //       same direction, but becomes vec(0) at 0°, so we can use it instead
-                vec2 miter_n1 = is_truncated[0] ? normalize(v0.xy - v1.xy) : normalize(n0 + n1);
-                vec2 miter_n2 = is_truncated[1] ? normalize(v1.xy - v2.xy) : normalize(n1 + n2);
+                vec2 miter_n1 = is_truncated[0] ? sign(dot(v0.xy, n1)) * normalize(v0.xy - v1.xy) : normalize(n0 + n1);
+                vec2 miter_n2 = is_truncated[1] ? sign(dot(v1.xy, n2)) * normalize(v1.xy - v2.xy) : normalize(n1 + n2);
 
                 // miter vectors (line vector matching miter normal)
                 vec2 miter_v1 = -normal_vector(miter_n1);
@@ -525,14 +504,36 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 ////////////////////////////////////////////////////////////////////
 
 
-                // For truncated miter joints we discard overlapping sections of
-                // the two involved line segments. To avoid discarding far into
-                // the line segment we limit the range here. (Without this short
-                // segments can cut holes into longer sections.)
-                f_discard_limit = vec2(
-                    is_truncated[0] ? 0.0 : 1e12,
-                    is_truncated[1] ? 0.0 : 1e12
-                );
+
+                // For truncated miter joints we discard overlapping sections of the two
+                // involved line segments. To identify which sections overlap we calculate
+                // the signed distance in +- miter vector direction from the shared line
+                // point in fragment shader. We pass the necessary data here. If we do not
+                // have a truncated joint we adjust the data here to never discard.
+                // Why not calculate the sdf here?
+                // If we calculate the sdf here and pass it as an interpolated vertex output
+                // the values we get between the two line segments will differ since the
+                // the vertices each segment interpolates from differ. This causes the
+                // discard check to rarely be true or false for both segments, resulting in
+                // duplicated or missing pixel/fragment draw.
+                // Passing the line point and miter vector instead should fix this issue,
+                // because both of these values come from the same calculation between the
+                // two segments. I.e. (previous segment).p2 == (next segment).p1 and
+                // (previous segment).miter_v2 == (next segment).miter_v1 should be the case.
+                if (isvalid[0] && is_truncated[0]) {
+                    f_linepoints.xy = p1.xy + px_per_unit * scene_origin;   // FragCoords are relative to the window
+                    f_miter_vecs.xy = -miter_v1.xy;                         // but p1/p2 is relative to the scene origin
+                } else {
+                    f_linepoints.xy = vec2(-1e12);          // FragCoord > 0
+                    f_miter_vecs.xy = normalize(vec2(-1));
+                }
+                if (isvalid[3] && is_truncated[1]) {
+                    f_linepoints.zw = p2.xy + px_per_unit * scene_origin;
+                    f_miter_vecs.zw = miter_v2.xy;
+                } else {
+                    f_linepoints.zw = vec2(-1e12);
+                    f_miter_vecs.zw = normalize(vec2(-1));
+                }
 
                 // Used to elongate sdf to include joints
                 // if start/end         elongate slightly so that there is no AA gap in loops
@@ -587,24 +588,10 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 vec2 VP1 = point.xy - p1.xy;
                 vec2 VP2 = point.xy - p2.xy;
 
-                // Signed distance of the previous segment from the shared point
-                // p1 in line direction. Used decide which segments renders
-                // which joint fragment/pixel for truncated joints.
-                if (isvalid[0] && (adjustment[0] == 0.0) && is_truncated[0])
-                    f_quad_sdf0 = dot(VP1, v0.xy);
-                else
-                    f_quad_sdf0 = 1e12;
-
                 // sdf of this segment
-                f_quad_sdf1.x = dot(VP1, -v1.xy);
-                f_quad_sdf1.y = dot(VP2,  v1.xy);
-                f_quad_sdf1.z = dot(VP1,  n1);
-
-                // SDF for next segment, see quad_sdf0
-                if (isvalid[3] && (adjustment[1] == 0.0) && is_truncated[1])
-                    f_quad_sdf2 = dot(VP2, -v2.xy);
-                else
-                    f_quad_sdf2 = 1e12;
+                f_quad_sdf.x = dot(VP1, -v1.xy);
+                f_quad_sdf.y = dot(VP2,  v1.xy);
+                f_quad_sdf.z = dot(VP1,  n1);
 
                 // sdf for creating a flat cap on truncated joints
                 // (sign(dot(...)) detects if line bends left or right)
@@ -655,9 +642,7 @@ function lines_fragment_shader(uniforms, attributes) {
     precision mediump sampler2D;
     precision mediump sampler3D;
 
-    in highp float f_quad_sdf0;
-    in highp vec3 f_quad_sdf1;
-    in highp float f_quad_sdf2;
+    in highp vec3 f_quad_sdf;
     in vec2 f_truncation;
     in float f_linestart;
     in float f_linelength;
@@ -665,12 +650,13 @@ function lines_fragment_shader(uniforms, attributes) {
     flat in float f_linewidth;
     flat in vec4 f_pattern_overwrite;
     flat in vec2 f_extrusion;
-    flat in vec2 f_discard_limit;
     flat in ${color} f_color1;
     flat in ${color} f_color2;
     flat in float f_alpha_weight;
     flat in uint f_instance_id;
     flat in float f_cumulative_length;
+    flat in vec4 f_linepoints;
+    flat in vec4 f_miter_vecs;
 
     uniform uint object_id;
     ${uniform_decl}
@@ -779,26 +765,26 @@ function lines_fragment_shader(uniforms, attributes) {
     void main(){
         vec4 color;
 
-        // f_quad_sdf1.x is the distance from p1, negative in v1 direction.
+        // f_quad_sdf.x is the distance from p1, negative in v1 direction.
         vec2 uv = vec2(
-            (f_cumulative_length - f_quad_sdf1.x) / (2.0 * f_linewidth * pattern_length),
-            0.5 + 0.5 * f_quad_sdf1.z / f_linewidth
+            (f_cumulative_length - f_quad_sdf.x) / (2.0 * f_linewidth * pattern_length),
+            0.5 + 0.5 * f_quad_sdf.z / f_linewidth
         );
 
     #ifndef DEBUG
-        // discard fragments that are "more inside" the other segment to remove
-        // overlap between adjacent line segments. (truncated joints)
-        float dist_in_prev = max(f_quad_sdf0, - f_discard_limit.x);
-        float dist_in_next = max(f_quad_sdf2, - f_discard_limit.y);
-        if (dist_in_prev < f_quad_sdf1.x || dist_in_next < f_quad_sdf1.y)
+        // discard fragments that are other side of the truncated joint
+        float discard_sdf1 = dot(gl_FragCoord.xy - f_linepoints.xy, f_miter_vecs.xy);
+        float discard_sdf2 = dot(gl_FragCoord.xy - f_linepoints.zw, f_miter_vecs.zw);
+        if ((f_quad_sdf.x > 0.0 && discard_sdf1 > 0.0) ||
+            (f_quad_sdf.y > 0.0 && discard_sdf2 >= 0.0))
             discard;
 
         // SDF for inside vs outside along the line direction. extrusion adjusts
         // the distance from p1/p2 for joints etc
-        float sdf = max(f_quad_sdf1.x - f_extrusion.x, f_quad_sdf1.y - f_extrusion.y);
+        float sdf = max(f_quad_sdf.x - f_extrusion.x, f_quad_sdf.y - f_extrusion.y);
 
         // distance in linewidth direction
-        sdf = max(sdf, abs(f_quad_sdf1.z) - f_linewidth);
+        sdf = max(sdf, abs(f_quad_sdf.z) - f_linewidth);
 
         // truncation of truncated joints (creates flat cap)
         sdf = max(sdf, f_truncation.x);
@@ -809,8 +795,8 @@ function lines_fragment_shader(uniforms, attributes) {
         // where a is the smoothly cut of part just before discard triggers (i.e. visible)
         // and b is the (smoothly) cut of part where the discard triggers
         // 100.0x sdf makes the sdf much more sharply, avoiding overdraw in the center
-        sdf = max(sdf, min(f_quad_sdf1.x + 1.0, 100.0 * (f_quad_sdf1.x - f_quad_sdf0) - 1.0));
-        sdf = max(sdf, min(f_quad_sdf1.y + 1.0, 100.0 * (f_quad_sdf1.y - f_quad_sdf2) - 1.0));
+        sdf = max(sdf, min(f_quad_sdf.x + 1.0, 100.0 * discard_sdf1 - 1.0));
+        sdf = max(sdf, min(f_quad_sdf.y + 1.0, 100.0 * discard_sdf2 - 1.0));
 
         // pattern application
         sdf = max(sdf, get_pattern_sdf(pattern, uv));
@@ -823,11 +809,11 @@ function lines_fragment_shader(uniforms, attributes) {
         //      p1      v1
         //        '.   --->
         //          '----------
-        // -f_quad_sdf1.x is the distance from p1, positive in v1 direction
+        // -f_quad_sdf.x is the distance from p1, positive in v1 direction
         // f_linestart is the distance between p1 and the left edge along v1 direction
         // f_start_length.y is the distance between the edges of this segment, in v1 direction
         // so this is 0 at the left edge and 1 at the right edge (with extrusion considered)
-        float factor = (-f_quad_sdf1.x - f_linestart) / f_linelength;
+        float factor = (-f_quad_sdf.x - f_linestart) / f_linelength;
         color = get_color(f_color1 + factor * (f_color2 - f_color1), colormap, colorrange);
 
         color.a *= aastep(0.0, -sdf) * f_alpha_weight;
@@ -839,36 +825,35 @@ function lines_fragment_shader(uniforms, attributes) {
         color.rgb += (2.0 * mod(float(f_instance_id), 2.0) - 1.0) * 0.1;
 
         // show color interpolation as brightness gradient
-        // float factor = (-f_quad_sdf1.x - f_linestart) / f_linelength;
+        // float factor = (-f_quad_sdf.x - f_linestart) / f_linelength;
         // color.rgb += (2.0 * factor - 1.0) * 0.2;
 
         // mark "outside" define by quad_sdf in black
-        float sdf = max(f_quad_sdf1.x - f_extrusion.x, f_quad_sdf1.y - f_extrusion.y);
-        sdf = max(sdf, abs(f_quad_sdf1.z) - f_linewidth);
+        float sdf = max(f_quad_sdf.x - f_extrusion.x, f_quad_sdf.y - f_extrusion.y);
+        sdf = max(sdf, abs(f_quad_sdf.z) - f_linewidth);
         color.rgb -= vec3(0.4) * step(0.0, sdf);
 
         // Mark discarded space in red/blue
-        float dist_in_prev = max(f_quad_sdf0, - f_discard_limit.x);
-        float dist_in_next = max(f_quad_sdf2, - f_discard_limit.y);
-        if (dist_in_prev < f_quad_sdf1.x)
+        float discard_sdf1 = dot(gl_FragCoord.xy - f_linepoints.xy, f_miter_vecs.xy);
+        float discard_sdf2 = dot(gl_FragCoord.xy - f_linepoints.zw, f_miter_vecs.zw);
+        if (f_quad_sdf.x > 0.0 && discard_sdf1 > 0.0)
             color.r += 0.5;
-        if (dist_in_next <= f_quad_sdf1.y) {
+        if (f_quad_sdf.y > 0.0 && discard_sdf2 >= 0.0)
             color.b += 0.5;
-        }
 
         // remaining overlap as softer red/blue
-        if (f_quad_sdf1.x - f_quad_sdf0 - 1.0 > 0.0)
+        if (discard_sdf1 - 1.0 > 0.0)
             color.r += 0.2;
-        if (f_quad_sdf1.y - f_quad_sdf2 - 1.0 > 0.0)
+        if (discard_sdf2 - 1.0 > 0.0)
             color.b += 0.2;
 
         // Mark regions excluded via truncation in green
         color.g += 0.5 * step(0.0, max(f_truncation.x, f_truncation.y));
 
-        // and inner truncation as soft green
-        if (min(f_quad_sdf1.x + 1.0, 100.0 * (f_quad_sdf1.x - f_quad_sdf0) - 1.0) > 0.0)
+        // and inner truncation as softer green
+        if (min(f_quad_sdf.x + 1.0, 100.0 * discard_sdf1 - 1.0) > 0.0)
             color.g += 0.2;
-        if (min(f_quad_sdf1.y + 1.0, 100.0 * (f_quad_sdf1.y - f_quad_sdf2) - 1.0) > 0.0)
+        if (min(f_quad_sdf.y + 1.0, 100.0 * discard_sdf2 - 1.0) > 0.0)
             color.g += 0.2;
 
         // mark pattern in white

--- a/WGLMakie/src/Lines.js
+++ b/WGLMakie/src/Lines.js
@@ -503,8 +503,6 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // Static vertex data
                 ////////////////////////////////////////////////////////////////////
 
-
-
                 // For truncated miter joints we discard overlapping sections of the two
                 // involved line segments. To identify which sections overlap we calculate
                 // the signed distance in +- miter vector direction from the shared line
@@ -520,14 +518,14 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // because both of these values come from the same calculation between the
                 // two segments. I.e. (previous segment).p2 == (next segment).p1 and
                 // (previous segment).miter_v2 == (next segment).miter_v1 should be the case.
-                if (isvalid[0] && is_truncated[0]) {
+                if (isvalid[0] && is_truncated[0] && (adjustment[0] == 0.0)) {
                     f_linepoints.xy = p1.xy + px_per_unit * scene_origin;   // FragCoords are relative to the window
                     f_miter_vecs.xy = -miter_v1.xy;                         // but p1/p2 is relative to the scene origin
                 } else {
                     f_linepoints.xy = vec2(-1e12);          // FragCoord > 0
                     f_miter_vecs.xy = normalize(vec2(-1));
                 }
-                if (isvalid[3] && is_truncated[1]) {
+                if (isvalid[3] && is_truncated[1] && (adjustment[1] == 0.0)) {
                     f_linepoints.zw = p2.xy + px_per_unit * scene_origin;
                     f_miter_vecs.zw = miter_v2.xy;
                 } else {

--- a/WGLMakie/src/lines.jl
+++ b/WGLMakie/src/lines.jl
@@ -4,7 +4,8 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
     uniforms = Dict(
         :model => map(Makie.patch_model, f32_conversion_obs(plot), plot.model),
         :depth_shift => plot.depth_shift,
-        :picking => false
+        :picking => false,
+        :scene_origin => map(vp -> Vec2f(origin(vp)), plot, scene.viewport)
     )
 
     # TODO: maybe convert nothing to Sampler([-1.0]) to allowed dynamic linestyles?

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -21780,8 +21780,6 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // Static vertex data
                 ////////////////////////////////////////////////////////////////////
 
-
-
                 // For truncated miter joints we discard overlapping sections of the two
                 // involved line segments. To identify which sections overlap we calculate
                 // the signed distance in +- miter vector direction from the shared line
@@ -21797,14 +21795,14 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // because both of these values come from the same calculation between the
                 // two segments. I.e. (previous segment).p2 == (next segment).p1 and
                 // (previous segment).miter_v2 == (next segment).miter_v1 should be the case.
-                if (isvalid[0] && is_truncated[0]) {
+                if (isvalid[0] && is_truncated[0] && (adjustment[0] == 0.0)) {
                     f_linepoints.xy = p1.xy + px_per_unit * scene_origin;   // FragCoords are relative to the window
                     f_miter_vecs.xy = -miter_v1.xy;                         // but p1/p2 is relative to the scene origin
                 } else {
                     f_linepoints.xy = vec2(-1e12);          // FragCoord > 0
                     f_miter_vecs.xy = normalize(vec2(-1));
                 }
-                if (isvalid[3] && is_truncated[1]) {
+                if (isvalid[3] && is_truncated[1] && (adjustment[1] == 0.0)) {
                     f_linepoints.zw = p2.xy + px_per_unit * scene_origin;
                     f_miter_vecs.zw = miter_v2.xy;
                 } else {


### PR DESCRIPTION
# Description

#3558 still had an issue where sometimes both line segments would draw a pixel or both discard a pixel in a truncated joint. See for example:

![Screenshot from 2024-04-18 16-59-14](https://github.com/MakieOrg/Makie.jl/assets/10947937/ee77a471-64f9-4103-ac26-9f3005190656)

The discard was controlled by comparing the distance of a pixel/fragment along line direction from the shared line point. If it is closer to the first line segments it is drawn by it, otherwise by the next one. The problem with this is that the two line segments sometimes disagree on which one is closer, resulting in double or no draw. This happens because the signed distances were computed in the vertex/geom shader and passed as an interpolated vertex attribute. Since the two segments do not share all vertices, the interpolation differs on a float precision level.

The changes in this pr are:
- The calculation of the relevant signed distances now happens in the fragment shader. This avoids issues from interpolation.
- The discard decision is now based on the distance of the `FragCoord` from the shared line point in miter vector direction. All of these values are calculated the same way between the involved segments. (Which should also be true for the old method.)  This should also be a more stable decision than before, since distances along line direction will differ less as the line approaches a 180° turn while the new process doesn't care.

This pr may also be a slight performance improvement since it gets rid of two interpolated vertex attributes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
