### PR TITLE
Set voronoiplot's preferred axis type to 2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `plotfunc()` and `func2type()` support functions ending with `!` [#4275](https://github.com/MakieOrg/Makie.jl/pull/4275).
 - Fixed Boundserror in clipped multicolor lines in CairoMakie [#4313](https://github.com/MakieOrg/Makie.jl/pull/4313)
 - Fix float precision based assertions error in GLMakie.volume [#4311](https://github.com/MakieOrg/Makie.jl/pull/4311)
+- Set `Voronoiplot`'s preferred axis type to 2D in all cases [#4349](https://github.com/MakieOrg/Makie.jl/pull/4349)
 
 ## [0.21.9] - 2024-08-27
 

--- a/src/basic_recipes/voronoiplot.jl
+++ b/src/basic_recipes/voronoiplot.jl
@@ -36,6 +36,8 @@ DelaunayTriangulation.jl.
     MakieCore.mixin_colormap_attributes()...
 end
 
+preferred_axis_type(::Voronoiplot) = Axis
+
 function _clip_polygon(poly::Polygon, circle::Circle)
     # Sutherland-Hodgman adjusted
     @assert isempty(poly.interiors) "Polygon must not have holes for clipping."


### PR DESCRIPTION
# Description

Fixes #4335 (just the 3D axis part).

## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
