### PR TITLE
add tooltips to blocks

### DIFF
--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -103,6 +103,8 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
             return Vec2f(l - align * (l + r), -o - t - ts)
         elseif placement in (:above, :up, :top)
             return Vec2f(l - align * (l + r),  o + b + ts)
+        elseif placement === :center
+            return Vec2f(l - align * (l + r),  b - align * (b + t))
         else
             @error "Tooltip placement $placement invalid. Assuming :above"
             return Vec2f(0, o + b + ts)
@@ -118,6 +120,8 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
             return (align, 1.0)
         elseif placement in (:above, :up, :top)
             return (align, 0.0)
+        elseif placement === :center
+            return (0.5, 0.5)
         else
             @error "Tooltip placement $placement invalid. Assuming :above"
             return (align, 0.0)
@@ -184,6 +188,8 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         elseif placement in (:above, :up, :top)
             translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
             rotate!(mp, Quaternionf(0,0,0,1)) # 0
+        elseif placement === :center
+            mp.visible = false
         else
             @error "Tooltip placement $placement invalid. Assuming :above"
             translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
@@ -235,6 +241,10 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
                 (l + align * w,        b-s),
                 (l + align * w - 0.5s, b),
                 (l, b)
+            ]
+        elseif placement === :center
+            Vec2f[
+                (l, b), (l, t), (r, t), (r, b), (l, b)
             ]
         else
             @error "Tooltip placement $placement invalid. Assuming :above"

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -216,17 +216,37 @@ function extract_attributes!(body)
         layout_related_attribute_block.args
     )
 
+    tooltip_related_attribute_block = quote
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
+        tooltip_placement = :center
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
+        "Depth value of the tooltip. This should be high so that the tooltip is always in front."
+        tooltip_depth = 9e3
+    end
+    tooltip_related_attributes = filter(
+        x -> !(x isa LineNumberNode),
+        tooltip_related_attribute_block.args
+    )
+
     args = filter(x -> !(x isa LineNumberNode), attrs_block.args)
 
     attrs::Vector{Any} = map(MakieCore.extract_attribute_metadata, args)
 
     lras = map(MakieCore.extract_attribute_metadata, layout_related_attributes)
-
     for lra in lras
         i = findfirst(x -> x.symbol == lra.symbol, attrs)
-        if i === nothing
-            push!(attrs, lra)
-        end
+        i === nothing && push!(attrs, lra)
+    end
+
+    tras = map(MakieCore.extract_attribute_metadata, tooltip_related_attributes)
+    for tra in tras
+        i = findfirst(x -> x.symbol == tra.symbol, attrs)
+        i === nothing && push!(attrs, tra)
     end
 
     attrs

--- a/src/makielayout/blocks/button.jl
+++ b/src/makielayout/blocks/button.jl
@@ -46,6 +46,27 @@ function initialize_block!(b::Button)
         b.layoutobservables.autosize[] = (autowidth, autoheight)
     end
 
+    # tooltip
+    ttposition = lift(b.tooltip_placement, b.layoutobservables.computedbbox) do placement, bbox
+        if placement == :above
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]))
+        elseif placement == :below
+            bbox.origin + Point2f((bbox.widths[1]/2, 0))
+        elseif placement == :left
+            bbox.origin + Point2f((0, bbox.widths[2]/2))
+        elseif placement == :right
+            bbox.origin + Point2f((bbox.widths[1], bbox.widths[2]/2))
+        else
+            placement == :center || warn("invalid value for tooltip_placement, using :center")
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]/2))
+        end
+    end
+    ttvisible = lift((x,y)->x && y==:hover, b.tooltip_enable, mousestate)
+    tt = tooltip!(scene, ttposition, b.tooltip_text,
+                  visible=ttvisible, placement=b.tooltip_placement;
+                  b.tooltip_kwargs[]...)
+    translate!(tt, 0, 0, b.tooltip_depth[])
+
     mouseevents = addmouseevents!(scene, b.layoutobservables.computedbbox)
 
     onmouseover(mouseevents) do _

--- a/src/makielayout/blocks/intervalslider.jl
+++ b/src/makielayout/blocks/intervalslider.jl
@@ -109,6 +109,28 @@ function initialize_block!(isl::IntervalSlider)
     buttons = scatter!(blockscene, middlepoints, color = isl.color_active, strokewidth = 0,
         markersize = buttonsizes, inspectable = false, marker = Circle)
 
