### PR TITLE
Cleanup voxel clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Show DataInspector tooltip on NaN values if `nan_color` has been set to other than `:transparent` [#4310](https://github.com/MakieOrg/Makie.jl/pull/4310)
 - Fix `linestyle` not being used in `triplot` [#4332](https://github.com/MakieOrg/Makie.jl/pull/4332)
+- Fix voxel clipping not being based on voxel centers [#4397](https://github.com/MakieOrg/Makie.jl/pull/4397)
 
 ## [0.21.11] - 2024-09-13
 

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -1253,7 +1253,14 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Maki
     pos = Makie.voxel_positions(primitive)
     scale = Makie.voxel_size(primitive)
     colors = Makie.voxel_colors(primitive)
-    marker = normal_mesh(Rect3f(Point3f(-0.5), Vec3f(1)))
+    marker = GeometryBasics.normal_mesh(Rect3f(Point3f(-0.5), Vec3f(1)))
+    
+    # Face culling
+    if !isempty(primitive.clip_planes[]) && Makie.is_data_space(primitive.space[])
+        valid = [is_visible(primitive.clip_planes[], p) for p in pos]
+        pos = pos[valid]
+        colors = colors[valid]
+    end
 
     # For correct z-ordering we need to be in view/camera or screen space
     model = copy(primitive.model[])
@@ -1271,7 +1278,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Maki
         specular = primitive.specular, shininess = primitive.shininess,
         faceculling = get(primitive, :faceculling, -10),
         transformation = Makie.transformation(primitive),
-        clip_planes = primitive.clip_planes
+        clip_planes = Plane3f[]
     )
 
     for i in zorder

--- a/GLMakie/assets/shader/voxel.frag
+++ b/GLMakie/assets/shader/voxel.frag
@@ -85,18 +85,16 @@ vec4 get_color(sampler2D color, Nothing color_map, int id) {
 
 bool is_clipped()
 {
-    float d1, d2;
+    float d;
+    // Center of voxel
     ivec3 size = ivec3(textureSize(voxel_id, 0).xyz);
-    vec3 xyz = vec3(ivec3(o_uvw * size));
+    vec3 xyz = vec3(ivec3(o_uvw * size)) + vec3(0.5);
     for (int i = 0; i < _num_clip_planes; i++) {
-        // distance from clip planes with negative clipped
-        d1 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
-        d2 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
+        // distance between clip plane and center
+        d = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
 
-        // both outside - clip everything
-        if (d1 < 0.0 || d2 < 0.0) {
+        if (d < 0.0) 
             return true;
-        }
     }
 
     return false;

--- a/ReferenceTests/src/tests/examples3d.jl
+++ b/ReferenceTests/src/tests/examples3d.jl
@@ -682,7 +682,7 @@ end
 @reference_test "Clip planes - voxel" begin
     f = Figure()
     a = LScene(f[1, 1])
-    a.scene.theme[:clip_planes][] = [Plane3f(Vec3f(-2, -1, -0.5), 0.0), Plane3f(Vec3f(-0.5, -1, -2), 0.0)]
+    a.scene.theme[:clip_planes][] = [Plane3f(Vec3f(-2, -1, -0.5), 0.1), Plane3f(Vec3f(-0.5, -1, -2), 0.1)]
     r = -10:10
     p = voxels!(a, [cos(sin(x+y)+z) for x in r, y in r, z in r])
     f

--- a/WGLMakie/assets/voxel.frag
+++ b/WGLMakie/assets/voxel.frag
@@ -85,18 +85,15 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
 
 bool is_clipped()
 {
-    float d1, d2;
+    float d;
+    // get center pos of this voxel
     vec3 size = vec3(textureSize(voxel_id, 0).xyz);
-    vec3 xyz = vec3(ivec3(o_uvw * size));
+    vec3 xyz = vec3(ivec3(o_uvw * size)) + vec3(0.5);
     for (int i = 0; i < num_clip_planes; i++) {
-        // distance from clip planes with negative clipped
-        d1 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
-        d2 = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
-
-        // both outside - clip everything
-        if (d1 < 0.0 || d2 < 0.0) {
+        // distance between clip plane and voxel center
+        d = dot(xyz, clip_planes[i].xyz) - clip_planes[i].w;
+        if (d < 0.0)
             return true;
-        }
     }
 
     return false;


### PR DESCRIPTION
# Description

My intention for voxel clipping was to make it work based on voxel centers. I didn't bother with that in CairoMakie initially, but updated it in #4319 since mesh based clipping started looked pretty bad. After that there was still some discrepancy between the GL backends and CairoMakie. Turns out I was using voxel origins instead of centers. This pr fixes that and pulls in the CairoMakie changes. It also adjusts the test to avoid voxel centers sitting directly on the clipping plane, since that results in float precision based differences between backends.

This should make the voxel clip plane test fail, but be consistent between all backends.

## Type of change

- [x] Bug fix as it fixes unintended clipping behaviour

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
