### PR TITLE
[WIP] Better handling for `missing` in colors

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -3,7 +3,8 @@
 ################################################################################
 
 function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Union{Lines, LineSegments}))
-    @get_attribute(primitive, (color, linewidth, linestyle))
+    @get_attribute(primitive, (calculated_colors, linewidth, linestyle))
+    color = Makie.to_color(calculated_colors)
     ctx = screen.context
     model = primitive[:model][]
     positions = primitive[1][]
@@ -940,7 +941,7 @@ function draw_mesh2D(scene, screen, @nospecialize(plot), @nospecialize(mesh))
     vs = project_position(scene, transform_func, space, decompose(Point, mesh), model)
     fs = decompose(GLTriangleFace, mesh)::Vector{GLTriangleFace}
     uv = decompose_uv(mesh)::Union{Nothing, Vector{Vec2f}}
-    color = hasproperty(mesh, :color) ? to_color(mesh.color) : plot.calculated_colors[]
+    color = Makie.to_color(plot.calculated_colors[])
     cols = per_face_colors(color, nothing, fs, nothing, uv)
     return draw_mesh2D(screen, cols, vs, fs)
 end
@@ -998,7 +999,7 @@ function draw_mesh3D(scene, screen, attributes, mesh; pos = Vec4f(0), scale = 1f
     meshuvs = texturecoordinates(mesh)::Union{Nothing, Vector{Vec2f}}
 
     # Priorize colors of the mesh if present
-    color = hasproperty(mesh, :color) ? mesh.color : to_value(attributes.calculated_colors)
+    color = Makie.to_color(to_value(attributes.calculated_colors))
 
     per_face_col = per_face_colors(color, matcap, meshfaces, meshnormals, meshuvs)
 
@@ -1174,10 +1175,6 @@ end
 function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Surface))
     # Pretend the surface plot is a mesh plot and plot that instead
     mesh = Makie.surface2mesh(primitive[1][], primitive[2][], primitive[3][])
-    old = primitive[:color]
-    if old[] === nothing
-        primitive[:color] = primitive[3]
-    end
     if !haskey(primitive, :faceculling)
         primitive[:faceculling] = Observable(-10)
     end

--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -179,8 +179,8 @@ end
 """
     ColorMappingType
 
-* categorical: there are n categories, and n colors are assigned to each category
-* banded: there are ranges edge_start..edge_end, inside which values are mapped to one color
+* categorical: there are `n` categories, and a color is assigned to each category
+* banded: there are ranges `edge_start..edge_end`, inside which values are mapped to one color
 * continuous: colors are mapped continuously to values
 """
 @enum ColorMappingType categorical banded continuous

--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -132,7 +132,21 @@ apply_scale(scale::AbstractObservable, x) = lift(apply_scale, scale, x)
 apply_scale(::Union{Nothing,typeof(identity)}, x) = x  # noop
 apply_scale(scale, x) = broadcast(scale, x)
 
-function numbers_to_colors(numbers::Union{AbstractArray{<:Number},Number}, primitive)
+# Missing handling for `numbers_to_colors`
+numbers_to_colors(::Missing, primitive) = get_attribute(primitive, :nan_color, RGBAf(0,0,0,0))::RGBAf
+function numbers_to_colors(numbers::Union{AbstractArray{Missing, N}, Missing},
+                           colormap, colorscale, colorrange::Vec2,
+                           lowclip::Union{Automatic,RGBAf},
+                           highclip::Union{Automatic,RGBAf},
+                           nan_color::RGBAf)::Union{Array{RGBAf, N},RGBAf} where {N}
+    if numbers isa AbstractArray
+        return fill(nan_color, axes(numbers))
+    else # numbers isa single
+        return nan_color
+    end
+end
+
+function numbers_to_colors(numbers::AbstractArray{<: Union{<: Number, Missing}, N}, primitive) where N
     colormap = get_attribute(primitive, :colormap)::Vector{RGBAf}
     _colorrange = get_attribute(primitive, :colorrange)::Union{Nothing, Vec2f}
     colorscale = get_attribute(primitive, :colorscale)