+    # tooltip
+
+    ttposition = lift(isl.tooltip_placement, isl.layoutobservables.computedbbox) do placement, bbox
+        if placement == :above
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]))
+        elseif placement == :below
+            bbox.origin + Point2f((bbox.widths[1]/2, 0))
+        elseif placement == :left
+            bbox.origin + Point2f((0, bbox.widths[2]/2))
+        elseif placement == :right
+            bbox.origin + Point2f((bbox.widths[1], bbox.widths[2]/2))
+        else
+            placement == :center || warn("invalid value for tooltip_placement, using :center")
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]/2))
+        end
+    end
+    ttvisible = lift((x,y)->x && y!=:none, isl.tooltip_enable, state)
+    tt = tooltip!(blockscene, ttposition, isl.tooltip_text,
+                  visible=ttvisible, placement=isl.tooltip_placement;
+                  isl.tooltip_kwargs[]...)
+    translate!(tt, 0, 0, isl.tooltip_depth[])
+
     mouseevents = addmouseevents!(blockscene, isl.layoutobservables.computedbbox)
 
     # we need to record where a drag started for the case where the center of the

--- a/src/makielayout/blocks/textbox.jl
+++ b/src/makielayout/blocks/textbox.jl
@@ -113,6 +113,27 @@ function initialize_block!(tbox::Textbox)
     # trigger bbox
     tbox.layoutobservables.suggestedbbox[] = tbox.layoutobservables.suggestedbbox[]
 
+    # tooltip
+    ttposition = lift(tbox.tooltip_placement, tbox.layoutobservables.computedbbox) do placement, bbox
+        if placement == :above
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]))
+        elseif placement == :below
+            bbox.origin + Point2f((bbox.widths[1]/2, 0))
+        elseif placement == :left
+            bbox.origin + Point2f((0, bbox.widths[2]/2))
+        elseif placement == :right
+            bbox.origin + Point2f((bbox.widths[1], bbox.widths[2]/2))
+        else
+            placement == :center || warn("invalid value for tooltip_placement, using :center")
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]/2))
+        end
+    end
+    ttvisible = lift((x,y)->x && y, tbox.tooltip_enable, hovering)
+    tt = tooltip!(topscene, ttposition, tbox.tooltip_text,
+                  visible=ttvisible, placement=tbox.tooltip_placement;
+                  tbox.tooltip_kwargs[]...)
+    translate!(tt, 0, 0, tbox.tooltip_depth[])
+
     mouseevents = addmouseevents!(scene)
 
     onmouseleftdown(mouseevents) do state

--- a/src/makielayout/blocks/toggle.jl
+++ b/src/makielayout/blocks/toggle.jl
@@ -44,6 +44,27 @@ function initialize_block!(t::Toggle)
     button = scatter!(topscene, buttonpos, markersize = buttonsize,
         color = t.buttoncolor, strokewidth = 0, inspectable = false, marker = Circle)
 
+    # tooltip
+    ttposition = lift(t.tooltip_placement, t.layoutobservables.computedbbox) do placement, bbox
+        if placement == :above
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]))
+        elseif placement == :below
+            bbox.origin + Point2f((bbox.widths[1]/2, 0))
+        elseif placement == :left
+            bbox.origin + Point2f((0, bbox.widths[2]/2))
+        elseif placement == :right
+            bbox.origin + Point2f((bbox.widths[1], bbox.widths[2]/2))
+        else
+            placement == :center || warn("invalid value for tooltip_placement, using :center")
+            bbox.origin + Point2f((bbox.widths[1]/2, bbox.widths[2]/2))
+        end
+    end
+    ttvisible = lift((x,y)->x && y>1, t.tooltip_enable, buttonfactor)
+    tt = tooltip!(topscene, ttposition, t.tooltip_text,
+                  visible=ttvisible, placement=t.tooltip_placement;
+                  t.tooltip_kwargs[]...)
+    translate!(tt, 0, 0, t.tooltip_depth[])
+
     mouseevents = addmouseevents!(topscene, t.layoutobservables.computedbbox)
 
     onmouseleftdown(mouseevents) do event

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -222,6 +222,7 @@ Axis(fig_or_scene; palette = nothing, kwargs...)
     mouseeventhandle::MouseEventHandle
     scrollevents::Observable{ScrollEvent}
     keysevents::Observable{KeysEvent}
+    hovering::Observable{Bool}
     interactions::Dict{Symbol, Tuple{Bool, Any}}
     xaxis::LineAxis
     yaxis::LineAxis
