### PR TITLE
document `WilkinsonTicks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Document `WilkinsonTicks` [#3819](https://github.com/MakieOrg/Makie.jl/pull/3819).
 - Improved thread safety of rendering with CairoMakie (independent `Scene`s only) by locking FreeType handles [#3777](https://github.com/MakieOrg/Makie.jl/pull/3777).
 
 ## [0.20.9] - 2024-03-29

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -1,25 +1,28 @@
-function WilkinsonTicks(k_ideal::Int; k_min = 2, k_max = 10,
-        Q = [(1.0,1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
-        granularity_weight = 1/4,
-        simplicity_weight = 1/6,
-        coverage_weight = 1/3,
-        niceness_weight = 1/4,
-        min_px_dist = 50.0)
-
+function WilkinsonTicks(
+    k_ideal::Int;
+    k_min = 2, k_max = 10,
+    Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
+    granularity_weight = 1/4,
+    simplicity_weight = 1/6,
+    coverage_weight = 1/3,
+    niceness_weight = 1/4
+)
     if !(0 < k_min <= k_ideal <= k_max)
         error("Invalid tick number specifications k_ideal $k_ideal, k_min $k_min, k_max $k_max")
     end
 
-    WilkinsonTicks(k_ideal, k_min, k_max, Q, granularity_weight, simplicity_weight,
-        coverage_weight, niceness_weight, min_px_dist)
+    WilkinsonTicks(
+        k_ideal, k_min, k_max, Q, granularity_weight, simplicity_weight, coverage_weight, niceness_weight
+    )
 end
 
 get_tickvalues(ticks::WilkinsonTicks, vmin, vmax) = get_tickvalues(ticks, Float64(vmin), Float64(vmax))
 
 function get_tickvalues(ticks::WilkinsonTicks, vmin::Float64, vmax::Float64)
 
-    tickvalues, _ = PlotUtils.optimize_ticks(Float64(vmin), Float64(vmax);
-        extend_ticks = false, strict_span=true, span_buffer = nothing,
+    ticklocations, _ = PlotUtils.optimize_ticks(
+        Float64(vmin), Float64(vmax);
+        extend_ticks = false, strict_span = true, span_buffer = nothing,
         k_min = ticks.k_min,
         k_max = ticks.k_max,
         k_ideal = ticks.k_ideal,
@@ -29,5 +32,5 @@ function get_tickvalues(ticks::WilkinsonTicks, vmin::Float64, vmax::Float64)
         coverage_weight = ticks.coverage_weight,
         niceness_weight = ticks.niceness_weight)
 
-    tickvalues
+    ticklocations
 end

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -1,28 +1,37 @@
-function WilkinsonTicks(
-    k_ideal::Int;
+"""
+    WilkinsonTicks(k_ideal::Int;
+                   k_min = 2, k_max = 10,
+                   Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
+                   granularity_weight = 1/4,
+                   simplicity_weight = 1/6,
+                   coverage_weight = 1/3,
+                   niceness_weight = 1/4)
+
+`WilkinsonTicks` is a thin wrapper over `PlotUtils.optimize_ticks`, the docstring of which is reproduced below:
+
+$(@doc PlotUtils.optimize_ticks)
+"""
+function WilkinsonTicks(k_ideal::Int;
     k_min = 2, k_max = 10,
     Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
     granularity_weight = 1/4,
     simplicity_weight = 1/6,
     coverage_weight = 1/3,
-    niceness_weight = 1/4
-)
+    niceness_weight = 1/4)
+
     if !(0 < k_min <= k_ideal <= k_max)
         error("Invalid tick number specifications k_ideal $k_ideal, k_min $k_min, k_max $k_max")
     end
 
-    WilkinsonTicks(
-        k_ideal, k_min, k_max, Q, granularity_weight,
-        simplicity_weight, coverage_weight, niceness_weight
-    )
+    WilkinsonTicks(k_ideal, k_min, k_max, Q, granularity_weight,
+                   simplicity_weight, coverage_weight, niceness_weight)
 end
 
 get_tickvalues(ticks::WilkinsonTicks, vmin, vmax) = get_tickvalues(ticks, Float64(vmin), Float64(vmax))
 
 function get_tickvalues(ticks::WilkinsonTicks, vmin::Float64, vmax::Float64)
 
-    ticklocations, _ = PlotUtils.optimize_ticks(
-        Float64(vmin), Float64(vmax);
+    ticklocations, _ = PlotUtils.optimize_ticks(Float64(vmin), Float64(vmax);
         extend_ticks = false, strict_span = true, span_buffer = nothing,
         k_min = ticks.k_min,
         k_max = ticks.k_max,

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -1,37 +1,41 @@
 """
-    WilkinsonTicks(k_ideal::Int;
+    WilkinsonTicks(
+        k_ideal::Int;
         k_min = 2, k_max = 10,
         Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
         granularity_weight = 1/4,
         simplicity_weight = 1/6,
         coverage_weight = 1/3,
-        niceness_weight = 1/4)
+        niceness_weight = 1/4
+    )
 
 `WilkinsonTicks` is a thin wrapper over `PlotUtils.optimize_ticks`, the docstring of which is reproduced below:
 
 $(@doc PlotUtils.optimize_ticks)
 """
-function WilkinsonTicks(k_ideal::Int;
+function WilkinsonTicks(
+    k_ideal::Int;
     k_min = 2, k_max = 10,
     Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
     granularity_weight = 1/4,
     simplicity_weight = 1/6,
     coverage_weight = 1/3,
-    niceness_weight = 1/4)
-
+    niceness_weight = 1/4
+)
     if !(0 < k_min <= k_ideal <= k_max)
         error("Invalid tick number specifications k_ideal $k_ideal, k_min $k_min, k_max $k_max")
     end
 
     WilkinsonTicks(k_ideal, k_min, k_max, Q, granularity_weight,
-        simplicity_weight, coverage_weight, niceness_weight)
+                   simplicity_weight, coverage_weight, niceness_weight)
 end
 
 get_tickvalues(ticks::WilkinsonTicks, vmin, vmax) = get_tickvalues(ticks, Float64(vmin), Float64(vmax))
 
 function get_tickvalues(ticks::WilkinsonTicks, vmin::Float64, vmax::Float64)
 
-    ticklocations, _ = PlotUtils.optimize_ticks(Float64(vmin), Float64(vmax);
+    ticklocations, _ = PlotUtils.optimize_ticks(
+        Float64(vmin), Float64(vmax);
         extend_ticks = false, strict_span = true, span_buffer = nothing,
         k_min = ticks.k_min,
         k_max = ticks.k_max,
@@ -40,7 +44,8 @@ function get_tickvalues(ticks::WilkinsonTicks, vmin::Float64, vmax::Float64)
         granularity_weight = ticks.granularity_weight,
         simplicity_weight = ticks.simplicity_weight,
         coverage_weight = ticks.coverage_weight,
-        niceness_weight = ticks.niceness_weight)
+        niceness_weight = ticks.niceness_weight
+    )
 
     ticklocations
 end

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -12,7 +12,8 @@ function WilkinsonTicks(
     end
 
     WilkinsonTicks(
-        k_ideal, k_min, k_max, Q, granularity_weight, simplicity_weight, coverage_weight, niceness_weight
+        k_ideal, k_min, k_max, Q, granularity_weight,
+        simplicity_weight, coverage_weight, niceness_weight
     )
 end
 

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -24,7 +24,7 @@ function WilkinsonTicks(k_ideal::Int;
     end
 
     WilkinsonTicks(k_ideal, k_min, k_max, Q, granularity_weight,
-                   simplicity_weight, coverage_weight, niceness_weight)
+        simplicity_weight, coverage_weight, niceness_weight)
 end
 
 get_tickvalues(ticks::WilkinsonTicks, vmin, vmax) = get_tickvalues(ticks, Float64(vmin), Float64(vmax))

--- a/src/makielayout/ticklocators/wilkinson.jl
+++ b/src/makielayout/ticklocators/wilkinson.jl
@@ -1,11 +1,11 @@
 """
     WilkinsonTicks(k_ideal::Int;
-                   k_min = 2, k_max = 10,
-                   Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
-                   granularity_weight = 1/4,
-                   simplicity_weight = 1/6,
-                   coverage_weight = 1/3,
-                   niceness_weight = 1/4)
+        k_min = 2, k_max = 10,
+        Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
+        granularity_weight = 1/4,
+        simplicity_weight = 1/6,
+        coverage_weight = 1/3,
+        niceness_weight = 1/4)
 
 `WilkinsonTicks` is a thin wrapper over `PlotUtils.optimize_ticks`, the docstring of which is reproduced below:
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -47,11 +47,6 @@ struct LinearTicks
     end
 end
 
-"""
-Wilkinson's algorithm for positioning ticks.
-
-$(@doc PlotUtils.optimize_ticks)
-"""
 struct WilkinsonTicks
     k_ideal::Int
     k_min::Int

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -92,17 +92,15 @@ struct AngularTicks
     end
 end
 
-#=
-"""
-    LogitTicks{T}(linear_ticks::T)
-
-Wraps any other tick object.
-Used to apply a linear tick searching algorithm on a logit-transformed interval.
-"""
-struct LogitTicks{T}
-    linear_ticks::T
-end
-=#
+# """
+#     LogitTicks{T}(linear_ticks::T)
+# 
+# Wraps any other tick object.
+# Used to apply a linear tick searching algorithm on a logit-transformed interval.
+# """
+# struct LogitTicks{T}
+#     linear_ticks::T
+# end
 
 """
     LogTicks{T}(linear_ticks::T)

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -47,6 +47,11 @@ struct LinearTicks
     end
 end
 
+"""
+Wilkinson's algorithm for positioning ticks.
+
+$(@doc PlotUtils.optimize_ticks)
+"""
 struct WilkinsonTicks
     k_ideal::Int
     k_min::Int
@@ -56,7 +61,6 @@ struct WilkinsonTicks
     simplicity_weight::Float64
     coverage_weight::Float64
     niceness_weight::Float64
-    min_px_dist::Float64
 end
 
 """
@@ -93,17 +97,17 @@ struct AngularTicks
     end
 end
 
+#=
+"""
+    LogitTicks{T}(linear_ticks::T)
 
-
-# """
-#     LogitTicks{T}(linear_ticks::T)
-
-# Wraps any other tick object.
-# Used to apply a linear tick searching algorithm on a logit-transformed interval.
-# """
-# struct LogitTicks{T}
-#     linear_ticks::T
-# end
+Wraps any other tick object.
+Used to apply a linear tick searching algorithm on a logit-transformed interval.
+"""
+struct LogitTicks{T}
+    linear_ticks::T
+end
+=#
 
 """
     LogTicks{T}(linear_ticks::T)

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -92,9 +92,11 @@ struct AngularTicks
     end
 end
 
+
+
 # """
 #     LogitTicks{T}(linear_ticks::T)
-# 
+
 # Wraps any other tick object.
 # Used to apply a linear tick searching algorithm on a logit-transformed interval.
 # """


### PR DESCRIPTION
# Description

Fix https://github.com/MakieOrg/Makie.jl/issues/3164.

- supersedes https://github.com/MakieOrg/Makie.jl/pull/3717 by instead dynamically interpolate the docstring from `PlotUtils.optimize_ticks` (default values are identical);
- rename `tickvalues -> ticklocations` for consistency with the aforementioned docstring;
- remove unused `min_px_dist`;
- update `CHANGELOG`.

Resulting docstring:
```julia
help?> Makie.WilkinsonTicks
  Wilkinson's algorithm for positioning ticks.

  optimizeticks(xmin, xmax; extendticks::Bool = false, Q = [(1.0,1.0), (5.0,
  0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)], kmin = 2, kmax = 10, kideal = 5,
  granularityweight = 1/4, simplicityweight = 1/6, coverageweight = 1/3,
  nicenessweight = 1/4, strictspan = true, span_buffer = nothing)

  Find some reasonable values for tick marks.

  This is basically Wilkinson's ad-hoc scoring method that tries to balance
  tight fit around the data, optimal number of ticks, and simple numbers.

  Arguments:
  ==========

    •  xmax:
       The maximum value occurring in the data.

    •  xmin:
       The minimum value occurring in the data.

    •  extend_ticks:
       Determines whether to extend tick computation. Defaults to false.

    •  strict_span:
       True if no ticks should be outside [xmin, xmax]. Defaults to true.

    •  Q:
       A distribution of nice numbers from which labellings are sampled.
       Stored in the form (number, score).

    •  k_min:
       The minimum number of ticks.

    •  k_max:
       The maximum number of ticks.

    •  k_ideal:
       The ideal number of ticks.

    •  granularity_weight:
       Encourages returning roughly the number of labels requested.

    •  simplicity_weight:
       Encourages nicer labeling sequences by preferring step sizes that
       appear earlier in Q. Also rewards labelings that include 0 as a
       way to ground the sequence.

    •  coverage_weight:
       Encourages labelings that do not extend far beyond the range of
       the data, penalizing unnecessary whitespace.

    •  niceness_weight:
       Encourages labellings to produce nice ranges.

  Returns:
  ========

  (ticklocations::Vector{Float64}, x_min, x_max)

  Mathematical details
  ====================

  Wilkinson’s optimization function is defined as the sum of three components.
  If the user requests m labels and a possible labeling has k labels, then the
  components are simplicity, coverage and granularity.

  These components are defined as follows:

:$

  \begin{aligned} &\text{simplicity} = 1 - \frac{i}{|Q|} + \frac{v}{|Q|}\
  &\text{coverage} = \frac{x{max} - x{min}}{\mathrm{label}{max} -
  \mathrm{label}{min}}\ &\text{granularity}= 1 - \frac{\left|k - m\right|}{m}
  \end{aligned} :$

  and the variables here are:

    •  q: element of Q.

    •  i: index of q ∈ Q.

    •  v: 1 if label range includes 0, 0 otherwise.
```

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
