### PR TITLE
Fix outline for image scatter

### DIFF
--- a/WGLMakie/assets/sprites.frag
+++ b/WGLMakie/assets/sprites.frag
@@ -56,14 +56,8 @@ float rounded_rectangle(vec2 uv, vec2 tl, vec2 br){
     return -((length(max(vec2(0.0), d)) + min(0.0, max(d.x, d.y)))-tl.x);
 }
 
-void fill(bool image, vec4 fillcolor, vec2 uv, float infill, inout vec4 color){
-    color = mix(color, fillcolor, infill);
-}
-
-void fill(sampler2D image, vec4 fillcolor, vec2 uv, float infill, inout vec4 color){
-    vec4 im_color = texture(image, uv.yx);
-    color = mix(color, im_color, infill);
-}
+vec4 fill(vec4 fillcolor, bool image, vec2 uv) { return fillcolor; }
+vec4 fill(vec4 c, sampler2D image, vec2 uv) { return texture(image, uv.yx); }
 
 void stroke(vec4 strokecolor, float signed_distance, float width, inout vec4 color){
     if (width != 0.0){
@@ -135,8 +129,9 @@ void main() {
     float inside_start = max(-stroke_width, 0.0);
     float inside = aastep(inside_start, signed_distance);
 
-    vec4 final_color = vec4(frag_color.xyz, 0);
-    fill(image, frag_color, frag_uv, inside, final_color);
+    vec4 final_color = fill(frag_color, image, frag_uv);
+    final_color.a = final_color.a * inside;
+
     stroke(get_strokecolor(), signed_distance, -stroke_width, final_color);
     glow(get_glowcolor(), signed_distance, aastep(-stroke_width, signed_distance), final_color);
 


### PR DESCRIPTION
# Description

Fixes the outline artifacts from #4043

![Screenshot 2024-08-08 174047](https://github.com/user-attachments/assets/1bd3f953-ae83-4d4d-aeb1-558efb617a79)

by essentially copying the fix for GLMakie from https://github.com/MakieOrg/Makie.jl/pull/3113/commits/ac1b645ae6f0ab6fe8ae457bedc21be211245a5d.

This happened because rect markers no longer fill out the entire quad (which they shouldn't) and thus the `mix(image_color, background_color, fillvalue)` may add some background color at the edge. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- ~~Added an entry in CHANGELOG.md (for new features and breaking changes)~~ since it's unreleased I'm skipping the changelog entry
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- ~~Added reference image tests for new plotting functions, recipes, visual options, etc.~~ already has a refimg test
