### PR TITLE
fix visible update for plots inserted after scene

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -317,6 +317,7 @@ Base.insert!(::GLMakie.Screen, ::Scene, ::Makie.PlotList) = nothing
 
 function Base.insert!(screen::Screen, scene::Scene, @nospecialize(x::Plot))
     ShaderAbstractions.switch_context!(screen.glscreen)
+    add_scene!(screen, scene)
     # poll inside functions to make wait on compile less prominent
     pollevents(screen)
     if isempty(x.plots) # if no plots inserted, this truly is an atomic

--- a/src/makielayout/blocks/scene.jl
+++ b/src/makielayout/blocks/scene.jl
@@ -57,9 +57,3 @@ Makie.cam3d!(ax::LScene; kwargs...) = Makie.cam3d!(ax.scene; kwargs...)
 Makie.cam3d_cad!(ax::LScene; kwargs...) = Makie.cam3d_cad!(ax.scene; kwargs...)
 Makie.old_cam3d!(ax::LScene; kwargs...) = Makie.old_cam3d!(ax.scene; kwargs...)
 Makie.old_cam3d_cad!(ax::LScene; kwargs...) = Makie.old_cam3d_cad!(ax.scene; kwargs...)
-
-function Base.copy(ax::LScene)
-    ax2 = LScene(ax.parent, ax.layoutobservables, ax.blockscene)
-    ax2.scene = Scene(ax.scene; camera=ax.scene.camera, camera_controls=ax.scene.camera_controls)
-    return ax2
-end

--- a/src/makielayout/blocks/scene.jl
+++ b/src/makielayout/blocks/scene.jl
@@ -57,3 +57,9 @@ Makie.cam3d!(ax::LScene; kwargs...) = Makie.cam3d!(ax.scene; kwargs...)
 Makie.cam3d_cad!(ax::LScene; kwargs...) = Makie.cam3d_cad!(ax.scene; kwargs...)
 Makie.old_cam3d!(ax::LScene; kwargs...) = Makie.old_cam3d!(ax.scene; kwargs...)
 Makie.old_cam3d_cad!(ax::LScene; kwargs...) = Makie.old_cam3d_cad!(ax.scene; kwargs...)
+
+function Base.copy(ax::LScene)
+    ax2 = LScene(ax.parent, ax.layoutobservables, ax.blockscene)
+    ax2.scene = Scene(ax.scene; camera=ax.scene.camera, camera_controls=ax.scene.camera_controls)
+    return ax2
+end


### PR DESCRIPTION
`screen.requires_update` would not get updated when a new scene gets created after display and then plots inserted.
