### PR TITLE
Suppress keyboard shortcuts and context menu in JupyterLab output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Suppress keyboard shortcuts in notebook output [#4068](https://github.com/MakieOrg/Makie.jl/pull/4068).
 - Introduce stroke_depth_shift + forward normal depth_shift for Poly [#4058](https://github.com/MakieOrg/Makie.jl/pull/4058).
 - Use linestyle for Poly and Density legend elements [#4000](https://github.com/MakieOrg/Makie.jl/pull/4000).
 - Bring back interpolation attribute for surface [#4056](https://github.com/MakieOrg/Makie.jl/pull/4056).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Suppress keyboard shortcuts in notebook output [#4068](https://github.com/MakieOrg/Makie.jl/pull/4068).
+- Suppress keyboard shortcuts and context menu in JupyterLab output [#4068](https://github.com/MakieOrg/Makie.jl/pull/4068).
 - Introduce stroke_depth_shift + forward normal depth_shift for Poly [#4058](https://github.com/MakieOrg/Makie.jl/pull/4058).
 - Use linestyle for Poly and Density legend elements [#4000](https://github.com/MakieOrg/Makie.jl/pull/4000).
 - Bring back interpolation attribute for surface [#4056](https://github.com/MakieOrg/Makie.jl/pull/4056).

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -43,6 +43,10 @@ function code_to_keyboard(code::String)
         return Keyboard.caps_lock
     elseif sym === :contextmenu
         return Keyboard.menu
+    elseif sym === :left_meta
+        return Keyboard.left_super
+    elseif sym === :right_meta
+        return Keyboard.right_super
     else
         return Keyboard.unknown
     end

--- a/WGLMakie/src/three_plot.jl
+++ b/WGLMakie/src/three_plot.jl
@@ -33,9 +33,14 @@ function three_display(screen::Screen, session::Session, scene::Scene)
     window_open = scene.events.window_open
     width, height = size(scene)
     canvas_width = lift(x -> [round.(Int, widths(x))...], scene, viewport(scene))
-    # Pass `dataLmSuppressShortcuts=true` to ensure JupyterLab does not capture keyboard shortcuts
-    # see: https://jupyterlab.readthedocs.io/en/4.2.x/extension/notebook.html#keyboard-interaction-model
-    canvas = DOM.m("canvas"; tabindex="0", style="display: block", dataLmSuppressShortcuts=true)
+    canvas = DOM.m("canvas";
+        tabindex="0", style="display: block",
+        # Pass JupyterLab specific attributes to prevent it from capturing keyboard shortcuts
+        # and to suppress the JupyterLab context menu in Makie plots, see:
+        # https://jupyterlab.readthedocs.io/en/4.2.x/extension/notebook.html#keyboard-interaction-model
+        # https://jupyterlab.readthedocs.io/en/4.2.x/extension/extension_points.html#context-menu
+        dataLmSuppressShortcuts=true, dataJpSuppressContextMenu=nothing,
+    )
     wrapper = DOM.div(canvas; style="width: 100%; height: 100%")
     comm = Observable(Dict{String,Any}())
     done_init = Observable(false)

--- a/WGLMakie/src/three_plot.jl
+++ b/WGLMakie/src/three_plot.jl
@@ -33,7 +33,9 @@ function three_display(screen::Screen, session::Session, scene::Scene)
     window_open = scene.events.window_open
     width, height = size(scene)
     canvas_width = lift(x -> [round.(Int, widths(x))...], scene, viewport(scene))
-    canvas = DOM.m("canvas"; tabindex="0", style="display: block")
+    # Pass `dataLmSuppressShortcuts=true` to ensure JupyterLab does not capture keyboard shortcuts
+    # see: https://jupyterlab.readthedocs.io/en/4.2.x/extension/notebook.html#keyboard-interaction-model
+    canvas = DOM.m("canvas"; tabindex="0", style="display: block", dataLmSuppressShortcuts=true)
     wrapper = DOM.div(canvas; style="width: 100%; height: 100%")
     comm = Observable(Dict{String,Any}())
     done_init = Observable(false)

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -22902,6 +22902,9 @@ function add_canvas_events(screen, comm, resize_to) {
     }
     canvas.addEventListener("wheel", wheel);
     function keydown(event) {
+        if (event.code === "Space") {
+            event.preventDefault();
+        }
         comm.notify({
             keydown: [
                 event.code,

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -275,6 +275,10 @@ function add_canvas_events(screen, comm, resize_to) {
     canvas.addEventListener("wheel", wheel);
 
     function keydown(event) {
+        // Prevent the default browser behavior for `Space`, which is to scroll.
+        if (event.code === "Space") {
+            event.preventDefault();
+        }
         comm.notify({
             keydown: [event.code, event.key],
         });


### PR DESCRIPTION
# Description

Fixes #4057, #4067, #4075, and fixes capture of the `super` keys.

Add JupyterLab specific attributes to prevent it from capturing keyboard shortcuts and to suppress the JupyterLab context menu in Makie plots, see:
- https://jupyterlab.readthedocs.io/en/4.2.x/extension/notebook.html#keyboard-interaction-model
- https://jupyterlab.readthedocs.io/en/4.2.x/extension/extension_points.html#context-menu

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
