### PR TITLE
fix fullscreen in GLMakie

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -349,7 +349,8 @@ function apply_config!(screen::Screen, config::ScreenConfig; start_renderloop::B
     GLFW.SetWindowTitle(glw, config.title)
 
     if !isnothing(config.monitor)
-        GLFW.SetWindowMonitor(glw, config.monitor)
+        video_mode = GLFW.GetVideoMode(config.monitor)
+        GLFW.SetWindowMonitor(glw, config.monitor, 0, 0, video_mode.width, video_mode.height, video_mode.refreshrate)
     end
     screen.scalefactor[] = !isnothing(config.scalefactor) ? config.scalefactor : scale_factor(glw)
     screen.px_per_unit[] = !isnothing(config.px_per_unit) ? config.px_per_unit : screen.scalefactor[]


### PR DESCRIPTION
# Description

I was trying to display a GLMakie window in fullscreen, as described in [discourse](https://discourse.julialang.org/t/fullscreen-doesnt-work-in-glmakie/117014). The problem was that the fullscreen keyword in the `GLMakie.activate!()` function appeard to have no effect. As suggested there, the keyword wasn't actually used in the source code.

I then read the GFLW documentation, to see how would one make a fullscreen window. It appears that a call to the function [`glfwSetWindowMonitor`](https://www.glfw.org/docs/latest/group__window.html#ga81c76c418af80a1cce7055bccb0ae0a7) does the job, so I tried to find where it is called in the GLMakie source code. To my surprise, it is called with a wrong signature! I then attempted to fix it, and with this new version, the following code produces the result that I desire: a fullscreen image.

```julia
using GLMakie, GLMakie.GLFW
monitor = GLFW.GetPrimaryMonitor()
GLMakie.activate!(; decorated=false, monitor)

video_mode = GLFW.GetVideoMode(monitor)
w, h = video_mode.width, video_mode.height
img = rand(UInt8, w, h)

fig = Figure(size=(w, h), figure_padding=0)
ax = Axis(fig[1, 1], aspect=DataAspect())
hidedecorations!(ax)
heatmap!(ax, img, colormap=:greys)
fig
```

In the master branch, this will error do to the incorrect call to `GLFW.SetWindowMonitor`.

I'm not really familiar with the repository, so I don't know if this change might have effects elsewhere. If this is the right fix for the fullscreen problem, then the keyword could be removed, as it is not being used, and we should also update the [docs](https://docs.makie.org/v0.21/explanations/backends/glmakie).