### PR TITLE
propagate args as-is to convert_arguments(trait, args...)

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -16,9 +16,6 @@ function convert_arguments(T::Type{<:AbstractPlot}, args...; kw...)
     # Meaning, it needs to be a conversion trait, or it needs single_convert_arguments or expand_dimensions
     CT = conversion_trait(T, args...)
 
-    # Try to expand dimensions first, as this is the most basic step!
-    expanded = expand_dimensions(CT, args...)
-    !isnothing(expanded) && return convert_arguments(T, expanded...; kw...)
     # Try single argument convert after
     arguments_converted = map(convert_single_argument, args)
     if arguments_converted !== args

--- a/test/convert_arguments.jl
+++ b/test/convert_arguments.jl
@@ -66,6 +66,10 @@ end
     @test_throws ArgumentError heatmap(1im)
 end
 
+# custom vector type to ensure that the conversion can be overriden for vectors
+struct MyConvVector <: AbstractVector{Float64} end
+Makie.convert_arguments(::PointBased, ::MyConvVector) = ([Point(10, 20)],)
+
 @testset "convert_arguments" begin
     #=
     TODO:
@@ -227,6 +231,8 @@ end
 
                         @test apply_conversion(CT, m2)  isa Tuple{Vector{Point2{T_out}}}
                         @test apply_conversion(CT, m3)  isa Tuple{Vector{Point3{T_out}}}
+
+                        @test apply_conversion(CT, MyConvVector()) == ([Point(10, 20)],)
                     end
                 end
 


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/Makie.jl/issues/3847
The Makie 0.21 version doesn't propagate `convert_arguments` arguments to `convert_arguments(trait)` directly, making some common conversions impossible (#3847 for example). Turns out, the fix (this PR) is pretty simple.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added unit tests for new algorithms, conversion methods, etc.