### PR TITLE
Prototype Suggestions from #4131

### DIFF
--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -465,5 +465,5 @@ end
     cam = ax.scene.camera
 
     @test robj.uniforms[:resolution][]     == screen.px_per_unit[] * cam.resolution[]
-    @test robj.uniforms[:projectionview][] == cam.projectionview[]
+    @test robj.uniforms[:projectionview][] == Mat4f(cam.projectionview[])
 end

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -173,20 +173,20 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         scale!(mp, s, s, s)
 
         if placement === :left
-            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], o[3] - 1f0))
             rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
         elseif placement === :right
-            translate!(mp, Vec3f(o[1], o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1], o[2] + align * w[2], o[3] - 1f0))
             rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
         elseif placement in (:below, :down, :bottom)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], o[3] - 1f0))
             rotate!(mp, Quaternionf(0,0,1,0)) # pi
         elseif placement in (:above, :up, :top)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3] - 1f0))
             rotate!(mp, Quaternionf(0,0,0,1)) # 0
         else
             @error "Tooltip placement $placement invalid. Assuming :above"
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3] - 1f0))
             rotate!(mp, Quaternionf(0,0,0,1))
         end
         return
@@ -197,12 +197,6 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     outline = map(p, bbox, p.triangle_size, p.placement, p.align) do bb, s, placement, align
         l, b, z = origin(bb); w, h, _ = widths(bb)
         r, t = (l, b) .+ (w, h)
