### PR TITLE
Don't set the GLMakie window icon on OSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed support for GLFW 3.4 on OSX [#3999](https://github.com/MakieOrg/Makie.jl/issues/3999).
 - Changed camera variables to Float64 for increased accuracy [#3984](https://github.com/MakieOrg/Makie.jl/pull/3984) 
 - Allow CairoMakie to render `poly` overloads that internally don't use two child plots [#3986](https://github.com/MakieOrg/Makie.jl/pull/3986).
 - Fixes for Menu and DataInspector [#3975](https://github.com/MakieOrg/Makie.jl/pull/3975).

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -257,7 +257,10 @@ function empty_screen(debugging::Bool; reuse=true)
         rethrow(e)
     end
 
-    GLFW.SetWindowIcon(window, Makie.icon())
+    # GLFW doesn't support setting the icon on OSX
+    if !Sys.isapple()
+        GLFW.SetWindowIcon(window, Makie.icon())
+    end
 
     # tell GLAbstraction that we created a new context.
     # This is important for resource tracking, and only needed for the first context


### PR DESCRIPTION
# Description

Fixes #3997 (I think).

This disables setting the window icon on OSX. I updated `GLFW_jll` to 3.4 recently, and 3.4 will return an error upon setting the window icon on OSX: https://github.com/glfw/glfw/commit/9a87c2a4b49808d3666c7b093b77e8512fa23908
Previously it would do nothing, which is why it didn't throw before. I didn't audit the rest of the codebase so there may be other places we're calling unsupported functions.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
