### PR TITLE
Fix clip state corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed the broken OpenGL state cleanup for clip_planes which may cause plots to disappear randomly [#4157](https://github.com/MakieOrg/Makie.jl/pull/4157)
 
 ## [0.21.7] - 2024-08-19
 

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -10,7 +10,7 @@ function setup_clip_planes(robj)
     for i in 0:min(7, N-1)
         glEnable(GL_CLIP_DISTANCE0 + UInt32(i))
     end
-    for i in Max(0, N):7
+    for i in max(0, N):7
         glDisable(GL_CLIP_DISTANCE0 + UInt32(i))
     end
 end

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -10,10 +10,9 @@ function setup_clip_planes(robj)
     for i in 0:min(7, N-1)
         glEnable(GL_CLIP_DISTANCE0 + UInt32(i))
     end
-    # TODO: This crashes?
-    # for i in N:7
-    #     glDisable(GL_CLIP_DISTANCE0 + UInt32(i))
-    # end
+    for i in Max(0, N):7
+        glDisable(GL_CLIP_DISTANCE0 + UInt32(i))
+    end
 end
 
 

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -77,7 +77,11 @@ function mixin_generic_plot_attributes()
         inspector_clear = automatic
         "Sets a callback function `(inspector, plot, index) -> ...` which replaces the default `show_data` methods."
         inspector_hover = automatic
-        "TODO: docs"
+        """
+        Clip planes offer a way to do clipping in 3D space. You can set a Vector of up to 8 `Plane3f` planes here, 
+        behind which plots will be clipped (i.e. become invisible). By default clip planes are inherited from the 
+        parent plot or scene. You can remove parent clip_planes by passing `Plane3f[]`. 
+        """
         clip_planes = automatic
     end
 end

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -80,7 +80,7 @@ function mixin_generic_plot_attributes()
         """
         Clip planes offer a way to do clipping in 3D space. You can set a Vector of up to 8 `Plane3f` planes here, 
         behind which plots will be clipped (i.e. become invisible). By default clip planes are inherited from the 
-        parent plot or scene. You can remove parent clip_planes by passing `Plane3f[]`. 
+        parent plot or scene. You can remove parent `clip_planes` by passing `Plane3f[]`. 
         """
         clip_planes = automatic
     end

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -141,6 +141,7 @@ pages = [
             "reference/scene/lighting.md",
             "reference/scene/matcap.md",
             "reference/scene/SSAO.md",
+            "reference/scene/clip_planes.md",
         ]
     ],
     "Tutorials" => [


### PR DESCRIPTION
# Description

Re-enables the `glDisable(GL_CLIP_DISTANCE<N>)` lines without which OpenGL can get into a state where clipping is enabled but the values are not set. In that state plots will randomly get clipped. 

I got to this state in #4131 with some tests that include multiple Axis3, each setting 6 clip planes via ax.scene.theme.clip_planes. I don't think I managed to reproduce it by just setting one clip plane in a plot.

In #3958 I had some trouble with this code and had it disabled because of that. I'm not sure what exactly the problem was, but now I have no issues with it on my Laptop or PC.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
