### PR TITLE
Apply px per unit in `pick_closest`/`pick_sorted`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Apply px per unit in `pick_closest`/`pick_sorted` [#4137]https://github.com/MakieOrg/Makie.jl/pull/4137
+
 ## [0.21.6] - 2024-08-14
 
 - Fix RectangleZoom in WGLMakie [#4127](https://github.com/MakieOrg/Makie.jl/pull/4127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Apply px per unit in `pick_closest`/`pick_sorted` [#4137]https://github.com/MakieOrg/Makie.jl/pull/4137
+- Apply px per unit in `pick_closest`/`pick_sorted` [#4137](https://github.com/MakieOrg/Makie.jl/pull/4137).
 - Reduce updates for image/heatmap, improving performance [#4130](https://github.com/MakieOrg/Makie.jl/pull/4130).
 - Fix rendering of `band` with NaN values [#4178](https://github.com/MakieOrg/Makie.jl/pull/4178).
 

--- a/GLMakie/src/picking.jl
+++ b/GLMakie/src/picking.jl
@@ -81,10 +81,10 @@ function Makie.pick_closest(scene::Scene, screen::Screen, xy, range)
     glBindFramebuffer(GL_FRAMEBUFFER, fb.id[1])
     glReadBuffer(GL_COLOR_ATTACHMENT1)
     buff = fb.buffers[:objectid]
-    picks = zeros(SelectionID{UInt32}, dx, dy)
-    glReadPixels(x0, y0, dx, dy, buff.format, buff.pixeltype, picks)
+    sids = zeros(SelectionID{UInt32}, dx, dy)
+    glReadPixels(x0, y0, dx, dy, buff.format, buff.pixeltype, sids)
 
-    min_dist = range^2
+    min_dist = (ppu * range)^2
     id = SelectionID{Int}(0, 0)
     x, y = xy .* ppu .+ 1 .- Vec2f(x0, y0)
     for i in 1:dx, j in 1:dy
@@ -126,7 +126,7 @@ function Makie.pick_sorted(scene::Scene, screen::Screen, xy, range)
     glReadPixels(x0, y0, dx, dy, buff.format, buff.pixeltype, picks)
 
     selected = filter(x -> x.id > 0 && haskey(screen.cache2plot, x.id), unique(vec(picks)))
-    distances = Float32[range^2 for _ in selected]
+    distances = Float32[floatmax(Float32) for _ in selected]
     x, y = xy .* ppu .+ 1 .- Vec2f(x0, y0)
     for i in 1:dx, j in 1:dy
         if picks[i, j].id > 0

--- a/GLMakie/src/picking.jl
+++ b/GLMakie/src/picking.jl
@@ -12,7 +12,7 @@ function pick_native(screen::Screen, rect::Rect2i)
     glReadBuffer(GL_COLOR_ATTACHMENT1)
     rx, ry = minimum(rect)
     rw, rh = widths(rect)
-    w, h = size(fb) # pixel dimensions
+    w, h = size(screen.root_scene)
     ppu = screen.px_per_unit[]
     if rx > 0 && ry > 0 && rx + rw <= w && ry + rh <= h
         rx, ry, rw, rh = round.(Int, ppu .* (rx, ry, rw, rh))
@@ -32,7 +32,7 @@ function pick_native(screen::Screen, xy::Vec{2, Float64})
     glBindFramebuffer(GL_FRAMEBUFFER, fb.id[1])
     glReadBuffer(GL_COLOR_ATTACHMENT1)
     x, y = floor.(Int, xy)
-    w, h = size(fb) # pixel dimensions
+    w, h = size(screen.root_scene)
     ppu = screen.px_per_unit[]
     if x > 0 && y > 0 && x <= w && y <= h
         x, y = round.(Int, ppu .* (x, y))

--- a/GLMakie/src/picking.jl
+++ b/GLMakie/src/picking.jl
@@ -105,7 +105,7 @@ end
 
 # Skips some allocations
 function Makie.pick_sorted(scene::Scene, screen::Screen, xy, range)
-    isopen(screen) || return (nothing, 0)
+    isopen(screen) || return Tuple{AbstractPlot, Int}[]
     w, h = size(screen.root_scene) # unitless dimensions
     if !((1.0 <= xy[1] <= w) && (1.0 <= xy[2] <= h))
         return Tuple{AbstractPlot, Int}[]

--- a/GLMakie/src/picking.jl
+++ b/GLMakie/src/picking.jl
@@ -67,7 +67,7 @@ end
 # Skips one set of allocations
 function Makie.pick_closest(scene::Scene, screen::Screen, xy, range)
     isopen(screen) || return (nothing, 0)
-    w, h = size(scene) # unitless dimensions
+    w, h = size(screen.root_scene) # unitless dimensions
     ((1.0 <= xy[1] <= w) && (1.0 <= xy[2] <= h)) || return (nothing, 0)
 
     fb = screen.framebuffer
@@ -106,7 +106,7 @@ end
 # Skips some allocations
 function Makie.pick_sorted(scene::Scene, screen::Screen, xy, range)
     isopen(screen) || return (nothing, 0)
-    w, h = size(scene) # unitless dimensions
+    w, h = size(screen.root_scene) # unitless dimensions
     if !((1.0 <= xy[1] <= w) && (1.0 <= xy[2] <= h))
         return Tuple{AbstractPlot, Int}[]
     end

--- a/GLMakie/src/picking.jl
+++ b/GLMakie/src/picking.jl
@@ -84,7 +84,7 @@ function Makie.pick_closest(scene::Scene, screen::Screen, xy, range)
     sids = zeros(SelectionID{UInt32}, dx, dy)
     glReadPixels(x0, y0, dx, dy, buff.format, buff.pixeltype, sids)
 
-    min_dist = (ppu * range)^2
+    min_dist = floatmax(Float32)
     id = SelectionID{Int}(0, 0)
     x, y = xy .* ppu .+ 1 .- Vec2f(x0, y0)
     for i in 1:dx, j in 1:dy

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -323,7 +323,6 @@ end
     screen = display(GLMakie.Screen(visible = true, scalefactor = 2), fig)
     @test screen.scalefactor[] === 2f0
     @test screen.px_per_unit[] === 2f0  # inherited from scale factor
-    winscale = screen.scalefactor[] / (@static Sys.isapple() ? GLMakie.scale_factor(screen.glscreen) : 1)
     @test size(screen.framebuffer) == (2W, 2H)
     @test GLMakie.window_size(screen.glscreen) == scaled(screen, (W, H))
 
@@ -341,6 +340,11 @@ end
     picks = pick(ax.scene, quadrant)
     points = Set(Int(p[2]) for p in picks if p[1] isa Scatter)
     @test points == Set(((N+1)÷2):N)
+    # - pick sorted
+    xy_px = project_sp(ax.scene, Point2f(x[1], y[1]))
+    picks = pick_sorted(ax.scene, screen, xy_px, 50)
+    points = [i for (p, i) in picks if p == pl]
+    @test points == [1, 2, 3]
 
     # render at lower resolution
     screen = display(GLMakie.Screen(visible = false, scalefactor = 2, px_per_unit = 1), fig)

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -342,7 +342,7 @@ end
     @test points == Set(((N+1)÷2):N)
     # - pick sorted
     xy_px = project_sp(ax.scene, Point2f(x[1], y[1]))
-    picks = pick_sorted(ax.scene, screen, xy_px, 50)
+    picks = GLMakie.Makie.pick_sorted(ax.scene, screen, xy_px, 50)
     points = [i for (p, i) in picks if p == pl]
     @test points == [1, 2, 3]
 

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -23258,7 +23258,7 @@ function pick_closest(scene, xy, range) {
     const dy = y1 - y0;
     const [plot_data, _] = pick_native(scene, x0, y0, dx, dy, false);
     const plot_matrix = plot_data.data;
-    let min_dist = Math.pow(px_per_unit * range, 2);
+    let min_dist = 1e30;
     let selection = [
         null,
         0

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -23152,14 +23152,16 @@ function set_picking_uniforms(scene, last_id, picking, picked_plots, plots, id_t
     });
     return next_id;
 }
-function pick_native(scene, _x, _y, _w, _h) {
+function pick_native(scene, _x, _y, _w, _h, apply_ppu = true) {
     const { renderer , picking_target , px_per_unit  } = scene.screen;
-    [_x, _y, _w, _h] = [
-        _x,
-        _y,
-        _w,
-        _h
-    ].map((x)=>Math.ceil(x * px_per_unit));
+    if (apply_ppu) {
+        [_x, _y, _w, _h] = [
+            _x,
+            _y,
+            _w,
+            _h
+        ].map((x)=>Math.round(x * px_per_unit));
+    }
     const [x, y, w, h] = [
         _x,
         _y,
@@ -23237,7 +23239,7 @@ function get_picking_buffer(scene) {
     };
 }
 function pick_closest(scene, xy, range) {
-    const { renderer  } = scene.screen;
+    const { canvas , px_per_unit , renderer  } = scene.screen;
     const [width, height] = [
         renderer._width,
         renderer._height
@@ -23248,21 +23250,21 @@ function pick_closest(scene, xy, range) {
             0
         ];
     }
-    const x0 = Math.max(1, xy[0] - range);
-    const y0 = Math.max(1, xy[1] - range);
-    const x1 = Math.min(width, Math.floor(xy[0] + range));
-    const y1 = Math.min(height, Math.floor(xy[1] + range));
+    const x0 = Math.max(1, Math.floor(px_per_unit * (xy[0] - range)));
+    const y0 = Math.max(1, Math.floor(px_per_unit * (xy[1] - range)));
+    const x1 = Math.min(canvas.width, Math.ceil(px_per_unit * (xy[0] + range)));
+    const y1 = Math.min(canvas.height, Math.ceil(px_per_unit * (xy[1] + range)));
     const dx = x1 - x0;
     const dy = y1 - y0;
-    const [plot_data, _] = pick_native(scene, x0, y0, dx, dy);
+    const [plot_data, _] = pick_native(scene, x0, y0, dx, dy, false);
     const plot_matrix = plot_data.data;
     let min_dist = Math.pow(range, 2);
     let selection = [
         null,
         0
     ];
-    const x = xy[0] + 1 - x0;
-    const y = xy[1] + 1 - y0;
+    const x = xy[0] * px_per_unit + 1 - x0;
+    const y = xy[1] * px_per_unit + 1 - y0;
     let pindex = 0;
     for(let i = 1; i <= dx; i++){
         for(let j = 1; j <= dx; j++){
@@ -23281,7 +23283,7 @@ function pick_closest(scene, xy, range) {
     return selection;
 }
 function pick_sorted(scene, xy, range) {
-    const { renderer  } = scene.screen;
+    const { canvas , px_per_unit , renderer  } = scene.screen;
     const [width, height] = [
         renderer._width,
         renderer._height
@@ -23289,20 +23291,20 @@ function pick_sorted(scene, xy, range) {
     if (!(1.0 <= xy[0] <= width && 1.0 <= xy[1] <= height)) {
         return null;
     }
-    const x0 = Math.max(1, xy[0] - range);
-    const y0 = Math.max(1, xy[1] - range);
-    const x1 = Math.min(width, Math.floor(xy[0] + range));
-    const y1 = Math.min(height, Math.floor(xy[1] + range));
+    const x0 = Math.max(1, Math.floor(px_per_unit * (xy[0] - range)));
+    const y0 = Math.max(1, Math.floor(px_per_unit * (xy[1] - range)));
+    const x1 = Math.min(canvas.width, Math.ceil(px_per_unit * (xy[0] + range)));
+    const y1 = Math.min(canvas.height, Math.ceil(px_per_unit * (xy[1] + range)));
     const dx = x1 - x0;
     const dy = y1 - y0;
-    const [plot_data, selected] = pick_native(scene, x0, y0, dx, dy);
+    const [plot_data, selected] = pick_native(scene, x0, y0, dx, dy, false);
     if (selected.length == 0) {
         return null;
     }
     const plot_matrix = plot_data.data;
     const distances = selected.map((x)=>Math.pow(range, 2));
-    const x = xy[0] + 1 - x0;
-    const y = xy[1] + 1 - y0;
+    const x = xy[0] * px_per_unit + 1 - x0;
+    const y = xy[1] * px_per_unit + 1 - y0;
     let pindex = 0;
     for(let i = 1; i <= dx; i++){
         for(let j = 1; j <= dx; j++){

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -23258,7 +23258,7 @@ function pick_closest(scene, xy, range) {
     const dy = y1 - y0;
     const [plot_data, _] = pick_native(scene, x0, y0, dx, dy, false);
     const plot_matrix = plot_data.data;
-    let min_dist = Math.pow(range, 2);
+    let min_dist = Math.pow(px_per_unit * range, 2);
     let selection = [
         null,
         0
@@ -23302,7 +23302,7 @@ function pick_sorted(scene, xy, range) {
         return null;
     }
     const plot_matrix = plot_data.data;
-    const distances = selected.map((x)=>Math.pow(range, 2));
+    const distances = selected.map((x)=>1e30);
     const x = xy[0] * px_per_unit + 1 - x0;
     const y = xy[1] * px_per_unit + 1 - y0;
     let pindex = 0;

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -598,7 +598,7 @@ export function pick_closest(scene, xy, range) {
     const dy = y1 - y0;
     const [plot_data, _] = pick_native(scene, x0, y0, dx, dy, false);
     const plot_matrix = plot_data.data;
-    let min_dist = Math.pow(range, 2);
+    let min_dist = Math.pow(px_per_unit * range, 2);
     let selection = [null, 0];
     const x = xy[0] * px_per_unit + 1 - x0;
     const y = xy[1] * px_per_unit + 1 - y0;
@@ -638,7 +638,7 @@ export function pick_sorted(scene, xy, range) {
         return null;
     }
     const plot_matrix = plot_data.data;
-    const distances = selected.map((x) => Math.pow(range, 2));
+    const distances = selected.map((x) => 1e30);
     const x = xy[0] * px_per_unit + 1 - x0;
     const y = xy[1] * px_per_unit + 1 - y0;
     let pindex = 0;

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -598,7 +598,7 @@ export function pick_closest(scene, xy, range) {
     const dy = y1 - y0;
     const [plot_data, _] = pick_native(scene, x0, y0, dx, dy, false);
     const plot_matrix = plot_data.data;
-    let min_dist = Math.pow(px_per_unit * range, 2);
+    let min_dist = 1e30;
     let selection = [null, 0];
     const x = xy[0] * px_per_unit + 1 - x0;
     const y = xy[1] * px_per_unit + 1 - y0;


### PR DESCRIPTION
# Description

Apply px per unit in `pick_closest`/`pick_sorted`. ~I haven't applied this change to GLMakie because I had some more questions about the suggestion in #4136.~ Instead of blocking #4136, I decided to open a separate PR for this fix.

Before this PR, PPU wasn't accounted for in `pick_closest`/`pick_sorted`. A `PPU < 1` would crash GLMakie and a `PPU > 1` would cause erroneous tooltip behavior in GLMakie/WGLMakie.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
