### PR TITLE
Fix GLMakie shader compatibility problems with arrays of arrays

### DIFF
--- a/GLMakie/assets/shader/sprites.geom
+++ b/GLMakie/assets/shader/sprites.geom
@@ -39,17 +39,20 @@ uniform float glow_width;
 uniform int shape; // for RECTANGLE hack below
 uniform vec2 resolution;
 uniform float depth_shift;
+uniform mat4 preprojection, projection, view, model;
+uniform int num_clip_planes;
+uniform vec4 clip_planes[8];
 
 in int g_primitive_index[];
 in vec4 g_uv_texture_bbox[];
 in vec4 g_color[];
 in vec4 g_stroke_color[];
 in vec4 g_glow_color[];
-in vec3 g_position[];
+in vec3 g_world_position[];
+in vec3 g_marker_offset[];
 in vec4 g_rotation[];
 in vec4 g_offset_width[];
 in uvec2 g_id[];
-in float g_clip_distance[][8];
 
 flat out int  f_primitive_index;
 flat out float f_viewport_from_u_scale;
@@ -64,7 +67,17 @@ flat out vec4 f_uv_texture_bbox;
 flat out vec2 f_sprite_scale;
 out float gl_ClipDistance[8];
 
-uniform mat4 projection, view, model;
+void process_clip_planes(vec3 world_pos)
+{
+    // distance = dot(world_pos - plane.point, plane.normal)
+    // precalculated: dot(plane.point, plane.normal) -> plane.w
+    for (int i = 0; i < num_clip_planes; i++)
+        gl_ClipDistance[i] = dot(world_pos, clip_planes[i].xyz) - clip_planes[i].w;
+
+    // TODO: can be skipped?
+    for (int i = num_clip_planes; i < 8; i++)
+        gl_ClipDistance[i] = 1.0;
+}
 
 float get_distancefield_scale(sampler2D distancefield){
     // Glyph distance field units are in pixels; convert to dimensionless
@@ -109,6 +122,11 @@ void main(void)
     o_view_pos = vec3(0);
     o_view_normal = vec3(0);
 
+    // Position of sprite center in marker space + clipping
+    process_clip_planes(g_world_position[0]);
+    vec4 p = preprojection * vec4(g_world_position[0], 1);
+    vec3 position = p.xyz / p.w + g_marker_offset[0];
+
     // emit quad as triangle strip
     // v3. ____ . v4
     //    |\   |
@@ -127,7 +145,7 @@ void main(void)
     trans = (billboard ? projection : pview) * qmat(g_rotation[0]) * trans;
 
     // Compute centre of billboard in clipping coordinates
-    vec4 vclip = pview*vec4(g_position[0],1) + trans*vec4(sprite_bbox_centre,0,0);
+    vec4 vclip = pview*vec4(position, 1) + trans*vec4(sprite_bbox_centre,0,0);
 
     // Extra buffering is required around sprites which are antialiased so that
     // the antialias blur doesn't get cut off (see #15). This blur falls to

--- a/GLMakie/assets/shader/sprites.geom
+++ b/GLMakie/assets/shader/sprites.geom
@@ -104,8 +104,6 @@ void emit_vertex(vec4 vertex, vec2 uv)
     f_glow_color      = g_glow_color[0];
     f_id              = g_id[0];
     f_sprite_scale    = g_offset_width[0].zw;
-    for (int i = 0; i < 8; i++)
-        gl_ClipDistance[i] = g_clip_distance[0][i];
     EmitVertex();
 }
 


### PR DESCRIPTION
# Description

#3958 introduced `g_clip_planes[][8]` in sprites.geom which works on my PC and apparently also CI, but doesn't on my Laptop. This pr moves the clipping code to the geometry shader so that the result doesn't need to be passed around.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)