### PR TITLE
Don't assume poly always has two children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## [Unreleased]
 
-- Fixes for Menu and DataInspector [#3975](https://github.com/MakieOrg/Makie.jl/pull/3975)
-- Add line-loop detection and rendering to GLMakie and WGLMakie [#3907](https://github.com/MakieOrg/Makie.jl/pull/3907)
+- Allow CairoMakie to render `poly` overloads that internally don't use two child plots [#3986](https://github.com/MakieOrg/Makie.jl/pull/3986).
+- Fixes for Menu and DataInspector [#3975](https://github.com/MakieOrg/Makie.jl/pull/3975).
+- Add line-loop detection and rendering to GLMakie and WGLMakie [#3907](https://github.com/MakieOrg/Makie.jl/pull/3907).
 
 ## [0.21.3] - 2024-06-17
 

--- a/CairoMakie/src/overrides.jl
+++ b/CairoMakie/src/overrides.jl
@@ -31,8 +31,9 @@ is_cairomakie_atomic_plot(plot::Poly) = true
 
 
 function draw_poly_as_mesh(scene, screen, poly)
-    draw_plot(scene, screen, poly.plots[1])
-    draw_plot(scene, screen, poly.plots[2])
+    for i in eachindex(poly.plots)
+        draw_plot(scene, screen, poly.plots[i])
+    end
 end
 
 # As a general fallback, draw all polys as meshes.


### PR DESCRIPTION
Otherwise the fallback logic doesn't work when `poly` gets an external override which plots a `poly` internally again