### PR TITLE
Fix bands with NaN values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Reduce updates for image/heatmap, improving performance [#4130](https://github.com/MakieOrg/Makie.jl/pull/4130).
+- Fix rendering of `band` with NaN values [#4178](https://github.com/MakieOrg/Makie.jl/pull/4178).
 
 ## [0.21.7] - 2024-08-19
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -195,6 +195,40 @@ end
     current_figure()
 end
 
+@reference_test "Band with NaN" begin
+    f = Figure()
+    ax1 = Axis(f[1, 1])
+
+    # NaN in the middle
+    band!(ax1, 1:5, [1, 2, NaN, 4, 5], [1.5, 3, 4, 5, 6.5])
+    band!(ax1, 1:5, [3, 4, 5, 6, 7], [3.5, 5, NaN, 7, 8.5])
+    band!(ax1, [1, 2, NaN, 4, 5], [5, 6, 7, 8, 9], [5.5, 7, 8, 9, 10.5])
+
+    ax2 = Axis(f[1, 2])
+
+    # NaN at the beginning and end
+    band!(ax2, 1:5, [NaN, 2, 3, 4, NaN], [1.5, 3, 4, 5, 6.5])
+    band!(ax2, 1:5, [3, 4, 5, 6, 7], [NaN, 5, 6, 7, NaN])
+    band!(ax2, [NaN, 2, 3, 4, NaN], [5, 6, 7, 8, 9], [5.5, 7, 8, 9, 10.5])
+
+    ax3 = Axis(f[2, 1])
+
+    # No complete section
+    band!(ax3, 1:5, [NaN, 2, NaN, 4, NaN], [1.5, 3, 4, 5, 6.5])
+    band!(ax3, 1:5, [3, 4, 5, 6, 7], [NaN, 5, NaN, 7, NaN])
+    band!(ax3, [NaN, 2, NaN, 4, NaN], [5, 6, 7, 8, 9], [5.5, 7, 8, 9, 10.5])
+
+    ax4 = Axis(f[2, 2])
+    # Two adjacent NaNs
+    band!(ax4, 1:6, [1, 2, NaN, NaN, 5, 6], [1.5, 3, 4, 5, 6, 7.5])
+    band!(ax4, 1:6, [3, 4, 5, 6, 7, 8], [3.5, 5, NaN, NaN, 8, 9.5])
+    band!(ax4, [1, 2, NaN, NaN, 5, 6], [5, 6, 7, 8, 9, 10], [5.5, 7, 8, 9, 10, 11.5])
+
+    linkaxes!(ax1, ax2, ax3, ax4)
+
+    f
+end
+
 @reference_test "Streamplot animation" begin
     v(x::Point2{T}, t) where T = Point2{T}(one(T) * x[2] * t, 4 * x[1])
     sf = Observable(Base.Fix2(v, 0.0))

--- a/src/basic_recipes/band.jl
+++ b/src/basic_recipes/band.jl
@@ -27,9 +27,20 @@ end
 
 function Makie.plot!(plot::Band)
     @extract plot (lowerpoints, upperpoints)
+    nanpoint(::Type{<:Point3}) = Point3(NaN)
+    nanpoint(::Type{<:Point2}) = Point2(NaN)
     coordinates = lift(plot, lowerpoints, upperpoints) do lowerpoints, upperpoints
-        @assert length(lowerpoints) == length(upperpoints) "length of lower band is not equal to length of upper band!"
-        return [lowerpoints; upperpoints]
+        n = length(lowerpoints)
+        @assert n == length(upperpoints) "length of lower band is not equal to length of upper band!"
+        concat = [lowerpoints; upperpoints]
+        # if either x, upper or lower is NaN, all of them should be NaN to cut out a whole band segment and not just a triangle
+        for i in 1:n
+            if isnan(lowerpoints[i]) || isnan(upperpoints[i])
+                concat[i] = nanpoint(eltype(concat))
+                concat[n + i] = nanpoint(eltype(concat))
+            end
+        end
+        return concat
     end
     connectivity = lift(x -> band_connect(length(x)), plot, plot[1])
 


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/2845

This PR changes GLMakie behavior also, such that bands miss the complete sections where either x, lower or upper is NaN. This matches behavior of matplotlib, for example, and makes sense because the user shouldn't be exposed to the fact that band is rendered using triangles.

In CairoMakie, the new test cases look like this on master:

<img width="540" alt="image" src="https://github.com/user-attachments/assets/90a34dc7-6157-49fe-b610-4a84407fda78">

And like this in this PR:

<img width="541" alt="image" src="https://github.com/user-attachments/assets/2f42c02b-73e4-4dca-a32b-9c807a5b25d5">


In GLMakie, the new test cases look like this on master:

<img width="538" alt="image" src="https://github.com/user-attachments/assets/08f68c6d-12f5-45bb-b6eb-7fed9e8de8c2">

And like this in this PR:

<img width="538" alt="image" src="https://github.com/user-attachments/assets/dab57ae6-7126-468a-8545-b88930c4aa0d">

