### PR TITLE
Clean up color/linewidth handling in CairoMakie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bring back `poly` convert arguments for matrix with points as row [#4266](https://github.com/MakieOrg/Makie.jl/pull/4258).
 - Fix gl_ClipDistance related segfault on WSL with GLMakie [#4270](https://github.com/MakieOrg/Makie.jl/pull/4270)
 - Added option `label_position = :center` to place labels centered over each bar [#4274](https://github.com/MakieOrg/Makie.jl/pull/4274).
+- Fixed Boundserror in clipped multicolor lines in CairoMakie [#4313](https://github.com/MakieOrg/Makie.jl/pull/4313)
 
 ## [0.21.9] - 2024-08-27
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -190,10 +190,11 @@ function clip2screen(p, res)
     return res .* s
 end
 
-@generated function project_line_points(scene, plot::T, positions, colors) where {T <: Union{Lines, LineSegments}}
+@generated function project_line_points(scene, plot::T, positions, colors, linewidths) where {T <: Union{Lines, LineSegments}}
     # If colors are defined per point they need to be interpolated like positions
     # at clip planes
     per_point_colors = colors <: AbstractArray
+    per_point_linewidths = linewidths <: AbstractArray
     
     quote
         @get_attribute(plot, (space, model))
@@ -228,18 +229,20 @@ end
         
         # outputs
         screen_points = sizehint!(Vec2f[], length(clip_points))
-        indices = Vector{Int}(undef, 0)
         $(if per_point_colors
             quote
                 color_output = sizehint!(eltype(colors)[], length(clip_points))
                 skipped_color = RGBAf(1,0,1,1) # for debug purposes, should not show
             end
         end)
+        $(if per_point_linewidths
+            quote
+                linewidth_output = sizehint!(eltype(linewidths)[], length(clip_points))
+            end
+        end)
 
         # Handling one segment per iteration
         if plot isa Lines
-
-            sizehint!(indices, length(clip_points))
 
             last_is_nan = true
             for i in 1:length(clip_points)-1
@@ -303,7 +306,9 @@ end
                     # if segment hidden make sure the line separates
                     last_is_nan = true
                     push!(screen_points, Vec2f(NaN))
-                    push!(indices, i)
+                    $(if per_point_linewidths
+                        :(push!(linewidth_output, linewidths[i]))
+                    end)
                     $(if per_point_colors
                         :(push!(color_output, c1))
                     end)
@@ -314,7 +319,9 @@ end
                     # line separates before it
                     if disconnect1 && !last_is_nan
                         push!(screen_points, Vec2f(NaN))
-                        push!(indices, i)
+                        $(if per_point_linewidths
+                            :(push!(linewidth_output, linewidths[i]))
+                        end)
                         $(if per_point_colors
                             :(push!(color_output, c1))
                         end)
@@ -322,7 +329,9 @@ end
                     
                     last_is_nan = false
                     push!(screen_points, clip2screen(p1, res))
-                    push!(indices, i)
+                    $(if per_point_linewidths
+                        :(push!(linewidth_output, linewidths[i]))
+                    end)
                     $(if per_point_colors
                         :(push!(color_output, c1))
                     end)
@@ -332,7 +341,9 @@ end
                     if disconnect2
                         last_is_nan = true
                         push!(screen_points, clip2screen(p2, res), Vec2f(NaN))
-                        push!(indices, i+1, i+1)
+                        $(if per_point_linewidths
+                            :(push!(linewidth_output, linewidths[i+1], linewidths[i+1]))
+                        end)
                         $(if per_point_colors
                             :(push!(color_output, c2, c2)) # relevant, irrelevant
                         end)
@@ -345,7 +356,9 @@ end
             # clip_points
             if !last_is_nan
                 push!(screen_points, clip2screen(clip_points[end], res))
-                push!(indices, length(clip_points))
+                $(if per_point_linewidths
+                        :(push!(linewidth_output, linewidths[end]))
+                    end)
                 $(if per_point_colors
                     :(push!(color_output, colors[end]))
                 end)
@@ -413,7 +426,8 @@ end
 
         end
 
-        return screen_points, indices, $(ifelse(per_point_colors, :color_output, :colors))
+        return screen_points, $(ifelse(per_point_colors, :color_output, :colors)),
+            $(ifelse(per_point_linewidths, :linewidth_output, :linewidths))
     end
 end
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -194,7 +194,7 @@ end
     # If colors are defined per point they need to be interpolated like positions
     # at clip planes
     per_point_colors = colors <: AbstractArray
-    per_point_linewidths = linewidths <: AbstractArray
+    per_point_linewidths = (T <: Lines) && (linewidths <: AbstractArray)
     
     quote
         @get_attribute(plot, (space, model))

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -150,6 +150,11 @@ end
     plotlist!([Makie.SpecApi.Scatter(1:10)])
 end
 
+@testset "multicolor line clipping (#4313)" begin
+    fig, ax, p = contour(rand(20,20))
+    xlims!(ax, 0, 10)
+    Makie.colorbuffer(fig; backend=CairoMakie)
+end
 
 excludes = Set([
     "Colored Mesh",


### PR DESCRIPTION
# Description

Fixes #4276

In the clip planes pr (iirc), I adjusted lines to clip to the viewport of a scene. I believe this fixed some issue where far away start/endpoints caused lines to disappear.
If you have per-linepoint colors and move one of the points, the colors of the line changes. (This was another CairoMakie bug from before iirc.) To fix that I added some color adjustments to the clipping code in `CairoMakie.project_line_points()`. After that function both position and colors are fully processed w.r.t clipping.
Linewidths are not though. They still used the old `linewidths = [linewidth for _ in colors]` and then later used the `indices` which is suppsoed to map old per-linepoint data to new per-linepoint data. But since colors is already new per-linepoint data this can get out of bounds.

The first commit fixes this by replacing the pad-to-vector with calls to `sv_getindex`, which just returns the value if you don't pass an array. The second commit moves the remapping to the clip function to avoid having indices alltogether.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
