### PR TITLE
[WIP] Allow heatmaps of offsetarrays to be plotted

### DIFF
--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -524,6 +524,15 @@ cairo_scatter_marker(marker) = Makie.to_spritemarker(marker)
 
 to_cairo_image(img::AbstractMatrix{<: Colorant}) =  to_cairo_image(to_uint32_color.(img))
 
+function to_cairo_image(img::AbstractMatrix{UInt32})
+    # we need to convert from column-major to row-major storage,
+    # therefore we permute the dimensions.
+    # the materialization is necessary since the image is passed directly to Cairo.
+    materialized_matrix = collect(permutedims(img)) 
+    return Cairo.CairoARGBSurface(materialized_matrix) 
+end
+
+# This code path is more efficient since it avoids iterating over the returned matrix if we don't have to.
 function to_cairo_image(img::Matrix{UInt32})
     # we need to convert from column-major to row-major storage,
     # therefore we permute x and y

--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -155,7 +155,7 @@ function numbers_to_colors(numbers::Union{AbstractArray{<:Number, N},Number},
                            colormap, colorscale, colorrange::Vec2,
                            lowclip::Union{Automatic,RGBAf},
                            highclip::Union{Automatic,RGBAf},
-                           nan_color::RGBAf)::Union{Array{RGBAf, N},RGBAf} where {N}
+                           nan_color::RGBAf)::Union{AbstractArray{RGBAf, N},RGBAf} where {N}
     cmin, cmax = colorrange
     scaled_cmin = apply_scale(colorscale, cmin)
     scaled_cmax = apply_scale(colorscale, cmax)
@@ -366,7 +366,7 @@ end
 function assemble_colors(::Number, color, plot)
     plot.colorrange[] isa Automatic && error("Cannot determine a colorrange automatically for single number color value. Pass an explicit colorrange.")
     cm = assemble_colors([color[]], lift(x -> [x], color), plot)
-    return lift((args...)-> numbers_to_colors(args...)[1], cm.color_scaled, cm.colormap, identity, cm.colorrange_scaled, cm.lowclip, cm.highclip,
+    return lift((args...)-> numbers_to_colors(args...)[1], plot, cm.color_scaled, cm.colormap, identity, cm.colorrange_scaled, cm.lowclip, cm.highclip,
                       cm.nan_color)
 end
 


### PR DESCRIPTION
# Description

Fixes some method definitions to allow offset heatmaps to be plotted.  Related to #4242 but still not sure if this is the right direction.

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