@@ -151,18 +165,18 @@ function numbers_to_colors(numbers::Union{AbstractArray{<:Number},Number}, primi
     return numbers_to_colors(numbers, colormap, colorscale, colorrange, lowclip, highclip, nan_color)
 end
 
-function numbers_to_colors(numbers::Union{AbstractArray{<:Number, N},Number},
-                           colormap, colorscale, colorrange::Vec2,
-                           lowclip::Union{Automatic,RGBAf},
-                           highclip::Union{Automatic,RGBAf},
-                           nan_color::RGBAf)::Union{Array{RGBAf, N},RGBAf} where {N}
+function numbers_to_colors(numbers::Union{AbstractArray{<:Union{Missing, <: Number}, N},Union{Missing, <: Number}},
+                            colormap, colorscale, colorrange::Vec2,
+                            lowclip::Union{Automatic,RGBAf},
+                            highclip::Union{Automatic,RGBAf},
+                            nan_color::RGBAf)::Union{Array{RGBAf, N},RGBAf} where {N}
     cmin, cmax = colorrange
     scaled_cmin = apply_scale(colorscale, cmin)
     scaled_cmax = apply_scale(colorscale, cmax)
 
     return map(numbers) do number
         scaled_number = apply_scale(colorscale, Float64(number))  # ints don't work in interpolated_getindex
-        if isnan(scaled_number)
+        if ismissing(scaled_number) || isnan(scaled_number)
             return nan_color
         elseif !isnothing(lowclip) && scaled_number < scaled_cmin
             return lowclip
@@ -172,7 +186,8 @@ function numbers_to_colors(numbers::Union{AbstractArray{<:Number, N},Number},
         return interpolated_getindex(
             colormap,
             scaled_number,
-            (scaled_cmin, scaled_cmax))
+            (scaled_cmin, scaled_cmax)
+        )
     end
 end
 
@@ -245,7 +260,7 @@ colormapping_type(@nospecialize(colormap)) = continuous
 colormapping_type(::PlotUtils.CategoricalColorGradient) = banded
 colormapping_type(::Categorical) = categorical
 
-
+# Create the Observables for a `ColorMapping` struct.
 function _colormapping(
         color_tight::Observable{V},
         @nospecialize(colors_obs),
@@ -262,7 +277,7 @@ function _colormapping(
     raw_colormap = Observable(RGBAf[]; ignore_equal_values=true)
     mapping = Observable{Union{Nothing,Vector{Float64}}}(nothing; ignore_equal_values=true)
     colorscale = convert(Observable{Function}, colorscale)
-
+    # This function only updates the colormap observables, not the raw colors themselves.
     function update_colors(cmap, a)
         colors = to_colormap(cmap)
         raw_colors = _to_colormap(cmap) # dont do the scaling from cgrad
@@ -337,8 +352,9 @@ function ColorMapping(
                          colorscale, alpha, lowclip, highclip, nan_color, color_mapping_type)
 end
 
-function assemble_colors(c::AbstractArray{<:Number}, @nospecialize(color), @nospecialize(plot))
-    return ColorMapping(c, color, plot.colormap, plot.colorrange, plot.colorscale, plot.alpha, plot.lowclip,
+function assemble_colors(c::AbstractArray{<:Union{Missing, <: Number}}, @nospecialize(color), @nospecialize(plot))
+    # TODO: this is a hack, what's a better method?
+    return ColorMapping(replace(c, missing => NaN), @lift(replace($color, missing => NaN)), plot.colormap, plot.colorrange, plot.colorscale, plot.alpha, plot.lowclip,
                     plot.highclip, plot.nan_color)
 end
 
@@ -349,6 +365,10 @@ end
 function Base.get(c::ColorMapping, value::Number)
     return numbers_to_colors([value], c.colormap[], c.scale[], c.colorrange_scaled[], lowclip(c)[],
                              highclip(c)[], c.nan_color[])[1]
+end
+
+function Base.get(c::ColorMapping, ::Missing)
+    return c.nan_color[]
 end
 
 function assemble_colors(colortype, color, plot)

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -195,6 +195,7 @@ function isfinite_rect(x::Rect{N}, dim::Int) where N
     end
 end
 _isfinite(x) = isfinite(x)
+_isfinite(::Missing) = false
 _isfinite(x::VecTypes) = all(isfinite, x)
 
 finite_min(a, b) = isfinite(a) ? (isfinite(b) ? min(a, b) : a) : (isfinite(b) ? b : a)

--- a/test/missing_support.jl
+++ b/test/missing_support.jl
@@ -1,0 +1,34 @@
+using Makie
+
+@testset "Missings in colors" begin
+    @testset "Grid-like plots" begin
+        @testset "Direct in heatmap" begin
+            data = Union{Missing, Float64}[missing 2; 3 4]
+            @test_nowarn heatmap(data)
+            f, a, p = heatmap(data; nan_color = RGBAf(1, 0, 0, 1))
+            colors = Makie.to_color(p.calculated_colors[])
+            @test colors[1] == RGBAf(1, 0, 0, 1)
+        end
+        @testset "Color in surface" begin
+            data = Union{Missing, Float64}[missing 2 3; 3 4 5; 6 7 8]
+            @test_nowarn surface(rand(3, 3); color = data)
+            f, a, p = surface(rand(3, 3); color = data)
+            colors = Makie.to_color(p.calculated_colors[])
+            @test colors[1] == RGBAf(0, 0, 0, 0)
+        end
+    end
+
+    @testset "PointBased" begin
+        data = Vector{Union{Float64, Missing}}(undef, 100)
+        data .= rand(100)
+        data[50] = missing
+
+        @test_nowarn lines(rand(100); color = data, nan_color = RGBAf(1, 0, 0, 1))
+        f, a, p = lines(rand(100); color = data, nan_color = RGBAf(1, 0, 0, 1))
+        colors = Makie.to_color(p.calculated_colors[])
+        @test colors[50] == RGBAf(1, 0, 0, 1)
+    end
+end
+
+@testset "Missings in data" begin
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ using Makie: volume
     include("barplot.jl")
     include("bezier.jl")
     include("hist.jl")
+    include("missing_support.jl")
 
     # TODO: move some things in here
     include("convert_arguments.jl")


### PR DESCRIPTION
# Description

This PR aims to support users passing `Array{Union{Missing, <: Number}}` to a plot's `color` argument in all circumstances.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [X] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
