### PR TITLE
show tooltip on NaN if nan_color is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Show DataInspector tooltip on NaN values if `nan_color` has been set to other than `:transparent` [#4310](https://github.com/MakieOrg/Makie.jl/pull/4310)
 - Fix attribute updates for SpecApi and SpecPlots (e.g. ecdfplot) [#4265](https://github.com/MakieOrg/Makie.jl/pull/4265).
 - Bring back `poly` convert arguments for matrix with points as row [#4266](https://github.com/MakieOrg/Makie.jl/pull/4258).
 - Fix gl_ClipDistance related segfault on WSL with GLMakie [#4270](https://github.com/MakieOrg/Makie.jl/pull/4270)

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -650,7 +650,7 @@ function show_imagelike(inspector, plot, name, edge_based)
     end
 
     # in case we hover over NaN values
-    if isnan(z)
+    if isnan(z) && plot.nan_color == :transparent
         a.indicator_visible[] = false
         tt.visible[] = false
         return true
@@ -664,10 +664,14 @@ function show_imagelike(inspector, plot, name, edge_based)
     end
 
     a._color[] = if z isa AbstractFloat
-        interpolated_getindex(
-            to_colormap(plot.colormap[]), z,
-            extract_colorrange(plot)
-        )
+        if isnan(z)
+            plot.nan_color
+        else
+            interpolated_getindex(
+                to_colormap(plot.colormap[]), z,
+                extract_colorrange(plot)
+            )
+        end
     else
         z
     end


### PR DESCRIPTION
title says it all.  specifically, for a heatmap in which some squares are NaN, if `nan_color` has been set (to other than the default `:transparent`), then show the tooltip.  otherwise, behave like before and don't show one for NaN values.

i suppose technically this is a breaking change?

does this need to be documented anywhere other than the CHANGELOG?

are there tests that can be written?



- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
