### PR TITLE
Remove color type restrictions for potentially array-valued colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## [Unreleased]
 
-- Support intervals for specifying axis limits [#3696](https://github.com/MakieOrg/Makie.jl/pull/3696)
-- Add recipes for plotting intervals to `Band`, `Rangebars`, `H/VSpan` [3695](https://github.com/MakieOrg/Makie.jl/pull/3695)
-- Document `WilkinsonTicks` [#3819](https://github.com/MakieOrg/Makie.jl/pull/3819).
-- Add `axislegend(ax, "title")` method [#3808](https://github.com/MakieOrg/Makie.jl/pull/3808).
+- Loosened type restrictions for potentially array-valued colors in `Axis` attributes like `xticklabelcolor` [#3826](https://github.com/MakieOrg/Makie.jl/pull/3826).
+- Added support for intervals for specifying axis limits [#3696](https://github.com/MakieOrg/Makie.jl/pull/3696)
+- Added recipes for plotting intervals to `Band`, `Rangebars`, `H/VSpan` [3695](https://github.com/MakieOrg/Makie.jl/pull/3695)
+- Documented `WilkinsonTicks` [#3819](https://github.com/MakieOrg/Makie.jl/pull/3819).
+- Added `axislegend(ax, "title")` method [#3808](https://github.com/MakieOrg/Makie.jl/pull/3808).
 - Improved thread safety of rendering with CairoMakie (independent `Scene`s only) by locking FreeType handles [#3777](https://github.com/MakieOrg/Makie.jl/pull/3777).
-- Added methods `hidedecorations!`, `hiderdecorations!`, `hidethetadecorations!` and  `hidespines!` for `PolarAxis` axes
+- Added methods `hidedecorations!`, `hiderdecorations!`, `hidethetadecorations!` and  `hidespines!` for `PolarAxis` axes [#3823](https://github.com/MakieOrg/Makie.jl/pull/3823).
 
 ## [0.20.9] - 2024-03-29
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -291,9 +291,9 @@ end
         "The font family of the yticklabels."
         yticklabelfont = :regular
         "The color of xticklabels."
-        xticklabelcolor::RGBAf = @inherit(:textcolor, :black)
+        xticklabelcolor = @inherit(:textcolor, :black)
         "The color of yticklabels."
-        yticklabelcolor::RGBAf = @inherit(:textcolor, :black)
+        yticklabelcolor = @inherit(:textcolor, :black)
         "The font size of the xticklabels."
         xticklabelsize::Float64 = @inherit(:fontsize, 16f0)
         "The font size of the yticklabels."
@@ -335,9 +335,9 @@ end
         "The width of the ytick marks."
         ytickwidth::Float64 = 1f0
         "The color of the xtick marks."
-        xtickcolor::RGBAf = RGBf(0, 0, 0)
+        xtickcolor = RGBf(0, 0, 0)
         "The color of the ytick marks."
-        ytickcolor::RGBAf = RGBf(0, 0, 0)
+        ytickcolor = RGBf(0, 0, 0)
         "Controls if the x ticks and minor ticks are mirrored on the other side of the Axis."
         xticksmirrored::Bool = false
         "Controls if the y ticks and minor ticks are mirrored on the other side of the Axis."
@@ -365,9 +365,9 @@ end
         "The width of the y grid lines."
         ygridwidth::Float64 = 1f0
         "The color of the x grid lines."
-        xgridcolor::RGBAf = RGBAf(0, 0, 0, 0.12)
+        xgridcolor = RGBAf(0, 0, 0, 0.12)
         "The color of the y grid lines."
-        ygridcolor::RGBAf = RGBAf(0, 0, 0, 0.12)
+        ygridcolor = RGBAf(0, 0, 0, 0.12)
         "The linestyle of the x grid lines."
         xgridstyle = nothing
         "The linestyle of the y grid lines."
@@ -381,9 +381,9 @@ end
         "The width of the y minor grid lines."
         yminorgridwidth::Float64 = 1f0
         "The color of the x minor grid lines."
-        xminorgridcolor::RGBAf = RGBAf(0, 0, 0, 0.05)
+        xminorgridcolor = RGBAf(0, 0, 0, 0.05)
         "The color of the y minor grid lines."
-        yminorgridcolor::RGBAf = RGBAf(0, 0, 0, 0.05)
+        yminorgridcolor = RGBAf(0, 0, 0, 0.05)
         "The linestyle of the x minor grid lines."
         xminorgridstyle = nothing
         "The linestyle of the y minor grid lines."
@@ -582,7 +582,7 @@ end
         "The tick width of x minor ticks"
         xminortickwidth::Float64 = 1f0
         "The tick color of x minor ticks"
-        xminortickcolor::RGBAf = :black
+        xminortickcolor = :black
         """
         The tick locator for the minor ticks of the x axis.
 
@@ -601,7 +601,7 @@ end
         "The tick width of y minor ticks"
         yminortickwidth::Float64 = 1f0
         "The tick color of y minor ticks"
-        yminortickcolor::RGBAf = :black
+        yminortickcolor = :black
         """
         The tick locator for the minor ticks of the y axis.
 


### PR DESCRIPTION
Makes this kind of thing possible again (which is not advisable for situations where tick numbers may change, but for static plots that doesn't matter):

```julia
f = Figure()
ax = Axis(
    f[1, 1],
    xticklabelcolor = [:red, :green, :blue],
)
f
```

<img width="612" alt="grafik" src="https://github.com/MakieOrg/Makie.jl/assets/22495855/e54546c2-ecf3-40cf-8f05-1da5241e4683">

The strong typing was at some point intended to help performance, but I think that's just a drop in the bucket anyway to tighten these few observables, given how many untyped ones we have in the whole system.