### PR TITLE
Fix lines with OffsetArrays in CairoMakie

### DIFF
--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -203,8 +203,8 @@ end
         f32convert = Makie.f32_convert_matrix(scene.float32convert, space)
         transform = Makie.space_to_clip(scene.camera, space) * model * f32convert
         clip_points = Vector{Vec4f}(undef, length(points))
-        @inbounds for i in eachindex(points)
-            clip_points[i] = transform * to_ndim(Vec4d, to_ndim(Vec3d, points[i], 0), 1)
+        @inbounds for (i, point) in enumerate(points)
+            clip_points[i] = transform * to_ndim(Vec4d, to_ndim(Vec3d, point, 0), 1)
         end
         
         # yflip and clip -> screen/pixel coords

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1564,3 +1564,7 @@ end
     spy(f[2, 2], data; highclip=:red, lowclip=(:grey, 0.5), nan_color=:black, colorrange=(0.3, 0.7))
     f
 end
+
+@reference_test "Lines with OffsetArrays" begin
+    lines(Makie.OffsetArrays(-50)(1:100))
+end


### PR DESCRIPTION
# Description

Allows `lines(::OffsetArray{T, 1})` to work again.  CairoMakie had an issue with the new line clipping code where it assumed that the indexing of the point array was one based, which has now been fixed.  The final array returned from clipping is guaranteed to be a regular `Vector`, though.

Also adds a new reference test.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [X] Added reference image tests for new plotting functions, recipes, visual options, etc.
