### PR TITLE
Bind remaining observables to plots

### DIFF
--- a/src/basic_recipes/hvspan.jl
+++ b/src/basic_recipes/hvspan.jl
@@ -46,7 +46,7 @@ function Makie.plot!(p::Union{HSpan, VSpan})
     mi = p isa HSpan ? p.xmin : p.ymin
     ma = p isa HSpan ? p.xmax : p.ymax
 
-    onany(limits, p[1], p[2], mi, ma, transf) do lims, lows, highs, mi, ma, transf
+    onany(p, limits, p[1], p[2], mi, ma, transf) do lims, lows, highs, mi, ma, transf
         empty!(rects[])
         min_x, min_y = minimum(lims)
         max_x, max_y = maximum(lims)

--- a/src/basic_recipes/scatterlines.jl
+++ b/src/basic_recipes/scatterlines.jl
@@ -36,7 +36,7 @@ function plot!(p::Plot{scatterlines, <:NTuple{N, Any}}) where N
 
     # markercolor is the same as linecolor if left automatic
     real_markercolor = Observable{Any}()
-    map!(real_markercolor, p.color, p.markercolor) do col, mcol
+    map!(p, real_markercolor, p.color, p.markercolor) do col, mcol
         if mcol === automatic
             return to_color(col)
         else
@@ -45,12 +45,12 @@ function plot!(p::Plot{scatterlines, <:NTuple{N, Any}}) where N
     end
 
     real_markercolormap = Observable{Any}()
-    map!(real_markercolormap, p.colormap, p.markercolormap) do col, mcol
+    map!(p, real_markercolormap, p.colormap, p.markercolormap) do col, mcol
         mcol === automatic ? col : mcol
     end
 
     real_markercolorrange = Observable{Any}()
-    map!(real_markercolorrange, p.colorrange, p.markercolorrange) do col, mcol
+    map!(p, real_markercolorrange, p.colorrange, p.markercolorrange) do col, mcol
         mcol === automatic ? col : mcol
     end
 

--- a/src/basic_recipes/timeseries.jl
+++ b/src/basic_recipes/timeseries.jl
@@ -40,7 +40,7 @@ function Makie.plot!(plot::TimeSeries)
     buffer = copy(points[])
     lines!(plot, points)
     start = time()
-    on(plot.signal) do x
+    on(plot, plot.signal) do x
         points[][end] = signal2point(x, start)
         circshift!(buffer, points[], 1)
         buff_ref = buffer

--- a/src/basic_recipes/volumeslices.jl
+++ b/src/basic_recipes/volumeslices.jl
@@ -24,7 +24,7 @@ function Makie.plot!(plot::VolumeSlices)
     bbox_visible = pop!(attr, :bbox_visible)
     pop!(attr, :model) # stops `transform!()` from working
 
-    bbox = map(x, y, z) do x, y, z
+    bbox = lift(plot, x, y, z) do x, y, z
         mx, Mx = extrema(x)
         my, My = extrema(y)
         mz, Mz = extrema(z)


### PR DESCRIPTION
# Description

Fixes #4304
Adds the plot as a second argument to `(lift|map|on|onany)` calls in `plot!` functions of basic recipes.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
