### PR TITLE
`viewmode = :free` prototype for Axis3 controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 ## [Unreleased]
 
 - Added translation, zoom and limit reset interactions to Axis3 [4131](https://github.com/MakieOrg/Makie.jl/pull/4131)
+
+## [0.21.12] - 2024-09-28
+
+- Fix NaN handling in WGLMakie [#4282](https://github.com/MakieOrg/Makie.jl/pull/4282).
 - Show DataInspector tooltip on NaN values if `nan_color` has been set to other than `:transparent` [#4310](https://github.com/MakieOrg/Makie.jl/pull/4310)
 - Fix `linestyle` not being used in `triplot` [#4332](https://github.com/MakieOrg/Makie.jl/pull/4332)
+- Fix voxel clipping not being based on voxel centers [#4397](https://github.com/MakieOrg/Makie.jl/pull/4397)
+- Parsing `Q` and `q` commands in svg paths with `BezierPath` is now supported [#4413](https://github.com/MakieOrg/Makie.jl/pull/4413)
 
 ## [0.21.11] - 2024-09-13
 
@@ -17,12 +23,13 @@
 - Make sure we wait for the screen session [#4316](https://github.com/MakieOrg/Makie.jl/pull/4316).
 - Fix for absrect [#4312](https://github.com/MakieOrg/Makie.jl/pull/4312).
 - Fix attribute updates for SpecApi and SpecPlots (e.g. ecdfplot) [#4265](https://github.com/MakieOrg/Makie.jl/pull/4265).
-- Bring back `poly` convert arguments for matrix with points as row [#4266](https://github.com/MakieOrg/Makie.jl/pull/4258).
+- Bring back `poly` convert arguments for matrix with points as row [#4258](https://github.com/MakieOrg/Makie.jl/pull/4258).
 - Fix gl_ClipDistance related segfault on WSL with GLMakie [#4270](https://github.com/MakieOrg/Makie.jl/pull/4270).
 - Added option `label_position = :center` to place labels centered over each bar [#4274](https://github.com/MakieOrg/Makie.jl/pull/4274).
 - `plotfunc()` and `func2type()` support functions ending with `!` [#4275](https://github.com/MakieOrg/Makie.jl/pull/4275).
 - Fixed Boundserror in clipped multicolor lines in CairoMakie [#4313](https://github.com/MakieOrg/Makie.jl/pull/4313)
 - Fix float precision based assertions error in GLMakie.volume [#4311](https://github.com/MakieOrg/Makie.jl/pull/4311)
+ - Support images with reversed axes [#4338](https://github.com/MakieOrg/Makie.jl/pull/4338)
 
 ## [0.21.9] - 2024-08-27
 
@@ -603,7 +610,8 @@ All other changes are collected [in this PR](https://github.com/MakieOrg/Makie.j
 - Fixed rendering of `heatmap`s with one or more reversed ranges in CairoMakie, as in `heatmap(1:10, 10:-1:1, rand(10, 10))` [#1100](https://github.com/MakieOrg/Makie.jl/pull/1100).
 - Fixed volume slice recipe and added docs for it [#1123](https://github.com/MakieOrg/Makie.jl/pull/1123).
 
-[Unreleased]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.11...HEAD
+[Unreleased]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.12...HEAD
+[0.21.12]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.11...v0.21.12
 [0.21.11]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.10...v0.21.11
 [0.21.10]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.9...v0.21.10
 [0.21.9]: https://github.com/MakieOrg/Makie.jl/compare/v0.21.8...v0.21.9

--- a/CairoMakie/Project.toml
+++ b/CairoMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "CairoMakie"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 author = ["Simon Danisch <sdanisch@gmail.com>"]
-version = "0.12.11"
+version = "0.12.12"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
@@ -24,7 +24,7 @@ FileIO = "1.1"
 FreeType = "3, 4.0"
 GeometryBasics = "0.4.11"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.11"
+Makie = "=0.21.12"
 PrecompileTools = "1.0"
 julia = "1.3"
 

--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.10.11"
+version = "0.10.12"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -30,7 +30,7 @@ FreeTypeAbstraction = "0.10"
 GLFW = "3.4.3"
 GeometryBasics = "0.4.11"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.11"
+Makie = "=0.21.12"
 Markdown = "1.0, 1.6"
 MeshIO = "0.4"
 ModernGL = "1"

--- a/GLMakie/assets/shader/voxel.frag
+++ b/GLMakie/assets/shader/voxel.frag
@@ -85,18 +85,16 @@ vec4 get_color(sampler2D color, Nothing color_map, int id) {
 
 bool is_clipped()
 {
-    float d1, d2;
+    float d;
+    // Center of voxel
     ivec3 size = ivec3(textureSize(voxel_id, 0).xyz);
-    vec3 xyz = vec3(ivec3(o_uvw * size));
+    vec3 xyz = vec3(ivec3(o_uvw * size)) + vec3(0.5);
     for (int i = 0; i < _num_clip_planes; i++) {
-        // distance from clip planes with negative clipped
-        d1 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
-        d2 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
+        // distance between clip plane and center
+        d = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
 
-        // both outside - clip everything
-        if (d1 < 0.0 || d2 < 0.0) {
+        if (d < 0.0) 
             return true;
-        }
     }
 
     return false;

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -691,8 +691,8 @@ end
 function draw_image(screen::Screen, scene::Scene, plot::Union{Heatmap, Image})
     return cached_robj!(screen, scene, plot) do gl_attributes
         position = lift(plot, plot[1], plot[2]) do x, y
-            xmin, xmax = extrema(x)
-            ymin, ymax = extrema(y)
+            xmin, xmax = x
+            ymin, ymax = y
             rect = Rect2(xmin, ymin, xmax - xmin, ymax - ymin)
             return decompose(Point2d, rect)
         end

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Makie"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 authors = ["Simon Danisch", "Julius Krumbiegel"]
-version = "0.21.11"
+version = "0.21.12"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
@@ -85,9 +85,9 @@ FreeTypeAbstraction = "0.10.3"
 GeometryBasics = "0.4.11"
 GridLayoutBase = "0.11"
 ImageBase = "0.1.7"
-ImageIO = "0.2, 0.3, 0.4, 0.5, 0.6"
+ImageIO = "0.5, 0.6"
 InteractiveUtils = "1.0, 1.6"
-Interpolations = "0.15.1"
+Interpolations = "0.14, 0.15.1"
 IntervalSets = "0.3, 0.4, 0.5, 0.6, 0.7"
 Isoband = "0.1"
 KernelDensity = "0.5, 0.6"

--- a/RPRMakie/Project.toml
+++ b/RPRMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "RPRMakie"
 uuid = "22d9f318-5e34-4b44-b769-6e3734a732a6"
 authors = ["Simon Danisch"]
-version = "0.7.11"
+version = "0.7.12"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -17,7 +17,7 @@ Colors = "0.9, 0.10, 0.11, 0.12"
 FileIO = "1.6"
 GeometryBasics = "0.4.11"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.11"
+Makie = "=0.21.12"
 Printf = "1.0, 1.6"
 RadeonProRender = "0.3.0"
 julia = "1.3"

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -682,7 +682,7 @@ end
 @reference_test "Clip planes - voxel" begin
     f = Figure()
     a = LScene(f[1, 1])
-    a.scene.theme[:clip_planes][] = [Plane3f(Vec3f(-2, -1, -0.5), 0.0), Plane3f(Vec3f(-0.5, -1, -2), 0.0)]
+    a.scene.theme[:clip_planes][] = [Plane3f(Vec3f(-2, -1, -0.5), 0.1), Plane3f(Vec3f(-0.5, -1, -2), 0.1)]
     r = -10:10
     p = voxels!(a, [cos(sin(x+y)+z) for x in r, y in r, z in r])
     f

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -273,6 +273,40 @@ end
     f
 end
 
+@reference_test "Axis3 viewmode x xreversed x aspect" begin
+    fig = Figure(size = (1200, 900))
+
+    protrusions = (40, 30, 20, 10)
+    perspectiveness = 0.0
+    m = load(Makie.assetpath("cat.obj"))
+    cs = 1:length(Makie.coordinates(m))
+    
+    for (bx, by, viewmode) in [(1,1,:fit), (1,2,:fitzoom), (2,1,:free), (2,2,:stretch)]
+        gl = GridLayout(fig[by, bx])
+        Label(gl[0, 1:3], "viewmode = $viewmode")
+        for (x, aspect) in enumerate((:data, :equal, (1.2, 0.8, 1.0)))
+            for (y, rev) in enumerate((true, false))
+                ax = Axis3(gl[y, x], viewmode = viewmode, xreversed = rev, aspect = aspect, 
+                    protrusions = protrusions, perspectiveness = perspectiveness)
+                mesh!(ax, m, color = cs)
+
+                # for debug purposes
+                ax.scene.clear = true
+                ax.scene.backgroundcolor[] = RGBAf(1,0.8,0.6, 1.0)
+                lines!(fig.scene, ax.layoutobservables.computedbbox, color = (:blue, 0.5), linestyle = :dash)
+                fullarea = lift(ax.layoutobservables.computedbbox, ax.layoutobservables.protrusions) do bbox, prot
+                    mini = minimum(bbox) - Vec2(prot.left, prot.bottom)
+                    maxi = maximum(bbox) + Vec2(prot.right, prot.top)
+                    return Rect2f(mini, maxi - mini)
+                end
+                lines!(fig.scene, fullarea, color = :red)
+            end
+        end
+    end
+
+    fig
+end
+
 @reference_test "Colorbar for recipes" begin
     fig, ax, pl = barplot(1:3; color=1:3, colormap=Makie.Categorical(:viridis), figure=(;size=(800, 800)))
     Colorbar(fig[1, 2], pl; size=100)

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -818,3 +818,31 @@ end
     end
     f
 end
+
+@reference_test "Reverse image, heatmap and surface axes" begin
+    img = [2 0 0 3; 0 0 0 0; 1 1 0 0; 1 1 0 4]
+
+    f = Figure(size = (600, 400))
+
+    for (i, interp) in enumerate((true, false))
+        for (j, plot_func) in enumerate((
+            (fp, x, y, cs, interp) -> image(fp, x, y, cs, colormap = :viridis, interpolate = interp), 
+            (fp, x, y, cs, interp) -> heatmap(fp, x, y, cs, colormap = :viridis, interpolate = interp), 
+            (fp, x, y, cs, interp) -> surface(fp, x, y, zeros(size(cs)), color = cs, colormap = :viridis, interpolate = interp, shading = NoShading)
+        ))
+
+            gl = GridLayout(f[i, j])
+
+            a, p = plot_func(gl[1, 1], 1:4, 1:4, img, interp)
+            hidedecorations!(a)
+            a, p = plot_func(gl[2, 1], 1:4, 4..1, img, interp)
+            hidedecorations!(a)
+            a, p = plot_func(gl[1, 2], 4:-1:1, 1:4, img, interp)
+            hidedecorations!(a)
+            a, p = plot_func(gl[2, 2], 4:-1:1, [4, 3, 2, 1], img, interp)
+            hidedecorations!(a)
+        end
+    end
+
+    f
+end

--- a/WGLMakie/Project.toml
+++ b/WGLMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "WGLMakie"
 uuid = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
 authors = ["SimonDanisch <sdanisch@gmail.com>"]
-version = "0.10.11"
+version = "0.10.12"
 
 [deps]
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
@@ -27,7 +27,7 @@ FreeTypeAbstraction = "0.10"
 GeometryBasics = "0.4.11"
 Hyperscript = "0.0.3, 0.0.4, 0.0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.21.11"
+Makie = "=0.21.12"
 Observables = "0.5.1"
 PNGFiles = "0.3, 0.4"
 PrecompileTools = "1.0"

--- a/WGLMakie/assets/voxel.frag
+++ b/WGLMakie/assets/voxel.frag
@@ -85,18 +85,15 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
 
 bool is_clipped()
 {
-    float d1, d2;
+    float d;
+    // get center pos of this voxel
     vec3 size = vec3(textureSize(voxel_id, 0).xyz);
-    vec3 xyz = vec3(ivec3(o_uvw * size));
+    vec3 xyz = vec3(ivec3(o_uvw * size)) + vec3(0.5);
     for (int i = 0; i < num_clip_planes; i++) {
-        // distance from clip planes with negative clipped
-        d1 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
-        d2 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
-
-        // both outside - clip everything
-        if (d1 < 0.0 || d2 < 0.0) {
+        // distance between clip plane and voxel center
+        d = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
+        if (d < 0.0)
             return true;
-        }
     }
 
     return false;

--- a/WGLMakie/src/Lines.js
+++ b/WGLMakie/src/Lines.js
@@ -188,7 +188,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // used to compute width sdf
                 f_linewidth = halfwidth;
 
-                f_instance_id = uint(2 * gl_InstanceID);
+                f_instance_id = lineindex_start; // NOTE: this is correct, no need to multiple by 2
 
                 // we restart patterns for each segment
                 f_cumulative_length = 0.0;
@@ -640,7 +640,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // used to compute width sdf
                 f_linewidth = halfwidth;
 
-                f_instance_id = uint(gl_InstanceID);
+                f_instance_id = lineindex_start;
 
                 f_cumulative_length = lastlen_start;
 

--- a/WGLMakie/src/Shaders.js
+++ b/WGLMakie/src/Shaders.js
@@ -1,12 +1,22 @@
 function typedarray_to_vectype(typedArray, ndim) {
-    if (ndim === 1) {
-        return "float";
-    } else if (typedArray instanceof Float32Array) {
-        return "vec" + ndim;
+    if (typedArray instanceof Float32Array) {
+        if (ndim === 1) {
+            return "float";
+        } else {
+            return "vec" + ndim;
+        }
     } else if (typedArray instanceof Int32Array) {
-        return "ivec" + ndim;
+        if (ndim === 1) {
+            return "int";
+        } else {
+            return "ivec" + ndim;
+        }
     } else if (typedArray instanceof Uint32Array) {
-        return "uvec" + ndim;
+        if (ndim === 1) {
+            return "uint";
+        } else {
+            return "uvec" + ndim;
+        }
     } else {
         return;
     }

--- a/WGLMakie/src/imagelike.jl
+++ b/WGLMakie/src/imagelike.jl
@@ -129,7 +129,7 @@ end
 
 
 
-xy_convert(x::Makie.EndPoints, n) = LinRange(extrema(x)..., n + 1)
+xy_convert(x::Makie.EndPoints, n) = LinRange(x..., n + 1)
 xy_convert(x::AbstractArray, n) = x
 
 # TODO, speed up GeometryBasics
@@ -166,8 +166,8 @@ function limits_to_uvmesh(plot, f32c)
     py = lift(identity, plot, py; ignore_equal_values=true)
     if px[] isa Makie.EndPoints && py[] isa Makie.EndPoints && Makie.is_identity_transform(t)
         rect = lift(plot, px, py) do x, y
-            xmin, xmax = extrema(x)
-            ymin, ymax = extrema(y)
+            xmin, xmax = x
+            ymin, ymax = y
             return Rect2f(xmin, ymin, xmax - xmin, ymax - ymin)
         end
         ps = lift(rect -> decompose(Point2f, rect), plot, rect)

--- a/WGLMakie/src/lines.jl
+++ b/WGLMakie/src/lines.jl
@@ -43,7 +43,7 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
     # involved point are not NaN, i.e. p1 -- p2 is only drawn if all of
     # (p0, p1, p2, p3) are not NaN. So if p3 is NaN we need to dublicate p2 to
     # make the p1 -- p2 segment draw, which is what indices does.
-    indices = Observable(Int[])
+    indices = Observable(UInt32[])
     points_transformed = lift(
             plot, f32c, transform_func_obs(plot), plot.model, plot[1], plot.space
         ) do f32c, tf, model, ps, space
@@ -118,7 +118,10 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
         end
     end
     positions = lift(serialize_buffer_attribute, plot, points_transformed)
-    attributes = Dict{Symbol, Any}(:linepoint => positions)
+    attributes = Dict{Symbol, Any}(
+        :linepoint => positions,
+        :lineindex => lift(_ -> serialize_buffer_attribute(indices[]), plot, points_transformed),
+    )
 
     # TODO: in Javascript
     # NOTE: clip.w needs to be available in shaders to avoid line inversion problems

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -20196,14 +20196,24 @@ function getErrorMessage(version) {
     return element;
 }
 function typedarray_to_vectype(typedArray, ndim) {
-    if (ndim === 1) {
-        return "float";
-    } else if (typedArray instanceof Float32Array) {
-        return "vec" + ndim;
+    if (typedArray instanceof Float32Array) {
+        if (ndim === 1) {
+            return "float";
+        } else {
+            return "vec" + ndim;
+        }
     } else if (typedArray instanceof Int32Array) {
-        return "ivec" + ndim;
+        if (ndim === 1) {
+            return "int";
+        } else {
+            return "ivec" + ndim;
+        }
     } else if (typedArray instanceof Uint32Array) {
-        return "uvec" + ndim;
+        if (ndim === 1) {
+            return "uint";
+        } else {
+            return "uvec" + ndim;
+        }
     } else {
         return;
     }
@@ -21473,7 +21483,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // used to compute width sdf
                 f_linewidth = halfwidth;
 
-                f_instance_id = uint(2 * gl_InstanceID);
+                f_instance_id = lineindex_start; // NOTE: this is correct, no need to multiple by 2
 
                 // we restart patterns for each segment
                 f_cumulative_length = 0.0;
@@ -21920,7 +21930,7 @@ function lines_vertex_shader(uniforms, attributes, is_linesegments) {
                 // used to compute width sdf
                 f_linewidth = halfwidth;
 
-                f_instance_id = uint(gl_InstanceID);
+                f_instance_id = lineindex_start;
 
                 f_cumulative_length = lastlen_start;
 

--- a/docs/src/explanations/backends/rprmakie.md
+++ b/docs/src/explanations/backends/rprmakie.md
@@ -11,7 +11,7 @@ using RadeonProRender
 RadeonProRender.Context()
 ```
 
-To use RPRMakie on a Mac with an M-series chip, for now, you need to use the x84 build of Julia (not the ARM build, you may have to download this manually).  RadeonProRender does not distribute binaries built for the ARM architecture of the M-series processors yet.
+To use RPRMakie on a Mac with an M-series chip, for now, you need to use the x86_64 build of Julia (not the ARM build, you may have to download this manually).  RadeonProRender does not distribute binaries built for the ARM architecture of the M-series processors yet.
 
 ## Activation and screen config
 

--- a/docs/src/tutorials/wrap-existing-recipe.md
+++ b/docs/src/tutorials/wrap-existing-recipe.md
@@ -26,8 +26,8 @@ nothing # hide
 ```
 
 Our target type is the `MyHist`, which has two fields, as defined above. Roughly speaking, when we
-plot a histograms, we're talking about drawing a bar plot, where `barcenters` tells us where to draw
-these bars and `barcounts` tells us how high each bar is.
+plot a histograms, we're talking about drawing a bar plot, where `bincenters` tells us where to draw
+these bars and `bincounts` tells us how high each bar is.
 
 ## BarPlot recipe -- extend `Makie.convert_arguments`
 

--- a/src/basic_recipes/buffers.jl
+++ b/src/basic_recipes/buffers.jl
@@ -86,7 +86,7 @@ function push!(tb::Annotations, text::String, position::VecTypes{N}; kw_args...)
 end
 
 function append!(tb::Annotations, text::Vector{String}, positions::Vector{Point{N, Float32}}; kw_args...) where N
-    text_positions = convert_argument(Annotations, text, positions)[1]
+    text_positions = convert_arguments(Annotations, text, positions)[1]
     append!(tb, text_positions; kw_args...)
     return
 end

--- a/src/bezier.jl
+++ b/src/bezier.jl
@@ -41,6 +41,19 @@ CurveTo(cx1, cy1, cx2, cy2, p1, p2) = CurveTo(
 )
 
 """
+    quadratic_curve_to(x0::Real, y0::Real, cx1::Real, cy1::Real, p1::Real, p2::Real)
+
+A path command for use within a `BezierPath` which continues the current subpath with a quadratic
+bezier curve to point `p`, with the control point `c`. The curve is converted into a cubic bezier
+curve internally.
+"""
+quadratic_curve_to(x0, y0, cx1, cy1, p1, p2) = CurveTo(
+    x0 + 2/3 * (cx1 - x0), y0 + 2/3 * (cy1 - y0),
+    p1 + 2/3 * (cx1 - p1), p2 + 2/3 * (cy1 - p2),
+    p1, p2
+)
+
+"""
     EllipticalArc(c::VecTypes, r1::Real, r2::Real, angle::Real, a1::Real, a2::Real)
     EllipticalArc(cx::Real, cy::Real, r1::Real, r2::Real, angle::Real, a1::Real, a2::Real)
 
@@ -492,6 +505,16 @@ function parse_bezier_commands(svg)
             l = lastp()
             push!(commands, LineTo(Point2d(l[1], y)))
             i += 2
+        elseif comm == "Q"
+            x0, y0 = lastp()
+            x1, y1, x2, y2 = parse.(Float64, args[i+1:i+4])
+            push!(commands, quadratic_curve_to(x0, y0, x1, y1, x2, y2))
+            i += 5
+        elseif comm == "q"
+            x0, y0 = lastp()
+            x1, y1, x2, y2 = parse.(Float64, args[i+1:i+4])
+            push!(commands, quadratic_curve_to(x0, y0, x1 + x0, y1 + y0, x2 + x0, y2 + y0))
+            i += 5
         else
             for c in commands
                 println(c)

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -130,6 +130,9 @@ from `eyeposition` to `lookat` will be used.  All inputs must be
 supplied as 3-vectors.
 """
 function lookat(eyePos::Vec{3, T}, lookAt::Vec{3, T}, up::Vec{3, T}) where T
+    return lookat_basis(eyePos, lookAt, up) * translationmatrix(-eyePos)
+end
+function lookat_basis(eyePos::Vec{3, T}, lookAt::Vec{3, T}, up::Vec{3, T}) where T
     zaxis  = normalize(eyePos-lookAt)
     xaxis  = normalize(cross(up,    zaxis))
     yaxis  = normalize(cross(zaxis, xaxis))
@@ -139,7 +142,7 @@ function lookat(eyePos::Vec{3, T}, lookAt::Vec{3, T}, up::Vec{3, T}) where T
         xaxis[2], yaxis[2], zaxis[2], T0,
         xaxis[3], yaxis[3], zaxis[3], T0,
         T0,       T0,       T0,       T1
-    ) * translationmatrix(-eyePos)
+    )
 end
 
 function lookat(::Type{T}, eyePos::Vec{3}, lookAt::Vec{3}, up::Vec{3}) where T

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -55,6 +55,7 @@ end
 # Leave concretely typed vectors alone (AbstractArray{<:Union{Missing, <:Real}} also dispatches for `Vector{Float32}`)
 convert_single_argument(a::AbstractArray{T}) where {T<:Real} = a
 convert_single_argument(a::AbstractArray{<:Point{N, T}}) where {N, T} = a
+convert_single_argument(a::OffsetArray{<:Point}) = OffsetArrays.no_offset_view(a)
 
 
 ################################################################################
@@ -86,6 +87,10 @@ function convert_arguments(::PointBased, positions::AbstractVector{<: VecTypes{N
         throw(ArgumentError("Only 2D and 3D points are supported."))
     end
     return (elconvert(Point{N, float_type(_T)}, positions),)
+end
+
+function convert_arguments(T::PointBased, positions::OffsetVector)
+   return convert_arguments(T, OffsetArrays.no_offset_view(positions))
 end
 
 function convert_arguments(::PointBased, positions::SubArray{<: VecTypes, 1})
@@ -365,12 +370,10 @@ function to_endpoints(x::Tuple{<:Real,<:Real})
     T = float_type(x...)
     return EndPoints(T.(x))
 end
-to_endpoints(x::ClosedInterval) = to_endpoints(endpoints(x))
-function to_endpoints(x::Union{Interval,AbstractVector,ClosedInterval})
-    return to_endpoints((minimum(x), maximum(x)))
-end
+to_endpoints(x::Interval) = to_endpoints(endpoints(x))
+to_endpoints(x::EndPoints) = x
+to_endpoints(x::AbstractVector) = to_endpoints((first(x), last(x)))
 function to_endpoints(x, dim)
-    # having minimum and maximum here actually invites bugs
     x isa AbstractVector && !(x isa EndPoints) && print_range_warning(dim, x)
     return to_endpoints(x)
 end
@@ -698,7 +701,8 @@ end
 #                               Helper Functions                               #
 ################################################################################
 
-to_linspace(interval, N) = range(minimum(interval), stop = maximum(interval), length = N)
+to_linspace(interval::Interval, N) = range(leftendpoint(interval), stop = rightendpoint(interval), length = N)
+to_linspace(x, N) = range(first(x), stop = last(x), length = N)
 
 """
 Converts the element array type to `T1` without making a copy if the element type matches

--- a/src/interaction/inspector.jl
+++ b/src/interaction/inspector.jl
@@ -677,10 +677,12 @@ function show_imagelike(inspector, plot, name, edge_based)
         tt.text[] = plot[:inspector_label][](plot, (i, j), ins_p)
     end
 
-    a._color[] = if z isa Real
-        get(plot.calculated_colors[], z)
+    if z isa Real
+        if haskey(plot, :calculated_colors)
+            a._color[] = get(plot.calculated_colors[], z)
+        end
     else
-        z
+        a._color[] = z
     end
 
     proj_pos = Point2f(mouseposition_px(inspector.root))

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -134,6 +134,8 @@ expand_dimensions(trait, args...) = nothing
 
 expand_dimensions(::PointBased, y::VecTypes) = nothing # VecTypes are nd points
 expand_dimensions(::PointBased, y::RealVector) = (keys(y), y)
+expand_dimensions(::PointBased, y::OffsetVector{<:Real}) =
+    (OffsetArrays.no_offset_view(keys(y)), OffsetArrays.no_offset_view(y))
 
 function expand_dimensions(::Union{ImageLike, GridBased}, data::AbstractMatrix{<:Union{<:Real, <:Colorant}})
     # Float32, because all ploteable sizes should fit into float32

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -100,7 +100,7 @@ function initialize_block!(ax::Axis3)
     zticks, zticklabels, zlabel =
         add_ticks_and_ticklabels!(blockscene, scene, ax, 3, finallimits, ticknode_3, mi3, mi1, mi2, ax.azimuth, ax.xreversed, ax.yreversed, ax.zreversed)
 
-    titlepos = lift(scene, scene.viewport, ax.titlegap, ax.titlealign) do a, titlegap, align
+    titlepos = lift(scene, ax.layoutobservables.computedbbox, ax.titlegap, ax.titlealign) do a, titlegap, align
 
         align_factor = halign2num(align, "Horizontal title align $align not supported.")
         x = a.origin[1] + align_factor * a.widths[1]

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -445,12 +445,13 @@ function add_gridlines_and_frames!(topscene, scene, ax, dim::Int, limits, tickno
         # we are going to transform the 3d frame points into 2d of the topscene
         # because otherwise the frame lines can
         # be cut when they lie directly on the scene boundary
-        to_topscene_z_2d.([p1, p2, p3, p4, p5, p6], Ref(scene))
+        # to_topscene_z_2d.([p1, p2, p3, p4, p5, p6], Ref(scene))
+        return [p1, p2, p3, p4, p5, p6]
     end
     colors = Observable{Any}()
     map!(vcat, colors, attr(:spinecolor_1), attr(:spinecolor_2), attr(:spinecolor_3))
-    framelines = linesegments!(topscene, framepoints, color = colors, linewidth = attr(:spinewidth),
-        # transparency = true,
+    framelines = linesegments!(scene, framepoints, color = colors, linewidth = attr(:spinewidth),
+        xautolimits = false, yautolimits = false, zautolimits = false, transparency = false,
         clip_planes = Plane3f[], visible = attr(:spinesvisible), inspectable = false)
 
     return gridline1, gridline2, framelines
@@ -482,7 +483,7 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
     end
     ticksize = attr(:ticksize)
 
-    tick_segments = lift(topscene, limits, tickvalues, miv, min1, min2,
+    tick_segments = lift(scene, limits, tickvalues, miv, min1, min2,
             scene.camera.projectionview, scene.viewport, ticksize, xreversed, yreversed, zreversed) do lims, ticks, miv, min1, min2,
                 pview, pxa, tsize, xrev, yrev, zrev
 
@@ -498,7 +499,8 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
         diff_f1 = f1 - f1_oppo
         diff_f2 = f2 - f2_oppo
 
-        o = pxa.origin
+        # o = pxa.origin
+        o = Vec2f(0)
 
         return map(ticks) do t
             p1 = dpoint(t, f1, f2)
@@ -523,13 +525,13 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
     # we are going to transform the 3d tick segments into 2d of the topscene
     # because otherwise they
     # be cut when they extend beyond the scene boundary
-    tick_segments_2dz = lift(topscene, tick_segments, scene.camera.projectionview, scene.viewport) do ts, _, _
-        map(ts) do p1_p2
-            to_topscene_z_2d.(p1_p2, Ref(scene))
-        end
-    end
+    # tick_segments_2dz = lift(topscene, tick_segments, scene.camera.projectionview, scene.viewport) do ts, _, _
+    #     map(ts) do p1_p2
+    #         to_topscene_z_2d.(p1_p2, Ref(scene))
+    #     end
+    # end
 
-    ticks = linesegments!(topscene, tick_segments,
+    ticks = linesegments!(scene, tick_segments,
         xautolimits = false, yautolimits = false, zautolimits = false,
         transparency = true, inspectable = false, clip_planes = Plane3f[],
         color = attr(:tickcolor), linewidth = attr(:tickwidth), visible = attr(:ticksvisible))
@@ -538,10 +540,11 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
     translate!(ticks, 0, 0, -10000)
 
     labels_positions = Observable{Any}()
-    map!(topscene, labels_positions, scene.viewport, scene.camera.projectionview,
+    map!(scene, labels_positions, scene.viewport, scene.camera.projectionview,
             tick_segments, ticklabels, attr(:ticklabelpad)) do pxa, pv, ticksegs, ticklabs, pad
 
-        o = pxa.origin
+        # o = pxa.origin
+        o = Vec2f(0)
 
         points = map(ticksegs) do (tstart, tend)
             offset = pad * Makie.GeometryBasics.normalize(Point2f(tend - tstart))
@@ -562,7 +565,7 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
         end
     end
 
-    ticklabels_text = text!(topscene, labels_positions, align = align,
+    ticklabels_text = text!(scene, labels_positions, align = align, space = :pixel,
         color = attr(:ticklabelcolor), fontsize = attr(:ticklabelsize), clip_planes = Plane3f[],
         font = attr(:ticklabelfont), visible = attr(:ticklabelsvisible), inspectable = false
     )
@@ -578,7 +581,8 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
             attr(:labeloffset), attr(:labelrotation), attr(:labelalign), xreversed, yreversed, zreversed
             ) do pxa, pv, lims, miv, min1, min2, labeloffset, lrotation, lalign, xrev, yrev, zrev
 
-        o = pxa.origin
+        # o = pxa.origin
+        o = Vec2f(0)
 
         rev1 = (xrev, yrev, zrev)[d1]
         rev2 = (xrev, yrev, zrev)[d2]
@@ -650,8 +654,10 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
     end
     notify(attr(:labelalign))
 
-    label = text!(topscene, label_position,
-        text = attr(:label), clip_planes = Plane3f[],
+    label = text!(scene, label_position,
+        space = :pixel, clip_planes = Plane3f[],
+        xautolimits = false, yautolimits = false, zautolimits = false,
+        text = attr(:label), 
         color = attr(:labelcolor),
         fontsize = attr(:labelsize),
         font = attr(:labelfont),

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -466,17 +466,17 @@ function add_gridlines_and_frames!(topscene, scene, ax, dim::Int, limits, tickno
         # p7 = dpoint(minimum(lims)[dim], f(!mi1)(lims)[d1], f(!mi2)(lims)[d2])
         # p8 = dpoint(maximum(lims)[dim], f(!mi1)(lims)[d1], f(!mi2)(lims)[d2])
 
-        # we are going to transform the 3d frame points into 2d of the topscene
-        # because otherwise the frame lines can
-        # be cut when they lie directly on the scene boundary
-        # to_topscene_z_2d.([p1, p2, p3, p4, p5, p6], Ref(scene))
-        return [p1, p2, p3, p4, p5, p6]
+        # Not projecting here causes alignment (and render order?) issues with
+        # ticks, probably due to float precision differences. 
+        map([p1, p2, p3, p4, p5, p6]) do p
+            return Point3f(project(scene, p)..., -10_000)
+        end
     end
     colors = Observable{Any}()
     map!(vcat, colors, attr(:spinecolor_1), attr(:spinecolor_2), attr(:spinecolor_3))
     framelines = linesegments!(scene, framepoints, color = colors, linewidth = attr(:spinewidth),
         xautolimits = false, yautolimits = false, zautolimits = false, transparency = false,
-        clip_planes = Plane3f[], visible = attr(:spinesvisible), inspectable = false)
+        clip_planes = Plane3f[], visible = attr(:spinesvisible), inspectable = false, space = :pixel)
 
     return gridline1, gridline2, framelines
 end

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -517,9 +517,6 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
         diff_f1 = f1 - f1_oppo
         diff_f2 = f2 - f2_oppo
 
-        # o = pxa.origin
-        o = Vec2f(0)
-
         return map(ticks) do t
             p1 = dpoint(t, f1, f2)
             p2 = if dim == 3
@@ -533,36 +530,22 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
                 dpoint(t, f1 + diff_f1, f2)
             end
 
-            pp1 = Point2f(o + Makie.project(scene, p1))
-            pp2 = Point2f(o + Makie.project(scene, p2))
+            pp1 = Point2f(Makie.project(scene, p1))
+            pp2 = Point2f(Makie.project(scene, p2))
             diff_pp = Makie.GeometryBasics.normalize(Point2f(pp2 - pp1))
 
             return (pp1, pp1 .+ Float32(tsize) .* diff_pp)
          end
     end
-    # we are going to transform the 3d tick segments into 2d of the topscene
-    # because otherwise they
-    # be cut when they extend beyond the scene boundary
-    # tick_segments_2dz = lift(topscene, tick_segments, scene.camera.projectionview, scene.viewport) do ts, _, _
-    #     map(ts) do p1_p2
-    #         to_topscene_z_2d.(p1_p2, Ref(scene))
-    #     end
-    # end
 
-    ticks = linesegments!(scene, tick_segments,
+    ticks = linesegments!(scene, tick_segments, space = :pixel,
         xautolimits = false, yautolimits = false, zautolimits = false,
         transparency = true, inspectable = false, clip_planes = Plane3f[],
         color = attr(:tickcolor), linewidth = attr(:tickwidth), visible = attr(:ticksvisible))
-    # -10000 is an arbitrary weird constant that in preliminary testing didn't seem
-    # to clip into plot objects anymore
-    translate!(ticks, 0, 0, -10000)
 
     labels_positions = Observable{Any}()
     map!(scene, labels_positions, scene.viewport, scene.camera.projectionview,
             tick_segments, ticklabels, attr(:ticklabelpad)) do pxa, pv, ticksegs, ticklabs, pad
-
-        # o = pxa.origin
-        o = Vec2f(0)
 
         points = map(ticksegs) do (tstart, tend)
             offset = pad * Makie.GeometryBasics.normalize(Point2f(tend - tstart))
@@ -599,9 +582,6 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
             attr(:labeloffset), attr(:labelrotation), attr(:labelalign), xreversed, yreversed, zreversed
             ) do pxa, pv, lims, miv, min1, min2, labeloffset, lrotation, lalign, xrev, yrev, zrev
 
-        # o = pxa.origin
-        o = Vec2f(0)
-
         rev1 = (xrev, yrev, zrev)[d1]
         rev2 = (xrev, yrev, zrev)[d2]
         revdim = (xrev, yrev, zrev)[dim]
@@ -617,8 +597,8 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
         p2 = dpoint(maximum(lims)[dim], f1, f2)
 
         # project them into screen space
-        pp1 = Point2f(o + Makie.project(scene, p1))
-        pp2 = Point2f(o + Makie.project(scene, p2))
+        pp1 = Point2f(Makie.project(scene, p1))
+        pp2 = Point2f(Makie.project(scene, p2))
 
         # find the midpoint
         midpoint = (pp1 + pp2) ./ 2

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -203,7 +203,7 @@ function calculate_matrices(limits, viewport, elev, azim, perspectiveness, aspec
     if aspect === :equal 
         scales = 2 ./ Float64.(ws)
     elseif aspect === :data
-        scales = 2 ./ max.(maximum(ws), Float64.(ws))
+        scales = 2 .* sign.(ws) ./ max.(maximum(ws), Float64.(ws))
     elseif aspect isa VecTypes{3}
         scales = 2 ./ Float64.(ws) .* Float64.(aspect) ./ maximum(aspect)
     else

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -211,7 +211,7 @@ function positivize(r::Rect2)
     return Rect2(newori, newwidths)
 end
 
-function process_interaction(::LimitReset, event::MouseEvent, ax::Union{Axis, Axis3})
+function process_interaction(::LimitReset, event::MouseEvent, ax::Axis)
 
     if event.type === MouseEventTypes.leftclick
         if ispressed(ax.scene, Keyboard.left_control)
@@ -498,4 +498,20 @@ function process_interaction(interaction::ScrollZoom, event::ScrollEvent, ax::Ax
 
     # NOTE this might be problematic if we add scrolling to something like Menu
     return Consume(true)
+end
+
+function process_interaction(::LimitReset, event::MouseEvent, ax::Axis3)
+
+    if event.type === MouseEventTypes.leftclick
+        if ispressed(ax.scene, Keyboard.left_control)
+            ax.zoom_mult[] = 1.0
+            ax.lookat[] = Vec3d(0)
+            if ispressed(ax.scene, Keyboard.left_shift)
+                autolimits!(ax)
+            end
+            return Consume(true)
+        end
+    end
+
+    return Consume(false)
 end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1495,6 +1495,8 @@ end
     scrollevents::Observable{ScrollEvent}
     keysevents::Observable{KeysEvent}
     interactions::Dict{Symbol, Tuple{Bool, Any}}
+    lookat::Observable{Vec3d}
+    zoom_mult::Observable{Float64}
     @attributes begin
         """
         Global state for the x dimension conversion.

--- a/test/bezier.jl
+++ b/test/bezier.jl
@@ -5,6 +5,20 @@ using Makie, Test
     @test_nowarn BezierPath("m 0,9 L 0,5138 0,9 z")
     @test_broken BezierPath("m 0,1e-5 L 0,5138 0,9 z") isa BezierPath
     @test_nowarn BezierPath("M 100,100 C 100,200 200,100 200,200 z")
-    @test_broken BezierPath("M 100,100 Q 50,150,100,100 z") isa BezierPath
+    @test_nowarn BezierPath("M 100,100 Q 50,150,100,100 z") isa BezierPath
     @test_broken BezierPath("M 3.0 10.0 A 10.0 7.5 0.0 0.0 0.0 20.0 15.0 z") isa BezierPath
+end
+
+@testset "Parsing Q/q" begin
+    x0, y0, x1, y1, x, y = 5.0, 0.0, 14.6, 5.2, 13.0, 15.9
+    C = Makie.quadratic_curve_to(x0, y0, x1, y1, x, y)
+    C2 = Makie.CurveTo(x0 + 2 / 3 * (x1 - x0), y0 + 2 / 3 * (y1 - y0), x + 2 / 3 * (x1 - x),
+                       y + 2 / 3 * (y1 - y),
+                       x, y)
+    @test C == C2
+    path = BezierPath("M 5.0 0.0 Q 14.6 5.2 13.0 15.9")
+    @test path.commands[2] == C2
+    path = BezierPath("M 5.0 0.0 q 0.2 2.3 1.0 -2.0")
+    C = Makie.quadratic_curve_to(x0, y0, x0 + 0.2, y0 + 2.3, x0 + 1.0, y0 - 2.0)
+    @test path.commands[2] == C
 end

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -92,6 +92,11 @@ end
     @test bb.origin ≈ Point3f(0)
     @test bb.widths ≈ Vec3f(10.0, 10.0, 0)
 
+    fig, ax, p = image(1..0, 1:10, rand(10, 10))
+    bb = boundingbox(p)
+    @test bb.origin ≈ Point3f(0, 1, 0)
+    @test bb.widths ≈ Vec3f(1.0, 9.0, 0)
+
     # text transforms to pixel space atm (TODO)
     fig = Figure(size = (400, 400))
     ax = Axis(fig[1, 1])

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -342,9 +342,11 @@ end
 
     v1 = collect(1:10)
     v2 = collect(1:6)
+    v3 = reverse(v1)
 
     i1 = 1 .. 10
     i2 = 1 .. 6
+    i3 = 10 .. 1
 
     o3 = Float32.(m3)
 
@@ -354,6 +356,8 @@ end
         @test convert_arguments(Image, m3) == ((0.0f0, 10.0f0), (0.0f0, 6.0f0), o3)
         @test convert_arguments(Image, v1, r2, m3) == ((1.0f0, 10.0f0), (1.0f0, 6.0f0), o3)
         @test convert_arguments(Image, i1, v2, m3) == ((1.0f0, 10.0f0), (1.0f0, 6.0f0), o3)
+        @test convert_arguments(Image, v3, i1, m3) == ((10, 1), (1, 10), o3)
+        @test convert_arguments(Image, v1, i3, m3) == ((1, 10), (10, 1), o3)
         @test convert_arguments(Image, m1, m2, m3) === (m1, m2, m3)
         @test convert_arguments(Heatmap, m1, m2) === (m1, m2)
     end

--- a/test/convert_arguments.jl
+++ b/test/convert_arguments.jl
@@ -121,6 +121,7 @@ Makie.convert_arguments(::PointBased, ::MyConvVector) = ([Point(10, 20)],)
                 nan = vcat(xs[1:4], NaN, zs[6:end])
                 r = T_in(1):T_in(1):T_in(10)
                 i = T_in(1)..T_in(10)
+                ov = Makie.OffsetVector(ys, -5:4)
 
                 ps2 = Point2.(xs, ys)
                 ps3 = Point3.(xs, ys, zs)
@@ -172,6 +173,7 @@ Makie.convert_arguments(::PointBased, ::MyConvVector) = ([Point(10, 20)],)
 
                         # because indices are Int we end up converting to Float64 no matter what
                         @test apply_conversion(CT, xs)         isa Tuple{Vector{Point2{Float64}}}
+                        @test apply_conversion(CT, ov)         isa Tuple{Vector{Point2{Float64}}}
 
                         @test apply_conversion(CT, xs, ys)     isa Tuple{Vector{Point2{T_out}}}
                         @test apply_conversion(CT, xs, v32)    isa Tuple{Vector{Point2{T_out}}}


### PR DESCRIPTION
# Description

Another prototype for the suggestions from #4131 and #4294.

This one adds a new `viewmode = :free` which skips the complications of making the other viewmodes work with zooming & translation. Iirc that was the reason why I pulled in #3550 which is not needed here. 

The clipping issues from #4294 should be fixed here. Rotation should be centered on the axis bbox like in the matlab example from https://github.com/MakieOrg/Makie.jl/pull/4131#issuecomment-2320703045, though rotation is still restricted. ~~I can look into adding an option to unlock that too.~~ That would require managing the axis orientation differently, as two angles aren't enough to specify both the forward direction and up direction.

Main changes;
- add `ax.zoom_mult` and `ax.lookat[]` for passing information from Interactions to camera matrices
- move the basis transformation part of the view matrix to `ax.scene.model` so that rotations are centered on the axis bbox rather than lookat (center of 3D scene)
- move axis decorations to `ax.scene` to get the same viewport clipping as Axis3 content

TODO:
- [x] test various different combinations of viewmode, x/y/z-reversed, aspect and perspectiveness
- [x] refimg tests
- [ ] interaction tests
- [ ] docs

## Example

(Changes from #4294 are different scroll direction to zoom out, different filename and `ax1.viewmode[] = :free` instead of `ax1.zoommode[] = :cursor`.

```julia
using GLMakie
using FileIO

begin
    brain = load(assetpath("brain.stl"))
    fig = Figure(size=(600,600))
    ax1 = Axis3(fig[1, 1], aspect = :data, xlabel = "X", ylabel = "Y", zlabel = "Z", title = "test")
    ax1.viewmode[] = :free
    mesh!(ax1,brain,color = :white,  shading = FastShading, transparency=false)
    fig
    record(fig, "camera_interaction.mp4", 1:150, fps = 30) do idx
        e = events(fig)
        if idx < 30
            e.mouseposition[] = (300, 300)
            e.scroll[] = (0.0, -0.5)
        elseif idx < 60
            if e.mousebutton[] != Makie.MouseButtonEvent(Mouse.right, Mouse.press)
                e.mousebutton[] = Makie.MouseButtonEvent(Mouse.right, Mouse.press)
            end
            e.mouseposition[] = e.mouseposition[] .+ 3
        elseif idx < 120
            if e.mousebutton[] != Makie.MouseButtonEvent(Mouse.left, Mouse.press)
                e.mousebutton[] = Makie.MouseButtonEvent(Mouse.right, Mouse.release)
                e.mousebutton[] = Makie.MouseButtonEvent(Mouse.left, Mouse.press)
            end
            e.mouseposition[] = e.mouseposition[] .- (4, 0)
        elseif idx < 150
            e.scroll[] = (0.0, 0.5)
        end 
    end
end
```


https://github.com/user-attachments/assets/7dbffa15-6cf3-42e9-94b0-8be818e9a304

