### PR TITLE
Use linestyle for Poly and Density legend elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Use linestyle for Poly and Density legend elements [#4000](https://github.com/MakieOrg/Makie.jl/pull/4000).
 - Bring back interpolation attribute for surface [#4056](https://github.com/MakieOrg/Makie.jl/pull/4056).
 - Improved accuracy of framerate settings in GLMakie [#3954](https://github.com/MakieOrg/Makie.jl/pull/3954)
 - Fix label_formatter being called twice in barplot [#4046](https://github.com/MakieOrg/Makie.jl/pull/4046).

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -300,7 +300,8 @@ function legendelement_plots!(scene, element::PolyElement, bbox::Observable{Rect
     points = lift((bb, fp) -> fractionpoint.(Ref(bb), fp), scene, bbox, fracpoints)
     pol = poly!(scene, points, strokewidth = attrs.polystrokewidth, color = attrs.polycolor,
         strokecolor = attrs.polystrokecolor, inspectable = false,
-        colormap = attrs.polycolormap, colorrange = attrs.polycolorrange)
+        colormap = attrs.polycolormap, colorrange = attrs.polycolorrange,
+        linestyle = attrs.linestyle)
 
     return [pol]
 end
@@ -437,7 +438,7 @@ function legendelements(plot::Scatter, legend)
     )]
 end
 
-function legendelements(plot::Union{Poly, Violin, BoxPlot, CrossBar, Density}, legend)
+function legendelements(plot::Union{Violin, BoxPlot, CrossBar}, legend)
     color = extract_color(plot, legend[:polycolor])
     LegendElement[PolyElement(
         color = color,
@@ -461,6 +462,19 @@ function legendelements(plot::Band, legend)
         polycolorrange = plot.colorrange,
     )]
 end
+
+function legendelements(plot::Union{Poly, Density}, legend)
+    color = Makie.extract_color(plot, legend[:polycolor])
+    LegendElement[Makie.PolyElement(
+        color = color,
+        strokecolor = Makie.choose_scalar(plot.strokecolor, legend[:polystrokecolor]),
+        strokewidth = Makie.choose_scalar(plot.strokewidth, legend[:polystrokewidth]),
+        colormap = plot.colormap,
+        colorrange = plot.colorrange,
+        linestyle = plot.linestyle,
+    )]
+end
+
 
 # if there is no specific overload available, we go through the child plots and just stack
 # those together as a simple fallback


### PR DESCRIPTION
# Description

Fixes legend elements for Poly and Density plots. #3998

Before:
![before](https://github.com/MakieOrg/Makie.jl/assets/6753265/ceb6133d-d20d-475d-8495-0dfc5d862030)

After:
![after](https://github.com/MakieOrg/Makie.jl/assets/6753265/e02466ff-e2eb-4d57-88f5-84bf205eb05a)



Add a description of your PR here.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

I am not sure what kind of unit test to add for this.
