### PR TITLE
Update CI to use the GeometryBasics refactor branch

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -44,6 +44,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: >
           cd docs;
+          julia --project=docs -e "using Pkg; Pkg.add(name=\"GeometryBasics\", rev = \"ff/refactor\")"
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24'
           julia --color=yes makedocs.jl
     - name: Upload site as artifact

--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -44,7 +44,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: >
           cd docs;
-          julia --project=docs -e "using Pkg; Pkg.add(name=\"GeometryBasics\", rev = \"ff/refactor\")"
+          julia --project=docs -e "using Pkg; Pkg.add(name=\"GeometryBasics\", rev = \"ff/refactor\"); Pkg.add(name=\"MeshIO\", rev = \"ff/GeometryBasics_refactor\")"
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24'
           julia --color=yes makedocs.jl
     - name: Upload site as artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           Pkg.update()
           pkg"dev . ./MakieCore"
           pkg"add GeometryBasics#ff/refactor"
+          pkg"add MeshIO#ff/GeometryBasics_refactor"
           Pkg.test("Makie"; coverage=true)
 
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           pkg"registry up"
           Pkg.update()
           pkg"dev . ./MakieCore"
+          pkg"add GeometryBasics#ff/refactor"
           Pkg.test("Makie"; coverage=true)
 
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -45,6 +45,7 @@ jobs:
           # dev mono repo versions
           pkg"registry up"
           Pkg.update()
+          pkg"add MeshIO#ff/GeometryBasics_refactor"
           pkg"add GeometryBasics#ff/refactor"
           pkg"dev . ./MakieCore ./CairoMakie ./ReferenceTests"
       - name: Run the tests
@@ -96,6 +97,7 @@ jobs:
           # dev mono repo versions
           pkg"registry up"
           Pkg.update()
+          pkg"add MeshIO#ff/GeometryBasics_refactor"
           pkg"add GeometryBasics#ff/refactor"
           pkg"dev . ./MakieCore ./GLMakie ./ReferenceTests"
       - name: Run the tests
@@ -147,6 +149,7 @@ jobs:
           # dev mono repo versions
           pkg"registry up"
           Pkg.update()
+          pkg"add MeshIO#ff/GeometryBasics_refactor"
           pkg"add GeometryBasics#ff/refactor"
           pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests"
       - name: Run the tests

--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -45,6 +45,7 @@ jobs:
           # dev mono repo versions
           pkg"registry up"
           Pkg.update()
+          pkg"add GeometryBasics#ff/refactor"
           pkg"dev . ./MakieCore ./CairoMakie ./ReferenceTests"
       - name: Run the tests
         continue-on-error: true
@@ -95,6 +96,7 @@ jobs:
           # dev mono repo versions
           pkg"registry up"
           Pkg.update()
+          pkg"add GeometryBasics#ff/refactor"
           pkg"dev . ./MakieCore ./GLMakie ./ReferenceTests"
       - name: Run the tests
         id: referencetests
@@ -145,6 +147,7 @@ jobs:
           # dev mono repo versions
           pkg"registry up"
           Pkg.update()
+          pkg"add GeometryBasics#ff/refactor"
           pkg"dev . ./MakieCore ./WGLMakie ./ReferenceTests"
       - name: Run the tests
         continue-on-error: true


### PR DESCRIPTION
This just updates the CI scripts to add the GeometryBasics update branch explicitly.  If it's squashed and merged it should be trivial to revert once the GeometryBasics PR is merged.