### PR TITLE
Fix `transform_func = nothing` in `Transformation(::Transformation)` from doing the opposite of what it's supposed to do

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -300,8 +300,8 @@ function Transformation(parent::Transformable;
                         translation=Vec3d(0),
                         rotation=Quaternionf(0, 0, 0, 1),
                         transform_func=nothing)
-    connect_func = isnothing(transform_func)
-    trans = isnothing(transform_func) ? identity : transform_func
+    connect_func = !isnothing(transform_func)
+    trans = connect_func ? transform_func : identity
 
     trans = Transformation(translation,
                            scale,


### PR DESCRIPTION
# Description

The `Transformation(::Transformation; transform_func)` constructor was supposed to check if the `transform_func` kwarg was `nothing`, and if so, **not** connect the transform func.  Instead, it used to **connect** the transform func if `transform_func=nothing`, and **not connect** the transform func if `isnothing(transform_func) == false`.  

This is the opposite of what it should be doing!  This PR fixes that strange behaviour by inverting the boolean `connect_func`.