### PR TITLE
[WIP] Allow GLMakie to display surfaces transformed by a 3d transform func

### DIFF
--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -820,33 +820,34 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Surface)
         if all(T -> T <: Union{AbstractMatrix, AbstractVector}, types)
             t = Makie.transform_func_obs(plot)
             mat = plot[3]
-            xypos = lift(plot, pop!(gl_attributes, :f32c), plot.model, t, plot[1], plot[2], space) do f32c, model, t, x, y, space
+            xyzpos = lift(plot, pop!(gl_attributes, :f32c), plot.model, t, plot[1], plot[2], mat, space) do f32c, model, t, x, y, z, space
                 # Only if transform doesn't do anything, we can stay linear in 1/2D
                 if Makie.is_identity_transform(t) && isnothing(f32c)
-                    return (x, y)
+                    return (x, y, z)
                 elseif Makie.is_translation_scale_matrix(model)
                     matrix = if x isa AbstractMatrix && y isa AbstractMatrix
-                        Makie.f32_convert(f32c, apply_transform.((t,), Point.(x, y), space), space)
+                        [Makie.f32_convert(f32c, apply_transform(t, Point3(x, y, z[ix, iy]), space), space) for (ix, x) in pairs(x), (iy, y) in pairs(y)]
                     else
                         # If we do any transformation, we have to assume things aren't on the grid anymore
                         # so x + y need to become matrices.
-                        [Makie.f32_convert(f32c, apply_transform(t, Point(x, y), space), space) for x in x, y in y]
+                        [Makie.f32_convert(f32c, apply_transform(t, Point3(x, y, z[ix, iy]), space), space) for (ix, x) in pairs(x), (iy, y) in pairs(y)]
                     end
-                    return (first.(matrix), last.(matrix))
+                    return (getindex.(matrix, 1), getindex.(matrix, 2), getindex.(matrix, 3))
                 else
                     matrix = if x isa AbstractMatrix && y isa AbstractMatrix
-                        Makie.f32_convert(f32c, apply_transform_and_model.((model,), (t,), Point.(x, y), space, Point2d), space)
+                        [Makie.f32_convert(f32c, apply_transform_and_model(model, t, Point3.(x, y, z[ix, iy]), space, Point3d), space) for (ix, x) in pairs(x), (iy, y) in pairs(y)]
                     else
                         # If we do any transformation, we have to assume things aren't on the grid anymore
                         # so x + y need to become matrices.
-                        [Makie.f32_convert(f32c, apply_transform_and_model(model, t, Point(x, y), space, Point2d), space) for x in x, y in y]
+                        [Makie.f32_convert(f32c, apply_transform_and_model(model, t, Point3(x, y, z[ix, iy]), space, Point3d), space) for (ix, x) in pairs(x), (iy, y) in pairs(y)]
                     end
-                    return (first.(matrix), last.(matrix))
+                    return (getindex.(matrix, 1), getindex.(matrix, 2), getindex.(matrix, 3))
                 end
             end
-            xpos = lift(first, plot, xypos)
-            ypos = lift(last, plot, xypos)
-            args = map((xpos, ypos, mat)) do arg
+            xpos = lift(Base.Fix2(getindex, 1), plot, xyzpos)
+            ypos = lift(Base.Fix2(getindex, 2), plot, xyzpos)
+            zpos = lift(Base.Fix2(getindex, 3), plot, xyzpos)
+            args = map((xpos, ypos, zpos)) do arg
                 Texture(lift(x-> convert(Array, el32convert(x)), plot, arg); minfilter=:linear)
             end
             if isnothing(img)


### PR DESCRIPTION
# Description

Fixes #2890

Modifies GLMakie to be able to use 2D to 3D transformations in `surface`.

Needs a reference test and to make sure this doesn't break anything.  It doesn't appear to do so at the moment, though.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
