### PR TITLE
Try to fix edit links in docs

### DIFF
--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -203,7 +203,7 @@ empty!(MakieDocsHelpers.FIGURES)
 Documenter.makedocs(;
     sitename="Makie",
     format=DocumenterVitepress.MarkdownVitepress(;
-        repo = "https://github.com/MakieOrg/Makie.jl",
+        repo = "github.com/MakieOrg/Makie.jl",
         devurl = "dev",
         devbranch = "master",
         deploy_url = "https://docs.makie.org", # for local testing not setting this has broken links with Makie.jl in them


### PR DESCRIPTION
# Description

Fixes #4340

DocumenterVitepress doesn't perform URI validation nor check that the URI is valid.  That's got to be fixed there but this will work for now.