### PR TITLE
Corrects isovalue/isorange docstrings in basic volume plot

### DIFF
--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -269,9 +269,9 @@ Available algorithms are:
     ) begin
     "Sets the volume algorithm that is used."
     algorithm = :mip
-    "Sets the range of values picked up by the IsoValue algorithm."
-    isovalue = 0.5
     "Sets the target value for the IsoValue algorithm."
+    isovalue = 0.5
+    "Sets the range of values picked up by the IsoValue algorithm."
     isorange = 0.05
     "Sets whether the volume data should be sampled with interpolation."
     interpolate = true


### PR DESCRIPTION
# Description

It seems like the docstrings for the `isovalue` and `isorange` arguments were inadvertently swapped in the docstring for the `volume` recipe. This PR just swaps them back.

Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [x] Fix docstring typo

## Checklist

- [x] Added or changed relevant sections in the documentation
