### PR TITLE
fix stairs type to match the input

### DIFF
--- a/src/basic_recipes/stairs.jl
+++ b/src/basic_recipes/stairs.jl
@@ -18,38 +18,38 @@ end
 
 conversion_trait(::Type{<:Stairs}) = PointBased()
 
-function plot!(p::Stairs{<:Tuple{<:AbstractVector{<:Point2}}})
+function plot!(p::Stairs{<:Tuple{<:AbstractVector{T}}}) where T <: Point2
     points = p[1]
 
     steppoints = lift(p, points, p.step) do points, step
         if step === :pre
-            s_points = Vector{Point2f}(undef, length(points) * 2 - 1)
+            s_points = Vector{T}(undef, length(points) * 2 - 1)
             s_points[1] = point = points[1]
             for i in 1:length(points)-1
                 nextpoint = points[i + 1]
-                s_points[2i] = Point2f(point[1], nextpoint[2])
+                s_points[2i] = T(point[1], nextpoint[2])
                 s_points[2i + 1] = nextpoint
                 point = nextpoint
             end
             s_points
         elseif step === :post
-            s_points = Vector{Point2f}(undef, length(points) * 2 - 1)
+            s_points = Vector{T}(undef, length(points) * 2 - 1)
             s_points[1] = point = points[1]
             for i in 1:length(points)-1
                 nextpoint = points[i+1]
-                s_points[2i] = Point2f(nextpoint[1], point[2])
+                s_points[2i] = T(nextpoint[1], point[2])
                 s_points[2i + 1] = nextpoint
                 point = nextpoint
             end
             s_points
         elseif step === :center
-            s_points = Vector{Point2f}(undef, length(points) * 2)
+            s_points = Vector{T}(undef, length(points) * 2)
             s_points[1] = point = points[1]
             for i in 1:length(points)-1
                 nextpoint = points[i+1]
                 halfx = (point[1] + nextpoint[1]) / 2
-                s_points[2i] = Point2f(halfx, point[2])
-                s_points[2i + 1] = Point2f(halfx, nextpoint[2])
+                s_points[2i] = T(halfx, point[2])
+                s_points[2i + 1] = T(halfx, nextpoint[2])
                 point = nextpoint
             end
             s_points[end] = point


### PR DESCRIPTION
# Description

Fixes the type of `steppoints` in `stairs` to match the input type. This prevents inputs with 64 bits of precision from getting truncated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
