### PR TITLE
Use `Base.depwarn()` exclusively, and fix deprecation tests

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,8 +1,16 @@
 ###########################################
 # v0.20 deprecations:
 ##
-Base.@deprecate_binding DiscreteSurface CellGrid true
-Base.@deprecate_binding ContinuousSurface VertexGrid true
+
+function DiscreteSurface(args...; kwargs...)
+    Base.depwarn("Makie.DiscreteSurface() is deprecated, use Makie.CellGrid() instead", :DiscreteSurface)
+    CellGrid(args...; kwargs...)
+end
+
+function ContinuousSurface(args...; kwargs...)
+    Base.depwarn("Makie.ContinuousSurface() is deprecated, use Makie.VertexGrid() instead", :ContinuousSurface)
+    VertexGrid(args...; kwargs...)
+end
 
 function Base.getproperty(scene::Scene, field::Symbol)
     if field === :px_area
@@ -14,7 +22,7 @@ end
 
 @deprecate pixelarea viewport true
 
-function Combined(args...) 
-    Base.depwarn("Makie.Combined(args...) is deprecated, use Makie.Plot(args...) instead")
-    Plot(args...)
+function Combined(args...; kwargs...)
+    Base.depwarn("Makie.Combined() is deprecated, use Makie.Plot() instead", :Combined)
+    Plot(args...; kwargs...)
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -3,12 +3,12 @@
 ##
 
 function DiscreteSurface(args...; kwargs...)
-    Base.depwarn("Makie.DiscreteSurface() is deprecated, use Makie.CellGrid() instead", :DiscreteSurface)
+    @warn "Makie.DiscreteSurface() is deprecated, use Makie.CellGrid() instead" maxlog=1
     CellGrid(args...; kwargs...)
 end
 
 function ContinuousSurface(args...; kwargs...)
-    Base.depwarn("Makie.ContinuousSurface() is deprecated, use Makie.VertexGrid() instead", :ContinuousSurface)
+    @warn "Makie.ContinuousSurface() is deprecated, use Makie.VertexGrid() instead" maxlog=1
     VertexGrid(args...; kwargs...)
 end
 
@@ -23,6 +23,6 @@ end
 @deprecate pixelarea viewport true
 
 function Combined(args...; kwargs...)
-    Base.depwarn("Makie.Combined() is deprecated, use Makie.Plot() instead", :Combined)
+    @warn "Makie.Combined() is deprecated, use Makie.Plot() instead" maxlog=1
     Plot(args...; kwargs...)
 end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -6,9 +6,9 @@ macro depwarn_message(expr)
             $(esc(expr))
         end
         if length(logger.logs) == 1
-            return logger.logs[1].message
+            logger.logs[1].message
         else
-            return nothing
+            nothing
         end
     end
 end
@@ -34,17 +34,14 @@ end
     end
     @testset "Plot -> Combined" begin
         logger = Test.TestLogger()
-        msg = @depwarn_message Combined
-        @test occursin("Combined is deprecated", msg)
-        @test Combined == Plot
+        msg = @depwarn_message Makie.Combined()
+        @test occursin("Combined() is deprecated", msg)
     end
     @testset "Surface Traits" begin
-        @test DiscreteSurface == CellGrid
-        @test ContinuousSurface == VertexGrid
-        msg = @depwarn_message DiscreteSurface()
-        @test occursin("DiscreteSurface is deprecated", msg)
-        msg = @depwarn_message ContinuousSurface()
-        @test occursin("ContinuousSurface is deprecated", msg)
+        msg = @depwarn_message Makie.DiscreteSurface()
+        @test occursin("DiscreteSurface() is deprecated", msg)
+        msg = @depwarn_message Makie.ContinuousSurface()
+        @test occursin("ContinuousSurface() is deprecated", msg)
     end
     @testset "AbstractVector ImageLike" begin
         msg = @depwarn_message image(1:10, 1..10, zeros(10, 10))


### PR DESCRIPTION
# Description

Partially fixes #4308.

A few changes:
- Use `Base.depwarn()` instead of `Base.@deprecate_binding` to avoid warnings when importing symbols.
- Pass the missing `funcsym` argument to `Base.depwarn()` in `Combined()`.
- Fix the deprecation tests. Most of them were actually getting skipped because `@depwarn_message` had a `return` statement, causing the entire testset to return early as soon as the passed expression was evaluated.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

(I don't think this needs a changelog entry?)

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
