### PR TITLE
Support glow for text

### DIFF
--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -499,6 +499,10 @@ Plots one or multiple texts passed via the `text` keyword.
     markerspace = :pixel
     "Controls whether the model matrix (without translation) applies to the glyph itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the text glyphs.)"
     transform_marker = false
+    "Sets the color of the glow effect around the text."
+    glowcolor = (:black, 0.0)
+    "Sets the size of a glow effect around the text."
+    glowwidth = 0.0
     "The offset of the text from the given position in `markerspace` units."
     offset = (0.0, 0.0)
     "Specifies a linewidth limit for text. If a word overflows this limit, a newline is inserted before it. Negative numbers disable word wrapping."

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -394,6 +394,14 @@ end
     meshscatter(positions, color=RGBAf(0.9, 0.2, 0.4, 1), markersize=0.05)
 end
 
+@reference_test "Text glow and overdraw" begin
+    p1 = Point3f(0,0,0)
+    p2 = Point3f(1,0,0)
+    meshscatter([p1, p2]; markersize=0.3, color=[:purple, :yellow])
+    text!(p1; text="A", align=(:center, :center), glowwidth=10.0, glowcolor=:white, color=:black, fontsize=40, overdraw=true)
+    text!(p2; text="B", align=(:center, :center), glowwidth=20.0, glowcolor=(:black, 0.6), color=:white, fontsize=40, overdraw=true)
+end
+
 @reference_test "Animated surface and wireframe" begin
     function xy_data(x, y)
         r = sqrt(x^2 + y^2)

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -397,9 +397,10 @@ end
 @reference_test "Text glow and overdraw" begin
     p1 = Point3f(0,0,0)
     p2 = Point3f(1,0,0)
-    meshscatter([p1, p2]; markersize=0.3, color=[:purple, :yellow])
-    text!(p1; text="A", align=(:center, :center), glowwidth=10.0, glowcolor=:white, color=:black, fontsize=40, overdraw=true)
-    text!(p2; text="B", align=(:center, :center), glowwidth=20.0, glowcolor=(:black, 0.6), color=:white, fontsize=40, overdraw=true)
+    f, ax, pl = meshscatter([p1, p2]; markersize=0.3, color=[:purple, :yellow])
+    text!(ax, p1; text="A", align=(:center, :center), glowwidth=10.0, glowcolor=:white, color=:black, fontsize=40, overdraw=true)
+    text!(ax, p2; text="B", align=(:center, :center), glowwidth=20.0, glowcolor=(:black, 0.6), color=:white, fontsize=40, overdraw=true)
+    f
 end
 
 @reference_test "Animated surface and wireframe" begin


### PR DESCRIPTION
# Description

The upgrade from Makie 0.20 to 0.21 broke support for `glowcolor` and `glowwidth` in text. This can apparently be fixed by updating the text recipe to include these items (as suggested by @jkrumbiegel and @asinghvi17).

This feature can be used to enhance the legibility of labels. For example,

```jl
p1 = Point3f(0,0,0)
p2 = Point3f(1,0,0)
meshscatter([p1, p2]; markersize=0.3, color=[:purple, :yellow])
text!(p1; text="A", align=(:center, :center), glowwidth=10.0, glowcolor=:white, color=:black, fontsize=40, overdraw=true)
text!(p2; text="B", align=(:center, :center), glowwidth=20.0, glowcolor=(:black, 0.6), color=:white, fontsize=40, overdraw=true)
```

generates the image below:

<img width="322" alt="image" src="https://github.com/MakieOrg/Makie.jl/assets/290205/9e2c9533-5d02-4ee8-9a0b-fe812b57ffdf">

~~I would kindly appreciate your help in completing the checklist items below: unit tests, reference images, etc.~~ I have updated the PR to use the above image as a test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
