### PR TITLE
Fix absrect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Improve support for embedding GLMakie. [#4073](https://github.com/MakieOrg/Makie.jl/pull/4073)
 - Update JS OrbitControls to match Julia OrbitControls [#4084](https://github.com/MakieOrg/Makie.jl/pull/4084).
 - Fix `select_point()` [#4101](https://github.com/MakieOrg/Makie.jl/pull/4101).
+- Fix `absrect()` and `select_rectangle()` [#4110](https://github.com/MakieOrg/Makie.jl/issues/4110).
 
 ## [0.21.5] - 2024-07-07
 

--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -200,7 +200,8 @@ function absrect(rect)
     xy = ntuple(Val(2)) do i
         wh[i] < 0 ? xy[i] + wh[i] : xy[i]
     end
-    return Rect2(Vec2(xy), Vec2(abs.(wh)))
+
+    return Rect2(Vec2(xy), abs.(wh))
 end
 
 

--- a/test/cameras.jl
+++ b/test/cameras.jl
@@ -1,0 +1,4 @@
+@testset "Camera utilities" begin
+    negative_rect = Rect2f(0, 0, -1, 1)
+    @test Makie.absrect(negative_rect) == Rect2(-1, 0, 1, 1)
+end

--- a/test/events.jl
+++ b/test/events.jl
@@ -504,4 +504,18 @@ end
         e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.release)
         @test point[] != initial_pos
     end
+
+    @testset "select_rectangle()" begin
+        rect = select_rectangle(a)
+        initial_rect = rect[]
+
+        # Similarly to the select_point() test, we initialize the mouse position
+        # and check that the rect isn't updated until the mouse is released.
+        e.mouseposition[] = (200, 200)
+        e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.press)
+        e.mouseposition[] = (100, 100)
+        @test rect[] == initial_rect
+        e.mousebutton[] = MouseButtonEvent(Mouse.left, Mouse.release)
+        @test rect[] != initial_rect
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,8 @@ using Makie: volume
     include("barplot.jl")
     include("bezier.jl")
     include("hist.jl")
+    include("cameras.jl")
+
     # for short tests of resolved issues
     include("issues.jl")
 


### PR DESCRIPTION
# Description

Fixes #4099.

`absrect()` would previously throw an ambiguity exception from calling `Vec2(abs.(wh::Vec2))`. But `abs.(::Vec2)` returns a `Vec2` so the explicit conversion isn't necessary anyway.

This showed up when using `select_rectangle()`.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
