### PR TITLE
resolve CairoMakie insert! ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Correct a bug in the `project` function when projecting using a `Scene`. [#3909](https://github.com/MakieOrg/Makie.jl/pull/3909).
+- Correct a method ambiguity in `insert!` which was causing `PlotList` to fail on CairoMakie. [#4038](https://github.com/MakieOrg/Makie.jl/pull/4038)
 
 ## [0.21.5] - 2024-07-07
 

--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -204,6 +204,7 @@ Base.size(screen::Screen) = round.(Int, (screen.surface.width, screen.surface.he
 # we render the scene directly, since we have
 # no screen dependent state like in e.g. opengl
 Base.insert!(screen::Screen, scene::Scene, plot) = nothing
+Base.insert!(screen::Screen, scene::Scene, plot::Plot{plotlist}) = nothing
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
     # Currently, we rerender every time, so nothing needs
     # to happen here.  However, in the event that changes,

--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -204,7 +204,8 @@ Base.size(screen::Screen) = round.(Int, (screen.surface.width, screen.surface.he
 # we render the scene directly, since we have
 # no screen dependent state like in e.g. opengl
 Base.insert!(screen::Screen, scene::Scene, plot) = nothing
-# Base.insert!(screen::Screen, scene::Scene, plot::Plot{plotlist}) = nothing
+# to resolve method ambiguity, since this method is defined in Makie for MakieScreen and PlotList:
+Base.insert!(screen::Screen, scene::Scene, plot::Plot{plotlist}) = nothing
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
     # Currently, we rerender every time, so nothing needs
     # to happen here.  However, in the event that changes,

--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -204,7 +204,7 @@ Base.size(screen::Screen) = round.(Int, (screen.surface.width, screen.surface.he
 # we render the scene directly, since we have
 # no screen dependent state like in e.g. opengl
 Base.insert!(screen::Screen, scene::Scene, plot) = nothing
-Base.insert!(screen::Screen, scene::Scene, plot::Plot{plotlist}) = nothing
+# Base.insert!(screen::Screen, scene::Scene, plot::Plot{plotlist}) = nothing
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
     # Currently, we rerender every time, so nothing needs
     # to happen here.  However, in the event that changes,

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -134,6 +134,11 @@ end
     rm("test.mp4")
 end
 
+@testset "plotlist no ambiguity" begin
+    plotlist([Makie.SpecApi.Scatter(1:10)])
+    plotlist!([Makie.SpecApi.Scatter(1:10)])
+end
+
 
 excludes = Set([
     "Colored Mesh",

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -136,7 +136,7 @@ end
 
 @testset "plotlist no ambiguity" begin
     f = plotlist([Makie.SpecApi.Scatter(1:10)])
-    save("test.png", f)
+    Makie.colorbuffer(f; backend=CairoMakie)
     plotlist!([Makie.SpecApi.Scatter(1:10)])
 end
 

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -135,7 +135,8 @@ end
 end
 
 @testset "plotlist no ambiguity" begin
-    plotlist([Makie.SpecApi.Scatter(1:10)])
+    f = plotlist([Makie.SpecApi.Scatter(1:10)])
+    save("test.png", f)
     plotlist!([Makie.SpecApi.Scatter(1:10)])
 end
 

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -134,7 +134,7 @@ end
     rm("test.mp4")
 end
 
-@testset "plotlist no ambiguity" begin
+@testset "plotlist no ambiguity (#4038)" begin
     f = plotlist([Makie.SpecApi.Scatter(1:10)])
     Makie.colorbuffer(f; backend=CairoMakie)
     plotlist!([Makie.SpecApi.Scatter(1:10)])


### PR DESCRIPTION
# Description

Before:
```julia
julia> plotlist([Makie.SpecApi.Scatter(1:10)])

julia> plotlist!([Makie.SpecApi.Scatter(1:10)])
ERROR: MethodError: insert!(::CairoMakie.Screen{CairoMakie.IMAGE}, ::Scene, ::Plot{Makie.plotlist, Tuple{Vector{PlotSpec}}}) is ambiguous.

Candidates:
  insert!(screen::CairoMakie.Screen, scene::Scene, plot)
    @ CairoMakie ~/.julia/packages/CairoMakie/wKKMp/src/screen.jl:206
  insert!(::MakieScreen, ::Scene, ::Plot{Makie.plotlist})
    @ Makie ~/.julia/packages/Makie/rEu75/src/specapi.jl:387

Possible fix, define
  insert!(::CairoMakie.Screen, ::Scene, ::Plot{Makie.plotlist})
```

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.