### PR TITLE
doc: Add `theme_latexfonts` to predefined_themes.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@
 - Fixed some errors around dynamic changes of `ax.xscale` or `ax.yscale` [#3084](https://github.com/MakieOrg/Makie.jl/pull/3084)
 - Improved Barplot Label Alignment [#3160](https://github.com/MakieOrg/Makie.jl/issues/3160).
 - Fixed regression in determining axis limits [#3179](https://github.com/MakieOrg/Makie.jl/pull/3179)
-- Added a theme `theme_latexfonts` that uses the latex font family as default fonts [#3147](https://github.com/MakieOrg/Makie.jl/pull/3147).
+- Added a theme `theme_latexfonts` that uses the latex font family as default fonts [#3147](https://github.com/MakieOrg/Makie.jl/pull/3147), [#3180](https://github.com/MakieOrg/Makie.jl/pull/3180).
 - Upgrades `StableHashTraits` from 0.3 to 1.0
 
 ## [0.19.8] - 2023-08-15

--- a/docs/explanations/theming.md
+++ b/docs/explanations/theming.md
@@ -11,6 +11,8 @@ update_theme!
 with_theme
 ```
 
+There are also [predefined themes](\reflink{Predefined themes}) that may form a useful starting point.
+
 ## set_theme!
 
 You can call `set_theme!(theme; kwargs...)` to change the current default theme to `theme` and override or add attributes given by `kwargs`.

--- a/docs/explanations/theming/predefined_themes.md
+++ b/docs/explanations/theming/predefined_themes.md
@@ -118,3 +118,13 @@ with_theme(demofigure, theme_light())
 with_theme(demofigure, theme_dark())
 ```
 \end{examplefigure}
+
+## theme_latexfonts
+
+See also [more general documentation on Makie and LaTeX](\reflink{LaTeX}).
+
+\begin{examplefigure}{}
+```julia
+with_theme(demofigure, theme_latexfonts())
+```
+\end{examplefigure}


### PR DESCRIPTION
# Description

The theme `theme_latexfonts` is documented with other tips for LaTeX but is missing from the page on predefined themes.  Add it there.

Also:

- add a more prominent link from the theming page to the page for predefined themes.
- add the continuation PR (3180) for `theme_latexfonts` to `CHANGELOG.md`

## Type of change

- [x] Documentation

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
  - No new feature or breaking change, so did not add to changelog.
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
  - N/A
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
  - N/A