### PR TITLE
Fix broken SVGs by not using `Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- CairoMakie: Fix broken SVGs when using non-interpolated image primitives, for example Colorbars, with recent Cairo versions [#3967](https://github.com/MakieOrg/Makie.jl/pull/3967).
 - CairoMakie: Add argument `pdf_version` to restrict the PDF version when saving a figure as a PDF [#3845](https://github.com/MakieOrg/Makie.jl/pull/3845).
 - CairoMakie: Fix incorrect scaling factor for SVGs with Cairo_jll 1.18 [#3964](https://github.com/MakieOrg/Makie.jl/pull/3964).
 

--- a/CairoMakie/src/infrastructure.jl
+++ b/CairoMakie/src/infrastructure.jl
@@ -143,7 +143,7 @@ end
 #   instead of the whole Scene
 # - Recognize when a screen is an image surface, and set scale to render the plot
 #   at the scale of the device pixel
-function draw_plot_as_image(scene::Scene, screen::Screen, primitive::Plot, scale::Number = 1)
+function draw_plot_as_image(scene::Scene, screen::Screen{RT}, primitive::Plot, scale::Number = 1) where RT
     # you can provide `p.rasterize = scale::Int` or `p.rasterize = true`, both of which are numbers
 
     # Extract scene width in device indepentent units
@@ -163,8 +163,11 @@ function draw_plot_as_image(scene::Scene, screen::Screen, primitive::Plot, scale
     # Cairo.scale(screen.context, w / scr.surface.width, h / scr.surface.height)
     Cairo.set_source_surface(screen.context, scr.surface, 0, 0)
     p = Cairo.get_source(scr.context)
-    # this is needed to avoid blurry edges
-    Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+    if RT !== SVG
+        # this is needed to avoid blurry edges in png renderings, however since Cairo 1.18 this
+        # setting seems to create broken SVGs
+        Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+    end
     # Set filter doesn't work!?
     Cairo.pattern_set_filter(p, Cairo.FILTER_BILINEAR)
     Cairo.fill(screen.context)

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -782,7 +782,7 @@ premultiplied_rgba(a::AbstractArray{<:Color}) = RGBA.(a)
 premultiplied_rgba(r::RGBA) = RGBA(r.r * r.alpha, r.g * r.alpha, r.b * r.alpha, r.alpha)
 premultiplied_rgba(c::Colorant) = premultiplied_rgba(RGBA(c))
 
-function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Union{Heatmap, Image}))
+function draw_atomic(scene::Scene, screen::Screen{RT}, @nospecialize(primitive::Union{Heatmap, Image})) where RT
     ctx = screen.context
     image = primitive[3][]
     xs, ys = primitive[1][], primitive[2][]
@@ -858,8 +858,11 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Unio
         Cairo.scale(ctx, w / s.width, h / s.height)
         Cairo.set_source_surface(ctx, s, 0, 0)
         p = Cairo.get_source(ctx)
-        # this is needed to avoid blurry edges
-        Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+        if RT !== SVG
+            # this is needed to avoid blurry edges in png renderings, however since Cairo 1.18 this
+            # setting seems to create broken SVGs
+            Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)
+        end
         filt = interpolate ? Cairo.FILTER_BILINEAR : Cairo.FILTER_NEAREST
         Cairo.pattern_set_filter(p, filt)
         Cairo.fill(ctx)


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/3016 for me on Firefox and Chrome and makes such SVGs editable in Inkscape. Firefox would not show SVGs with a continuous colorbar at all before and Chrome would glitch. The command `Cairo.pattern_set_extend(p, Cairo.EXTEND_PAD)` was present only because otherwise you'd get blurry edges when rendering pngs. Removing it for SVG surfaces does not seem to introduce any adverse effects. The effect of the pattern extend must have changed with some of the more recent Cairo updates.