### PR TITLE
fix distance calculation in WGLMakie JS functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed incorrect distance calculation in `pick_closest` in WGLMakie [#4082](https://github.com/MakieOrg/Makie.jl/pull/4082).
 - Introduce stroke_depth_shift + forward normal depth_shift for Poly [#4058](https://github.com/MakieOrg/Makie.jl/pull/4058).
 - Use linestyle for Poly and Density legend elements [#4000](https://github.com/MakieOrg/Makie.jl/pull/4000).
 - Bring back interpolation attribute for surface [#4056](https://github.com/MakieOrg/Makie.jl/pull/4056).

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -23189,7 +23189,7 @@ function pick_closest(scene, xy, range) {
     const dy = y1 - y0;
     const [plot_data, _] = pick_native(scene, x0, y0, dx, dy);
     const plot_matrix = plot_data.data;
-    let min_dist = range ^ 2;
+    let min_dist = Math.pow(range, 2);
     let selection = [
         null,
         0
@@ -23199,7 +23199,7 @@ function pick_closest(scene, xy, range) {
     let pindex = 0;
     for(let i = 1; i <= dx; i++){
         for(let j = 1; j <= dx; j++){
-            const d = x - i ^ 2 + (y - j) ^ 2;
+            const d = Math.pow(x - i, 2) + Math.pow(y - j, 2);
             const [plot_uuid, index] = plot_matrix[pindex];
             pindex = pindex + 1;
             if (d < min_dist && plot_uuid) {
@@ -23233,13 +23233,13 @@ function pick_sorted(scene, xy, range) {
         return null;
     }
     const plot_matrix = plot_data.data;
-    const distances = selected.map((x)=>range ^ 2);
+    const distances = selected.map((x)=>Math.pow(range, 2));
     const x = xy[0] + 1 - x0;
     const y = xy[1] + 1 - y0;
     let pindex = 0;
     for(let i = 1; i <= dx; i++){
         for(let j = 1; j <= dx; j++){
-            const d = x - i ^ 2 + (y - j) ^ 2;
+            const d = Math.pow(x - i, 2) + Math.pow(y - j, 2);
             if (plot_matrix.length <= pindex) {
                 continue;
             }

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -631,14 +631,14 @@ export function pick_closest(scene, xy, range) {
     const dy = y1 - y0;
     const [plot_data, _] = pick_native(scene, x0, y0, dx, dy);
     const plot_matrix = plot_data.data;
-    let min_dist = range ^ 2;
+    let min_dist = Math.pow(range, 2);
     let selection = [null, 0];
     const x = xy[0] + 1 - x0;
     const y = xy[1] + 1 - y0;
     let pindex = 0;
     for (let i = 1; i <= dx; i++) {
         for (let j = 1; j <= dx; j++) {
-            const d = (x - i) ^ 2 + (y - j) ^ 2;
+            const d = Math.pow(x - i, 2) + Math.pow(y - j, 2);
             const [plot_uuid, index] = plot_matrix[pindex];
             pindex = pindex + 1;
             if (d < min_dist && plot_uuid) {
@@ -671,13 +671,13 @@ export function pick_sorted(scene, xy, range) {
         return null;
     }
     const plot_matrix = plot_data.data;
-    const distances = selected.map((x) => range ^ 2);
+    const distances = selected.map((x) => Math.pow(range, 2));
     const x = xy[0] + 1 - x0;
     const y = xy[1] + 1 - y0;
     let pindex = 0;
     for (let i = 1; i <= dx; i++) {
         for (let j = 1; j <= dx; j++) {
-            const d = (x - i) ^ 2 + (y - j) ^ 2;
+            const d = Math.pow(x - i, 2) + Math.pow(y - j, 2);
             if (plot_matrix.length <= pindex) {
                 continue;
             }

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -638,7 +638,7 @@ export function pick_closest(scene, xy, range) {
     let pindex = 0;
     for (let i = 1; i <= dx; i++) {
         for (let j = 1; j <= dx; j++) {
-            const d = (x - i) ^ (2 + (y - j)) ^ 2;
+            const d = (x - i) ^ 2 + (y - j) ^ 2;
             const [plot_uuid, index] = plot_matrix[pindex];
             pindex = pindex + 1;
             if (d < min_dist && plot_uuid) {
@@ -677,7 +677,7 @@ export function pick_sorted(scene, xy, range) {
     let pindex = 0;
     for (let i = 1; i <= dx; i++) {
         for (let j = 1; j <= dx; j++) {
-            const d = (x - i) ^ (2 + (y - j)) ^ 2;
+            const d = (x - i) ^ 2 + (y - j) ^ 2;
             if (plot_matrix.length <= pindex) {
                 continue;
             }


### PR DESCRIPTION
# Description

Erratic tooltip snapping behavior in WGLMakie plots.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