-
-        # We start/end at half width/height here to avoid corners like this:
-        #     ______
-        #   _|
-        #  |    ____
-        #  |   |
 
         shift = if placement === :left
             Vec2f[

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -130,6 +130,9 @@ from `eyeposition` to `lookat` will be used.  All inputs must be
 supplied as 3-vectors.
 """
 function lookat(eyePos::Vec{3, T}, lookAt::Vec{3, T}, up::Vec{3, T}) where T
+    return lookat_basis(eyePos, lookAt, up) * translationmatrix(-eyePos)
+end
+function lookat_basis(eyePos::Vec{3, T}, lookAt::Vec{3, T}, up::Vec{3, T}) where T
     zaxis  = normalize(eyePos-lookAt)
     xaxis  = normalize(cross(up,    zaxis))
     yaxis  = normalize(cross(zaxis, xaxis))
@@ -139,7 +142,7 @@ function lookat(eyePos::Vec{3, T}, lookAt::Vec{3, T}, up::Vec{3, T}) where T
         xaxis[2], yaxis[2], zaxis[2], T0,
         xaxis[3], yaxis[3], zaxis[3], T0,
         T0,       T0,       T0,       T1
-    ) * translationmatrix(-eyePos)
+    )
 end
 
 function lookat(::Type{T}, eyePos::Vec{3}, lookAt::Vec{3}, up::Vec{3}) where T

--- a/src/makielayout/blocks/polaraxis.jl
+++ b/src/makielayout/blocks/polaraxis.jl
@@ -230,6 +230,7 @@ function setup_camera_matrices!(po::PolarAxis)
         mini = minimum(bb); ws = widths(bb)
         scale = minimum(2usable_fraction ./ ws)
         trans = to_ndim(Vec3f, -scale .* (mini .+ 0.5ws), 0)
+        camera(po.overlay).eyeposition[] = -Vec3f(scale, scale, 1)
         camera(po.scene).view[] = transformationmatrix(trans, Vec3f(scale, scale, 1))
         return
     end
@@ -242,6 +243,7 @@ function setup_camera_matrices!(po::PolarAxis)
         scale = minimum(2usable_fraction ./ ws)
         trans = to_ndim(Vec3f, -scale .* (mini .+ 0.5ws), 0)
         scale *= rmax
+        camera(po.overlay).eyeposition[] = -Vec3f(scale, scale, 1)
         camera(po.overlay).view[] = transformationmatrix(trans, Vec3f(scale, scale, 1))
     end
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1493,6 +1493,8 @@ end
     scrollevents::Observable{ScrollEvent}
     keysevents::Observable{KeysEvent}
     interactions::Dict{Symbol, Tuple{Bool, Any}}
+    lookat::Observable{Vec3d}
+    zoom_mult::Observable{Float64}
     @attributes begin
         """
         Global state for the x dimension conversion.

--- a/src/utilities/quaternions.jl
+++ b/src/utilities/quaternions.jl
@@ -153,3 +153,11 @@ function quaternion_to_2d_angle(quat::Quaternion)
     # this assumes that the quaternion was calculated from a simple 2d rotation as well
     return 2acos(quat[4]) * (signbit(quat[1]) ? -1 : 1)
 end
+
+# From Quaternions.jl without inf
+function Base.inv(q::Quaternion)
+    a = max(abs(q[4]), abs(q[1]), abs(q[2]), abs(q[3]))
+    p = q / a
+    iq = conj(p) / (a * sum(p.data .* p.data))
+    return iq
+end

--- a/test/primitives.jl
+++ b/test/primitives.jl
@@ -3,9 +3,9 @@
     f, ax, pl = ablines(fill(0), fill(1))
     reset_limits!(ax)
     points = pl.plots[1][1]
-    @test Point2f.(points[]) == [Point2f(0), Point2f(10)]
+    @test Point2f.(points[]) ≈ [Point2f(0), Point2f(10)]
     limits!(ax, 5, 15, 6, 17)
-    @test Point2f.(points[]) == [Point2f(5), Point2f(15)]
+    @test Point2f.(points[]) ≈ [Point2f(5), Point2f(15)]
 end
 
 @testset "arrows" begin

--- a/test/quaternions.jl
+++ b/test/quaternions.jl
@@ -56,4 +56,16 @@ Base.cos(θ::Degree) = cos(θ.θ * π/180)
     @test to_rotation((v, π)) == to_rotation((v, 1.0π))
     @test to_rotation(Degree(90)) == to_rotation(π/2)
     @test to_rotation((v, Degree(90))) == to_rotation((v, π/2))
+
+    # inversion
+    id = Quaternionf(0,0,0,1)
+    for _ in 1:10
+        v1 = Makie.normalize(2 .* rand(Vec3f) .- Vec3f(1))
+        q = Makie.rotation_between(v1, Vec3f(0,0,1))
+        p = inv(q)
+        maybe_id = q * p
+        for i in 1:4
+            @test id[i] ≈ maybe_id[i] atol = 2eps(1f0)
+        end
+    end
 end


### PR DESCRIPTION
# Description

This is a quick-ish prototype for the suggestion made in #4131, i.e. apply zoom and translation not just to the axis content, but also decorations.

Changes boil down to:
- add ax.zoom_mult and ax.lookat and have interactions affect camera matrices through them
- move ticks, tick labels, axis labels and axis frame to from the blockscene to the 3D scene to avoid different Scene/viewport base clipping
- merge #3550 to not completely break `viewmode` (Though I noticed that this is not allocating enough space for ticks yet. Also not sure if the rotation based resizing/zooming that viewmode does makes sense with these changes...)

Example:

https://github.com/user-attachments/assets/ba2725e7-b713-4885-a2b7-c29aadbd42ce

```julia
using GLMakie
using FileIO

begin
    brain = load(assetpath("brain.stl"))
    fig = Figure(size=(600,600))
    ax1 = Axis3(fig[1, 1], aspect = :data, xlabel = "X", ylabel = "Y", zlabel = "Z", title = "test")
    ax1.zoommode[] = :cursor
    mesh!(ax1,brain,color = :white,  shading = FastShading, transparency=false)
    fig
    record(fig, "hack2.mp4", 1:150, fps = 30) do idx
        e = events(fig)
        if idx < 30
            e.mouseposition[] = (300, 300)
            e.scroll[] = (0.0, 0.5)
        elseif idx < 60
            if e.mousebutton[] != Makie.MouseButtonEvent(Mouse.right, Mouse.press)
                e.mousebutton[] = Makie.MouseButtonEvent(Mouse.right, Mouse.press)
            end
            e.mouseposition[] = e.mouseposition[] .+ 3
        elseif idx < 120
            if e.mousebutton[] != Makie.MouseButtonEvent(Mouse.left, Mouse.press)
                e.mousebutton[] = Makie.MouseButtonEvent(Mouse.right, Mouse.release)
                e.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
            end
            e.mouseposition[] = e.mouseposition[] .- (4, 0)
        elseif idx < 150
            e.scroll[] = (0.0, -0.5)
        end 
    end
end

```