@@ -676,6 +677,14 @@ Axis(fig_or_scene; palette = nothing, kwargs...)
         on the values of `yticks` and `ytickformat`.
         """
         yscale = identity
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
+        tooltip_placement = :center
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -949,6 +958,14 @@ end
         alignmode = Inside()
         "Controls if the button snaps to valid positions or moves freely"
         snap::Bool = true
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
+        tooltip_placement = :above
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1049,6 +1066,14 @@ end
         alignmode = Inside()
         "Controls if the buttons snap to valid positions or move freely"
         snap::Bool = true
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
+        tooltip_placement = :above
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1098,6 +1123,14 @@ end
         clicks = 0
         "The align mode of the button in its parent GridLayout."
         alignmode = Inside()
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
+        tooltip_placement = :above
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1185,6 +1218,14 @@ end
         rimfraction = 0.33
         "The align mode of the toggle in its parent GridLayout."
         alignmode = Inside()
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
+        tooltip_placement = :above
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1284,6 +1325,14 @@ end
         prompt = "Select..."
         "Speed of scrolling in large Menu lists."
         scroll_speed = 15.0
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
+        tooltip_placement = :above
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1472,6 +1521,13 @@ end
         alignmode = Inside()
         "Controls the visibility of the 3D axis plot object."
         show_axis::Bool = true
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
+        tooltip_placement = :center
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1543,6 +1599,14 @@ end
         restriction = nothing
         "The color of the cursor."
         cursorcolor = :transparent
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
+        tooltip_placement = :above
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 
@@ -1552,6 +1616,7 @@ end
     mouseeventhandle::MouseEventHandle
     scrollevents::Observable{ScrollEvent}
     keysevents::Observable{KeysEvent}
+    hovering::Observable{Bool}
     interactions::Dict{Symbol, Tuple{Bool, Any}}
     @attributes begin
         """
@@ -1842,6 +1907,14 @@ end
         yreversed::Bool = false
         "Controls if the z axis goes upwards (false) or downwards (true) in default camera orientation."
         zreversed::Bool = false
+        "The String displayed by the tooltip."
+        tooltip_text = ""
+        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
+        tooltip_placement = :center
+        "Controls whether the tooltip will be rendered or not."
+        tooltip_enable = false
+        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
+        tooltip_kwargs = ()
     end
 end
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -677,14 +677,6 @@ Axis(fig_or_scene; palette = nothing, kwargs...)
         on the values of `yticks` and `ytickformat`.
         """
         yscale = identity
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
-        tooltip_placement = :center
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -958,14 +950,6 @@ end
         alignmode = Inside()
         "Controls if the button snaps to valid positions or moves freely"
         snap::Bool = true
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
-        tooltip_placement = :above
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1066,14 +1050,6 @@ end
         alignmode = Inside()
         "Controls if the buttons snap to valid positions or move freely"
         snap::Bool = true
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
-        tooltip_placement = :above
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1123,14 +1099,6 @@ end
         clicks = 0
         "The align mode of the button in its parent GridLayout."
         alignmode = Inside()
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
-        tooltip_placement = :above
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1218,14 +1186,6 @@ end
         rimfraction = 0.33
         "The align mode of the toggle in its parent GridLayout."
         alignmode = Inside()
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
-        tooltip_placement = :above
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1325,14 +1285,6 @@ end
         prompt = "Select..."
         "Speed of scrolling in large Menu lists."
         scroll_speed = 15.0
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
-        tooltip_placement = :above
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1521,13 +1473,6 @@ end
         alignmode = Inside()
         "Controls the visibility of the 3D axis plot object."
         show_axis::Bool = true
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
-        tooltip_placement = :center
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1599,14 +1544,6 @@ end
         restriction = nothing
         "The color of the cursor."
         cursorcolor = :transparent
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Textbox. Can be :above, :below, :left, :right."
-        tooltip_placement = :above
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 
@@ -1907,14 +1844,6 @@ end
         yreversed::Bool = false
         "Controls if the z axis goes upwards (false) or downwards (true) in default camera orientation."
         zreversed::Bool = false
-        "The String displayed by the tooltip."
-        tooltip_text = ""
-        "Sets where the tooltip should be placed relative to the Axis. Can be :above, :below, :left, :right, :center."
-        tooltip_placement = :center
-        "Controls whether the tooltip will be rendered or not."
-        tooltip_enable = false
-        "Keyword arguments to pass to the tooltip.  See the tooltip docstring for valid attributes."
-        tooltip_kwargs = ()
     end
 end
 


### PR DESCRIPTION
Adds tooltips to Textboxes which appear on hover.

<img width="712" alt="Screenshot 2024-09-18 at 6 26 13 PM" src="https://github.com/user-attachments/assets/5d4a8dc8-a8c5-48c9-b15e-e04a249d8541">

sadly, despite specifying `overdraw=true` to `tooltip!`, they sometimes appear behind other blocks.  see for yourself by executing the code below and hovering over `tb21`.  will this be fixed by https://github.com/MakieOrg/Makie.jl/pull/4150?  is there a workaround in the meantime?

```
using GLMakie
f = Figure()
tb11 = Textbox(f[1,1], tooltip_text="hi\nthere", tooltip_enable=true, tooltip_placement=:below)
tb21 = Textbox(f[2,1], tooltip_text="okay\nhere", tooltip_enable=true, tooltip_placement=:below)
m31 = Menu(f[3,1], options = ["a", "b", "c"], default = "a")
m32 = Menu(f[3,2], options = ["a", "b", "c"], default = "a")
tb22 = Textbox(f[2,2], tooltip_text="okay\nhere", tooltip_enable=true, tooltip_placement=:below)
tb12 = Textbox(f[1,2], tooltip_text="hi\nthere", tooltip_enable=true, tooltip_placement=:below)
```

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
