### PR TITLE
v0.21.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.21.9] - 2024-08-27
+
+- Hotfix for colormap + color updates [#4258](https://github.com/MakieOrg/Makie.jl/pull/4258).
+
 ## [0.21.8] - 2024-08-26
 
 - Fix selected list in `WGLMakie.pick_sorted` [#4136](https://github.com/MakieOrg/Makie.jl/pull/4136).
@@ -575,7 +579,8 @@ All other changes are collected [in this PR](https://github.com/MakieOrg/Makie.j
 - Fixed rendering of `heatmap`s with one or more reversed ranges in CairoMakie, as in `heatmap(1:10, 10:-1:1, rand(10, 10))` [#1100](https://github.com/MakieOrg/Makie.jl/pull/1100).
 - Fixed volume slice recipe and added docs for it [#1123](https://github.com/MakieOrg/Makie.jl/pull/1123).
 
-[Unreleased]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.8...HEAD
+[Unreleased]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.9...HEAD
+[0.21.9]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.8...v0.21.9
 [0.21.8]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.7...v0.21.8
 [0.21.7]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.6...v0.21.7
 [0.21.6]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.5...v0.21.6

--- a/CairoMakie/Project.toml
+++ b/CairoMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "CairoMakie"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 author = ["Simon Danisch <sdanisch@gmail.com>"]
-version = "0.12.8"
+version = "0.12.9"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
@@ -24,7 +24,7 @@ FileIO = "1.1"
 FreeType = "3, 4.0"
 GeometryBasics = "0.4.11"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.8"
+Makie = "=0.21.9"
 PrecompileTools = "1.0"
 julia = "1.3"
 

--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.10.8"
+version = "0.10.9"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -30,7 +30,7 @@ FreeTypeAbstraction = "0.10"
 GLFW = "3.4.3"
 GeometryBasics = "0.4.11"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.8"
+Makie = "=0.21.9"
 Markdown = "1.0, 1.6"
 MeshIO = "0.4"
 ModernGL = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Makie"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 authors = ["Simon Danisch", "Julius Krumbiegel"]
-version = "0.21.8"
+version = "0.21.9"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"

--- a/RPRMakie/Project.toml
+++ b/RPRMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "RPRMakie"
 uuid = "22d9f318-5e34-4b44-b769-6e3734a732a6"
 authors = ["Simon Danisch"]
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -17,7 +17,7 @@ Colors = "0.9, 0.10, 0.11, 0.12"
 FileIO = "1.6"
 GeometryBasics = "0.4.11"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.8"
+Makie = "=0.21.9"
 Printf = "1.0, 1.6"
 RadeonProRender = "0.3.0"
 julia = "1.3"

--- a/WGLMakie/Project.toml
+++ b/WGLMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "WGLMakie"
 uuid = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
 authors = ["SimonDanisch <sdanisch@gmail.com>"]
-version = "0.10.8"
+version = "0.10.9"
 
 [deps]
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
@@ -27,7 +27,7 @@ FreeTypeAbstraction = "0.10"
 GeometryBasics = "0.4.11"
 Hyperscript = "0.0.3, 0.0.4, 0.0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.8"
+Makie = "=0.21.9"
 Observables = "0.5.1"
 PNGFiles = "0.3, 0.4"
 PrecompileTools = "1.0"


### PR DESCRIPTION
v0.21.8 broke the lorentz example in the documentation front page (and updating colors, when notified with the same value).
