### PR TITLE
Corrected pt to cm conversion

### DIFF
--- a/docs/src/explanations/figure.md
+++ b/docs/src/explanations/figure.md
@@ -189,7 +189,7 @@ In GLMakie, the default behavior is different. Because GLMakie doesn't just prod
 Academic journals usually demand that figures you submit adhere to specific physical dimensions.
 How can you render Makie figures at exactly the right sizes?
 
-First, let's look at vector graphics, which are usually desired for documents because they have the best text and line rendering quality at any zoom level. The output unit of vector graphics is always `pt` in CairoMakie. You can convert to points from inches via `1 in == 72 pt` and from centimeters via `1 cm = 28,3465 pt`.
+First, let's look at vector graphics, which are usually desired for documents because they have the best text and line rendering quality at any zoom level. The output unit of vector graphics is always `pt` in CairoMakie. You can convert to points from inches via `1 in == 72 pt` and from centimeters via `1 cm = 28.3465 pt`.
 
 Let's say your desired output size is 5 x 4 inches and you should use a font size of 12 pt. You multiply 5 x 4 by 72 to get 360 x 288 pt. The size you need to set on your `Figure` depends on the `pt_per_unit` value you want to use. When making plots for publications, you should usually just save with `pt_per_unit = 1`. So in our example, we would use `Figure(size = (360, 288))` and for text set `fontsize = 12` to match the 12 pt requirement.
 


### PR DESCRIPTION
# Description

Fixed incorrect unit conversion of pt to cm on `docs/src/explanations/fonts.md` where it stated that `1 cm = 28,3465 pt` instead of `1 cm = 28.3465 pt`.

I understand this is exceptionally minor and that both full stops and commas are valid decimal separators, but the rest of the page uses the full stop causing a confusing inconsistency. 

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

As this change is so minor, I don't beleieve I have to carry out any of the checklist items. This is my first PR, so please let me know if I'm not correct in assuming this.

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
