### PR TITLE
support !-functions in plotfunc() and func2type()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bring back `poly` convert arguments for matrix with points as row [#4266](https://github.com/MakieOrg/Makie.jl/pull/4258).
 - Added option `label_position = :center` to place labels centered over each bar [#4274](https://github.com/MakieOrg/Makie.jl/pull/4274).
+- `plotfunc()` and `func2type()` support functions ending with `!` [#4275](https://github.com/MakieOrg/Makie.jl/pull/4275).
 
 ## [0.21.9] - 2024-08-27
 

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -12,13 +12,14 @@ end
 plotfunc(::Plot{F}) where F = F
 plotfunc(::Type{<: AbstractPlot{Func}}) where Func = Func
 plotfunc(::T) where T <: AbstractPlot = plotfunc(T)
-plotfunc(f::Function) =
+function plotfunc(f::Function)
     if endswith(string(nameof(f)), "!")
         name = Symbol(chopsuffix(string(nameof(f)), "!"))
-        getproperty(parentmodule(f), name)
+        return getproperty(parentmodule(f), name)
     else
-        f
+        return f
     end
+end
 
 function plotfunc!(x)
     F = plotfunc(x)::Function

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -12,11 +12,23 @@ end
 plotfunc(::Plot{F}) where F = F
 plotfunc(::Type{<: AbstractPlot{Func}}) where Func = Func
 plotfunc(::T) where T <: AbstractPlot = plotfunc(T)
-plotfunc(f::Function) = f
+plotfunc(f::Function) =
+    if endswith(string(nameof(f)), "!")
+        name = Symbol(chopsuffix(string(nameof(f)), "!"))
+        getproperty(parentmodule(f), name)
+    else
+        f
+    end
+
+function plotfunc!(x)
+    F = plotfunc(x)::Function
+    name = Symbol(nameof(F), :!)
+    return getproperty(parentmodule(F), name)
+end
 
 func2type(x::T) where T = func2type(T)
 func2type(x::Type{<: AbstractPlot}) = x
-func2type(f::Function) = Plot{f}
+func2type(f::Function) = Plot{plotfunc(f)}
 
 plotkey(::Type{<: AbstractPlot{Typ}}) where Typ = Symbol(lowercase(func2string(Typ)))
 plotkey(::T) where T <: AbstractPlot = plotkey(T)

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -14,7 +14,7 @@ plotfunc(::Type{<: AbstractPlot{Func}}) where Func = Func
 plotfunc(::T) where T <: AbstractPlot = plotfunc(T)
 function plotfunc(f::Function)
     if endswith(string(nameof(f)), "!")
-        name = Symbol(chopsuffix(string(nameof(f)), "!"))
+        name = Symbol(string(nameof(f))[begin:end-1])
         return getproperty(parentmodule(f), name)
     else
         return f

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -2,6 +2,7 @@ using Makie:
     to_vertices,
     categorical_colors,
     (..)
+using Makie.MakieCore: plotfunc, plotfunc!, func2type
 
 @testset "Conversions" begin
     # NoConversion
@@ -480,4 +481,15 @@ end
     # sanity checks
     @test isapprox(Makie.angle2align(pi/4),  Vec2f(1, 1), atol = 1e-12)
     @test isapprox(Makie.angle2align(5pi/4), Vec2f(0, 0), atol = 1e-12)
+end
+
+@testset "func-Plot conversions" begin
+    @test plotfunc(scatter) === scatter
+    @test plotfunc(hist!) === hist
+    @test plotfunc(ScatterLines) === scatterlines
+    @test plotfunc!(mesh) === mesh!
+    @test plotfunc!(ablines!) === ablines!
+    @test plotfunc!(Image) === image!
+    @test func2type(lines) == Lines
+    @test func2type(hexbin!) == Hexbin
 end


### PR DESCRIPTION
# Description

These are internal functions, but still are useful for generic code: stuff like "get the recipe type from a plotting function".
This PR makes them support !-functions as well. Eg, `plotfunc(scatter!) === scatter`, `func2type(scatter!) === Scatter`.

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.
