### PR TITLE
allows use of `hidedecorations!(ax)` and `hidespines!(ax)` for `PolarAxis` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `axislegend(ax, "title")` method [#3808](https://github.com/MakieOrg/Makie.jl/pull/3808)
 - Improved thread safety of rendering with CairoMakie (independent `Scene`s only) by locking FreeType handles [#3777](https://github.com/MakieOrg/Makie.jl/pull/3777).
+- Added methods `hidedecorations!`, `hiderdecorations!`, `hidethetadecorations!` and  `hidespines!` for `PolarAxis` axes
 
 ## [0.20.9] - 2024-03-29
 

--- a/docs/reference/blocks/polaraxis.md
+++ b/docs/reference/blocks/polaraxis.md
@@ -125,7 +125,7 @@ The hard limits for `ax.gridz` are `(-10_000, 10_000)` with `9000` being a soft 
 
 ## Hiding spines and decorations
 
-For a `PolarAxis` we interpret the outer ring limitting the plotting are as the
+For a `PolarAxis` we interpret the outer ring limiting the plotting area as the
 axis spine. You can manipulate it with the `spine...` attributes.
 
 \begin{examplefigure}{svg = true}
@@ -170,6 +170,32 @@ ax = PolarAxis(
 )
 
 f
+```
+\end{examplefigure}
+
+We can also hide the spine after creation 
+with `hidespines!(ax)`. And, hide the ticklabels, grid, and/or minorgrid with `hidedecorations!`, `hiderdecorations`, and `hidethetadecorations!`.
+
+\begin{examplefigure}{svg = true}
+```julia
+fig = Figure()
+fullaxis(figpos, title) = PolarAxis(figpos;
+                                    title,
+                                    thetaminorgridvisible=true,
+                                    rminorgridvisible=true,
+                                    rticklabelrotation=deg2rad(-90),
+                                    rticklabelsize=12,
+                                    )
+ax1 = fullaxis(fig[1, 1][1, 1], "all decorations")
+ax2 = fullaxis(fig[1, 1][1, 2], "hide spine")
+hidespines!(ax2)
+ax3 = fullaxis(fig[2, 1][1, 1], "hide r decorations")
+hiderdecorations!(ax3)
+ax4 = fullaxis(fig[2, 1][1, 2], "hide theta decorations")
+hidethetadecorations!(ax4)
+ax5 = fullaxis(fig[2, 1][1, 3], "hide all decorations")
+hidedecorations!(ax5)
+fig
 ```
 \end{examplefigure}
 

--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -55,6 +55,7 @@ export AxisAspect, DataAspect
 export autolimits!, limits!, reset_limits!, rlims!, thetalims!
 export LinearTicks, WilkinsonTicks, MultiplesTicks, IntervalsBetween, LogTicks
 export hidexdecorations!, hideydecorations!, hidezdecorations!, hidedecorations!, hidespines!
+export hiderdecorations!, hidethetadecorations!
 export tight_xticklabel_spacing!, tight_yticklabel_spacing!, tight_ticklabel_spacing!, tightlimits!
 export set_close_to!
 export labelslider!, labelslidergrid!

--- a/src/makielayout/blocks/polaraxis.jl
+++ b/src/makielayout/blocks/polaraxis.jl
@@ -936,3 +936,56 @@ function thetalims!(po::PolarAxis, thetamin::Union{Nothing, Real}, thetamax::Uni
     po.thetalimits[] = (thetamin, thetamax)
     return
 end
+
+"""
+    hiderdecorations!(ax::PolarAxis; ticklabels = true, grid = true, minorgrid = true)
+
+Hide decorations of the r-axis: label, ticklabels, ticks and grid. Keyword
+arguments can be used to disable hiding of certain types of decorations.
+"""
+function hiderdecorations!(ax::PolarAxis; ticklabels = true, grid = true, minorgrid = true)
+    if ticklabels
+        ax.rticklabelsvisible = false
+    end
+    if grid
+        ax.rgridvisible = false
+    end
+    if minorgrid
+        ax.rminorgridvisible = false
+    end
+end
+
+"""
+    hidethetadecorations!(ax::PolarAxis; ticklabels = true, grid = true, minorgrid = true)
+
+Hide decorations of the theta-axis: label, ticklabels, ticks and grid. Keyword
+arguments can be used to disable hiding of certain types of decorations.
+"""
+function hidethetadecorations!(ax::PolarAxis; ticklabels = true, grid = true, minorgrid = true)
+    if ticklabels
+        ax.thetaticklabelsvisible = false
+    end
+    if grid
+        ax.thetagridvisible = false
+    end
+    if minorgrid
+        ax.thetaminorgridvisible = false
+    end
+end
+
+"""
+    hidedecorations!(ax::PolarAxis; ticklabels = true, grid = true, minorgrid = true)
+
+Hide decorations of both r and theta-axis: label, ticklabels, ticks and grid.
+Keyword arguments can be used to disable hiding of certain types of decorations.
+
+See also [`hiderdecorations!`], [`hidethetadecorations!`], [`hidezdecorations!`]
+"""
+function hidedecorations!(ax::PolarAxis; ticklabels = true, grid = true, minorgrid = true)
+    hiderdecorations!(ax; ticklabels = ticklabels, grid = grid, minorgrid = minorgrid,)
+    hidethetadecorations!(ax; ticklabels = ticklabels, grid = grid, minorgrid = minorgrid)
+end
+
+function hidespines!(ax::PolarAxis)
+    ax.spinevisible = false
+end


### PR DESCRIPTION
# Description

Fixes # (issue)

allows use of `hidedecorations!(ax)` and `hidespines!(ax)` for `PolarAxis` blocks

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
