### PR TITLE
Force Observable{Any} in `apply_expand_dimensions`

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -155,7 +155,7 @@ function apply_expand_dimensions(trait, args, args_obs, deregister)
     if isnothing(expanded)
         return args_obs
     else
-        new_obs = map(Observable, expanded)
+        new_obs = map(Observable{Any}, expanded)
         fs = onany(args_obs...) do args...
             expanded = expand_dimensions(trait, args...)
             for (obs, arg) in zip(new_obs, expanded)

--- a/test/dim-converts.jl
+++ b/test/dim-converts.jl
@@ -91,3 +91,14 @@ end
         test_cleanup(dates)
     end
 end
+
+@testset "Type constraints (#3938)" begin
+    # Integers cannot be converted to Irrationals,
+    # so if the type of the observable is tightened
+    # somewhere within the pipeline, there should be a 
+    # conversion error!
+    obs = Observable{Vector}([π, π])
+    f, a, p = plot(obs)
+    obs.val = [1, 1] # Integers are not convertible to Irrational, so if the type was "solidified" here, there should be a conversion error
+    @test_nowarn notify(obs)
+end


### PR DESCRIPTION
# Description

Fixes #3938 

This is a pretty small change, just specifies that we're creating `Observable{Any}` out of the values returned by `expand_dimensions`.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Added unit tests for new algorithms, conversion methods, etc.