### PR TITLE
fixes typo in arc example

### DIFF
--- a/src/basic_recipes/arc.jl
+++ b/src/basic_recipes/arc.jl
@@ -9,7 +9,7 @@ from `start_angle` to `stop_angle`.
 Examples:
 
 `arc(Point2f(0), 1, 0.0, π)`
-`arc(Point2f(1, 2), 0.3. π, -π)`
+`arc(Point2f(1, 2), 0.3, π, -π)`
 
 ## Attributes
 $(ATTRIBUTES)


### PR DESCRIPTION
# Description

Fixes # (issue)

Small typo in arc docstring ( `.` instead of `,`) in function call

## Type of change

Correction

## Checklist

NA, dont think any docs are generated based on this.

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
