### PR TITLE
Fix `select_point()` from throwing an exception immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed `invert_normals` for surface plots in CairoMakie [#4021](https://github.com/MakieOrg/Makie.jl/pull/4021).
 - Improve support for embedding GLMakie. [#4073](https://github.com/MakieOrg/Makie.jl/pull/4073)
 - Update JS OrbitControls to match Julia OrbitControls [#4084](https://github.com/MakieOrg/Makie.jl/pull/4084).
+- Fix `select_point()` [#4101](https://github.com/MakieOrg/Makie.jl/pull/4101).
 
 ## [0.21.5] - 2024-07-07
 

--- a/src/interaction/interactive_api.jl
+++ b/src/interaction/interactive_api.jl
@@ -347,13 +347,12 @@ The `kwargs...` are propagated into `scatter!` which plots the selected point.
 """
 function select_point(scene; blocking = false, priority=2, kwargs...)
     key = Mouse.left
-    pmarker = Circle(Point2f(0, 0), Float32(1))
     waspressed = Observable(false)
     point = Observable([Point2f(0,0)])
     point_ret = Observable(Point2f(0,0))
     # Create an initially hidden  arrow
     plotted_point = scatter!(
-        scene, point; visible = false, marker = pmarker, markersize = 20px,
+        scene, point; visible = false, marker = Circle, markersize = 20px,
         color = RGBAf(0.1, 0.1, 0.8, 0.5), kwargs...,
     )
 

--- a/test/events.jl
+++ b/test/events.jl
@@ -484,3 +484,24 @@ Base.:(==)(l::Or, r::Or) = l.left == r.left && l.right == r.right
         @test !blocked[]
     end
 end
+
+@testset "Builtin interaction helpers" begin
+    f = Figure(size = (400, 400))
+    a = Axis(f[1, 1])
+    e = events(f)
+
+    @testset "select_point()" begin
+        point = select_point(a)
+        initial_pos = point[]
+
+        # Initialize the position in the axis
+        e.mouseposition[] = (200, 200)
+
+        # The point should only be updated when the user releases the mouse
+        e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.press)
+        e.mouseposition[] = (100, 100)
+        @test point[] == initial_pos
+        e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.release)
+        @test point[] != initial_pos
+    end
+end


### PR DESCRIPTION
# Description

Fixes this exception based on @ffreyer's suggestion: https://github.com/MakieOrg/Makie.jl/issues/3977#issuecomment-2273858790

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
