### PR TITLE
Remove randomisation of insertion order in calls to `triangulate` in `triplot`/`voronoiplot`/`triplot`

### DIFF
--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1254,7 +1254,7 @@ end
 #         (7.0, 7.8), (7.0, 7.4)]
 #     boundary_nodes, points = convert_boundary_points_to_indices(curves; existing_points=points)
 #     tri = triangulate(points; boundary_nodes=boundary_nodes, rng = RNG.STABLE_RNG)
-#     refine!(tri, max_area = 1e-3get_total_area(tri), rng = RNG.STABLE_RNG)
+#     refine!(tri, max_area = 1e-3get_area(tri), rng = RNG.STABLE_RNG)
 #     fig, ax, sc = triplot(tri,
 #         show_points=true,
 #         show_constrained_edges=true,
@@ -1353,11 +1353,6 @@ end
     fig
 end
 
-#=
-
-After DelaunayTriangulation@1.0.4, this test started to show slightly randomized triangulations.
-Until this gets fixed, we're disabling it.
-
 @reference_test "Voronoiplot with a nonlinear transform" begin
     f = Figure()
     ax = PolarAxis(f[1, 1], theta_as_x = false)
@@ -1371,7 +1366,7 @@ Until this gets fixed, we're disabling it.
     Makie.rlims!(ax, 12)
     f
 end
-=#
+
 
 @reference_test "Voronoiplot with some custom bounding boxes may not contain all data sites" begin
     points = [(-3.0, 7.0), (1.0, 6.0), (-1.0, 3.0), (-2.0, 4.0), (3.0, -2.0), (5.0, 5.0), (-4.0, -3.0), (3.0, 8.0)]

--- a/src/basic_recipes/tricontourf.jl
+++ b/src/basic_recipes/tricontourf.jl
@@ -63,7 +63,7 @@ function Makie.convert_arguments(::Type{<:Tricontourf}, x::AbstractVector{<:Real
     z = elconvert(T, z)
     points = [elconvert(T, x)'; elconvert(T, y)']
     if triangulation isa DelaunayTriangulation
-        tri = DelTri.triangulate(points)
+        tri = DelTri.triangulate(points; randomise = false)
     elseif !(triangulation isa DelTri.Triangulation)
         # Wrap user's provided triangulation into a Triangulation. Their triangulation must be such that DelTri.add_triangle! is defined.
         if typeof(triangulation) <: AbstractMatrix{<:Int} && size(triangulation, 1) != 3

--- a/src/basic_recipes/triplot.jl
+++ b/src/basic_recipes/triplot.jl
@@ -181,7 +181,7 @@ function Makie.plot!(p::Triplot{<:Tuple{<:Vector{<:Point}}})
     # Handle transform_func early so tessellation is in cartesian space.
     tri = map(p, p.transformation.transform_func, p[1]) do tf, ps
         transformed = Makie.apply_transform(tf, ps)
-        return DelTri.triangulate(transformed)
+        return DelTri.triangulate(transformed; randomise = false)
     end
 
     attr[:transformation] = Transformation(p.transformation; transform_func=identity)

--- a/src/basic_recipes/voronoiplot.jl
+++ b/src/basic_recipes/voronoiplot.jl
@@ -133,10 +133,10 @@ function plot!(p::Voronoiplot{<:Tuple{<:Vector{<:Point{N}}}}) where {N}
     # Handle transform_func early so tessellation is in cartesian space.
     vorn = map(p, p.transformation.transform_func, ps, smooth) do tf, ps, smooth
         transformed = Makie.apply_transform(tf, ps)
-        tri = DelTri.triangulate(transformed)
-        vorn = DelTri.voronoi(tri)
+        tri = DelTri.triangulate(transformed; randomise = false)
+        vorn = DelTri.voronoi(tri, clip = smooth)
         if smooth
-            vorn = DelTri.centroidal_smooth(vorn)
+            vorn = DelTri.centroidal_smooth(vorn; randomise = false)
         end
         return vorn
     end


### PR DESCRIPTION
Hopefully fixes the issue observed in #4003 as I've discussed with @SimonDanisch. Locally, running the test over and over gives the same centroidal tessellation. 

The test was actually broken before DelaunayTriangulation@1.0.4 (i.e. it always gave a different image), not sure why it suddenly started breaking though. 

Do I need to update the changelog for this?

