### PR TITLE
fix keyboard entry for WGLMakie Textbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - CairoMakie: Fix broken SVGs when using non-interpolated image primitives, for example Colorbars, with recent Cairo versions [#3967](https://github.com/MakieOrg/Makie.jl/pull/3967).
 - CairoMakie: Add argument `pdf_version` to restrict the PDF version when saving a figure as a PDF [#3845](https://github.com/MakieOrg/Makie.jl/pull/3845).
 - CairoMakie: Fix incorrect scaling factor for SVGs with Cairo_jll 1.18 [#3964](https://github.com/MakieOrg/Makie.jl/pull/3964).
+- Fixed use of Textbox from Bonito [#3924](https://github.com/MakieOrg/Makie.jl/pull/3924)
 
 ## [0.21.2] - 2024-05-22
 

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -85,11 +85,14 @@ function connect_scene_events!(scene::Scene, comm::Observable)
                 e.scroll[] = Float64.((sign.(scroll)...,))
             end
             @handle msg.keydown begin
-                button = code_to_keyboard(keydown)
+                button = code_to_keyboard(keydown[1])
                 # don't add unknown buttons...we can't work with them
                 # and they won't get removed
                 if button != Keyboard.unknown
                     e.keyboardbutton[] = KeyEvent(button, Keyboard.press)
+                end
+                if length(keydown[2])==1 && isascii(keydown[2])
+                    e.unicode_input[] = keydown[2][1]
                 end
             end
             @handle msg.keyup begin

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -22903,7 +22903,10 @@ function add_canvas_events(screen, comm, resize_to) {
     canvas.addEventListener("wheel", wheel);
     function keydown(event) {
         comm.notify({
-            keydown: event.code
+            keydown: [
+                event.code,
+                event.key
+            ]
         });
         return false;
     }

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -276,7 +276,7 @@ function add_canvas_events(screen, comm, resize_to) {
 
     function keydown(event) {
         comm.notify({
-            keydown: event.code,
+            keydown: [event.code, event.key],
         });
         return false;
     }


### PR DESCRIPTION
# Description

fixes https://github.com/SimonDanisch/Bonito.jl/issues/154

users can now enter text into a Makie.Textbox from a web app created with Bonito.jl

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
