### PR TITLE
sort objects in WGL as in GLMakie, nest rectanglezoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix RectangleZoom in WGLMakie [#4127](https://github.com/MakieOrg/Makie.jl/pull/4127)
 - Data inspector fixes (mostly for bar plots) [#4087](https://github.com/MakieOrg/Makie.jl/pull/4087)
 - Added "clip_planes" as a new generic plot and scene attribute. Up to 8 world space clip planes can be specified to hide sections of a plot. [#3958](https://github.com/MakieOrg/Makie.jl/pull/3958)
 - Updated handling of `model` matrices with active Float32 rescaling. This should fix issues with Float32-unsafe translations or scalings of plots, as well as rotated plots in Float32-unsafe ranges. [#4026](https://github.com/MakieOrg/Makie.jl/pull/4026)

--- a/WGLMakie/src/Serialization.js
+++ b/WGLMakie/src/Serialization.js
@@ -159,6 +159,7 @@ export function deserialize_plot(scene, data) {
     mesh.frustumCulled = false;
     mesh.matrixAutoUpdate = false;
     mesh.plot_uuid = data.uuid;
+    mesh.renderOrder = data.zvalue;
     update_visible(data.visible.value);
     data.visible.on(update_visible);
     connect_uniforms(mesh, data.uniform_updater);
@@ -453,7 +454,7 @@ function create_material(scene, program) {
         transparent: true,
         glslVersion: THREE.GLSL3,
         depthTest: !program.overdraw.value,
-        depthWrite: !program.transparency.value
+        depthWrite: !program.transparency.value,
     });
 }
 

--- a/WGLMakie/src/lines.jl
+++ b/WGLMakie/src/lines.jl
@@ -196,7 +196,7 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
     uniforms[:num_clip_planes] = map(plot, plot.clip_planes, plot.space) do planes, space
         return Makie.is_data_space(space) ? length(planes) : 0
     end
-    
+
     uniforms[:clip_planes] = map(plot, scene.camera.projectionview, plot.clip_planes, plot.space) do pv, planes, space
         Makie.is_data_space(space) || return [Vec4f(0, 0, 0, -1e9) for _ in 1:8]
 
@@ -226,7 +226,8 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
         :uniform_updater => uniform_updater(plot, uniforms),
         :attributes => attributes,
         :transparency => plot.transparency,
-        :overdraw => plot.overdraw
+        :overdraw => plot.overdraw,
+        :zvalue => Makie.zvalue2d(plot)
     )
     return attr
 end

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -22413,6 +22413,7 @@ function deserialize_plot(scene, data) {
     mesh.frustumCulled = false;
     mesh.matrixAutoUpdate = false;
     mesh.plot_uuid = data.uuid;
+    mesh.renderOrder = data.zvalue;
     update_visible(data.visible.value);
     data.visible.on(update_visible);
     connect_uniforms(mesh, data.uniform_updater);

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -123,7 +123,7 @@ end
 
 function _selection_vertices(ax_scene, outer, inner)
     _clamp(p, plow, phigh) = Point2(clamp(p[1], plow[1], phigh[1]), clamp(p[2], plow[2], phigh[2]))
-    proj(point) = project(ax_scene, point) .+ minimum(ax_scene.viewport[])
+    proj(point) = project(ax_scene, point)
     transf = Makie.transform_func(ax_scene)
     outer = positivize(Makie.apply_transform(transf, outer))
     inner = positivize(Makie.apply_transform(transf, inner))

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -672,16 +672,19 @@ end
 
 function RectangleZoom(f::Function, ax::Axis; kw...)
     r = RectangleZoom(f; kw...)
-    selection_vertices = lift(_selection_vertices, ax.blockscene, Observable(ax.scene), ax.finallimits,
+    rect_scene = Scene(ax.scene)
+    selection_vertices = lift(_selection_vertices, rect_scene, Observable(ax.scene), ax.finallimits,
                               r.rectnode)
     # manually specify correct faces for a rectangle with a rectangle hole inside
     faces = [1 2 5; 5 2 6; 2 3 6; 6 3 7; 3 4 7; 7 4 8; 4 1 8; 8 1 5]
     # plot to blockscene, so ax.scene stays exclusive for user plots
     # That's also why we need to pass `ax.scene` to _selection_vertices, so it can project to that space
-    mesh = mesh!(ax.blockscene, selection_vertices, faces, color = (:black, 0.2), shading = NoShading,
-                 inspectable = false, visible=r.active, transparency=true)
+    mesh = mesh!(rect_scene,
+        selection_vertices, faces, space=:pixel,
+        color = (:black, 0.2), shading = NoShading,
+        inspectable = false, transparency=true, overdraw=true, visible=r.active)
     # translate forward so selection mesh and frame are never behind data
-    translate!(mesh, 0, 0, 100)
+    translate!(mesh, 0, 0, 1000)
     return r
 end
 


### PR DESCRIPTION
Closes #4019, mostly by adding a new childscene for the rectangle zoom to the axis.
This comes from a problem in render order with Threejs, which I wasn't able to fix ad-hoc.
Going forward, adding something to the parent scene, that should overlay a child scene may never really make sense, so threejs behaviour might not be as wrong. 