### PR TITLE
CairoMakie: Allow restricting PDF version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- CairoMakie: Add argument `pdf_version` to restrict the PDF version when saving a figure as a PDF [#3845](https://github.com/MakieOrg/Makie.jl/pull/3845).
 
 ## [0.21.0] - 2024-05-21
 

--- a/CairoMakie/src/cairo-extension.jl
+++ b/CairoMakie/src/cairo-extension.jl
@@ -74,3 +74,10 @@ function get_render_type(surface::Cairo.CairoSurface)
     typ == Cairo.CAIRO_SURFACE_TYPE_IMAGE && return IMAGE
     return IMAGE # By default assume that the render type is IMAGE
 end
+
+function restrict_pdf_version!(surface::Cairo.CairoSurface, v::Integer)
+    @assert surface.ptr != C_NULL
+    0 ≤ v ≤ 3 || throw(ArgumentError("version must be 0, 1, 2, or 3 (received $v)"))
+    ccall((:cairo_pdf_surface_restrict_to_version, Cairo.libcairo), Nothing,
+          (Ptr{UInt8}, Int32), surface.ptr, v)
+end

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -198,3 +198,37 @@ functions = [:volume, :volume!, :uv_mesh]
     missing_images, scores = ReferenceTests.record_comparison(recording_dir)
     ReferenceTests.test_comparison(scores; threshold = 0.05)
 end
+
+@testset "PdfVersion" begin
+    @test CairoMakie.pdfversion("1.4") === CairoMakie.PDFv14
+    @test CairoMakie.pdfversion("1.5") === CairoMakie.PDFv15
+    @test CairoMakie.pdfversion("1.6") === CairoMakie.PDFv16
+    @test CairoMakie.pdfversion("1.7") === CairoMakie.PDFv17
+    @test_throws ArgumentError CairoMakie.pdfversion("foo")
+end
+
+@testset "restrict PDF version" begin
+    magic_number(filename) = open(filename) do f
+        return String(read(f, sizeof("%PDF-X.Y")))
+    end
+
+    filename = "$(tempname()).pdf"
+
+    try
+        save(filename, Figure(), pdf_version=nothing)
+        @test startswith(magic_number(filename), "%PDF-")
+    finally
+        rm(filename)
+    end
+
+    for version in ["1.4", "1.5", "1.6", "1.7"]
+        try
+            save(filename, Figure(), pdf_version=version)
+            @test magic_number(filename) == "%PDF-$version"
+        finally
+            rm(filename)
+        end
+    end
+
+    @test_throws ArgumentError save(filename, Figure(), pdf_version="foo")
+end

--- a/docs/explanations/backends/cairomakie.md
+++ b/docs/explanations/backends/cairomakie.md
@@ -62,3 +62,13 @@ v = rand(10,2)
 scatter(v[:,1], v[:,2], rasterize = 10, markersize = 30.0)
 ```
 \end{examplefigure}
+
+#### PDF version
+
+The version of output PDFs can be restricted via the `pdf_version` argument of the screen config. Conveniently, it can be also passed as an argument of the `save` function:
+```julia
+using CairoMakie
+fig = Figure()
+# ...
+save("figure.pdf", fig, pdf_version="1.4")
+```

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -89,7 +89,8 @@ const MAKIE_DEFAULT_THEME = Attributes(
         pt_per_unit = 0.75,
         antialias = :best,
         visible = true,
-        start_renderloop = false
+        start_renderloop = false,
+        pdf_version = nothing
     ),
 
     GLMakie = Attributes(


### PR DESCRIPTION
# Description

This PR allows users to restrict the version of an output PDF like this:
```julia
fig = Figure()
ax = Axis(fig[1, 1])
x = range(0, 10, length=100)
y = sin.(x)
save("version_1-4.pdf", fig, pdf_version="1.4")
save("version_1-7.pdf", fig, pdf_version="1.7")

shell> file version_1-4.pdf
version_1-4.pdf: PDF document, version 1.4, 1 page(s)

shell> file version_1-7.pdf
version_1-7.pdf: PDF document, version 1.7
```

This feature was discussed on [Discourse](https://discourse.julialang.org/t/cairomakie-restrict-pdf-version/113939) (and also [earlier](https://discourse.julialang.org/t/pdf-version-used-when-saving-a-figure-in-cairomakie/102282))

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.

I need guidance regarding documentation (where to best put this) ~and testing (I am not sure how to check a PDF's version in Julia)~. 

Also I was thinking that the `CAIRO_PDF_VERSION_*` constants together with `restrict_pdf_version!` should perhaps go to Cairo.jl. What do you think?