### PR TITLE
Update WGLMakie docs, removing stale section that no longer applies.

### DIFF
--- a/docs/src/explanations/backends/wglmakie.md
+++ b/docs/src/explanations/backends/wglmakie.md
@@ -10,10 +10,6 @@ Moving more of the implementation to JavaScript is currently the goal and will g
 
 
 
-#### Missing Backend Features
-
-* `lines(...)` just creates unconnected linesegments and `linestyle` isn't supported
-
 #### Browser Support
 
 


### PR DESCRIPTION
# Description

Updates stale docs for WGLMakie, removing a section that no longer applies.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
