### PR TITLE
Adjust layout of ReferenceUpdater

### DIFF
--- a/ReferenceUpdater/src/ReferenceUpdater.jl
+++ b/ReferenceUpdater/src/ReferenceUpdater.jl
@@ -24,4 +24,9 @@ include("image_download.jl")
 
 basedir(files...) = normpath(joinpath(@__DIR__, "..", files...))
 
+function __init__()
+    # cleanup downloaded files when julia closes
+    atexit(wipe_cache!)
+end
+
 end

--- a/ReferenceUpdater/src/local_server.jl
+++ b/ReferenceUpdater/src/local_server.jl
@@ -144,6 +144,7 @@ function serve_update_page(; commit = nothing, pr = nothing)
                 @info "Download successful"
                 tmpdir = mktempdir()
                 unzip(filepath, tmpdir)
+                rm(filepath)
                 split_scores(tmpdir)
                 URL_CACHE[download_url] = tmpdir
             else

--- a/ReferenceUpdater/src/local_server.jl
+++ b/ReferenceUpdater/src/local_server.jl
@@ -1,5 +1,13 @@
 const URL_CACHE = Dict{String, String}()
 
+function wipe_cache!()
+    for path in values(URL_CACHE)
+        rm(path, recursive = true)
+    end
+    empty!(URL_CACHE)
+    return
+end
+
 function serve_update_page_from_dir(folder)
 
     folder = realpath(folder)

--- a/ReferenceUpdater/src/reference_images.html
+++ b/ReferenceUpdater/src/reference_images.html
@@ -6,22 +6,25 @@
                 font-family: sans-serif;
             }
             .refimage {
-                display: block;
+                max-width: 100%;
             }
             .image-list {
-                display: flex;
-                flex-wrap: wrap;
+                display: table;
             }
             .image-list > div {
-                margin: 1em;
+                display: table-row;
+            } 
+            .image-list > div > td > div{
+                display: block;
+                margin: 0.25em;
                 padding: 0.5em;
-                border: 2px solid #eee;
+                border: 2px solid lightblue;
+                background-color: #eee;
                 border-radius: 1em;
-            }
-
-            .image-list > div > h3 {
+            } 
+            .image-list > div > td > div > h3 {
                 margin: 0 0 1em 0;  
-            }
+            }   
         </style>
 
     </head>
@@ -41,7 +44,7 @@
         // this string should be replaced by the server script with the correct value
         default_tag = DEFAULT_TAG
 
-        fetch('scores.tsv')
+        fetch('scores_table.tsv')
             .then(response => response.text())
             .then(data => {
                 di = document.querySelector("#refimage-list")
@@ -50,27 +53,48 @@
                         return
                     }
                     parts = line.split('\t')
-                    score = parseFloat(parts[0])
-                    let path = parts[1]
-                    
-                    div = document.createElement("div")
-                    di.append(div)
-                    div.innerHTML = `
-                    <input type="checkbox" class="update-checkbox" data-image="${path}"></input>
-                    <span>${path}</span>
-                    <div>Score: ${score.toFixed(4)}</div>
-                    <button class="mode-button">Showing recorded</button>
-                    `
-                    if (path.endsWith(".png")){
-                        div.innerHTML += `<img class="refimage" data-version="recorded" data-image="${path}" src="recorded/${encodeURIComponent(path)}">`
-                    } else if (path.endsWith(".mp4")){
-                        div.innerHTML += `<video class="refimage" data-version="recorded" data-image="${path}" controls src="recorded/${encodeURIComponent(path)}">`
+           
+                    // row
+                    row = document.createElement("div") 
+                    di.append(row)
+
+                    // Cells
+                    for (let i = 0; i < 3; i++) {
+                        score = parseFloat(parts[2*i])
+                        let path = parts[2*i+1]
+
+                        cell = document.createElement("td")
+                        row.append(cell)
+
+                        if (path == "")
+                            continue;
+
+                        div = document.createElement("div") 
+                        cell.append(div)
+
+                        if (score > 0.05)
+                            div.style.backgroundColor = '#ffbbbb';
+                        else if (score > 0.001)
+                            div.style.backgroundColor = '#ffffbb';
+
+                        div.innerHTML = `
+                        <input type="checkbox" class="update-checkbox" data-image="${path}"></input>
+                        <span>${path}</span>
+                        <div>Score: ${score.toFixed(4)}</div>
+                        <button class="mode-button">Showing recorded</button>
+                        <br>
+                        `
+                        if (path.endsWith(".png")){
+                            div.innerHTML += `<img class="refimage" data-version="recorded" data-image="${path}" src="recorded/${encodeURIComponent(path)}">`
+                        } else if (path.endsWith(".mp4")){
+                            div.innerHTML += `<video class="refimage" data-version="recorded" data-image="${path}" controls src="recorded/${encodeURIComponent(path)}">`
+                        }
                     }
                 })
 
                 document.querySelectorAll(".mode-button").forEach(but => {
                     but.onclick = function(){
-                        img = but.nextElementSibling
+                        img = but.nextElementSibling.nextElementSibling
                         if (img.dataset.version == "recorded"){
                             img.dataset.version = "reference"
                             but.innerHTML = "Showing reference"


### PR DESCRIPTION
# Description

This changes the layout of the page generated by ReferenceUpdater to be a table. The format is:

| | GLMakie | CairoMakie | WGLMakie |
| --- | --- | --- | --- |
| test 1 | image | image | image |
| test 2 | image | image | image |

without having the column and row labels explicitly. If a refimg does not exist for a given backend, the cell is left blank. These change are meant to make it easier to compare backend to backend and also bring cross-backend failures closer together. (E.g. if something is changed in Makie requiring refimg X to be updated for all backends, the related failures are now grouped together.)

Refimgs now resize based on the table column width (up to 100% of their size). This is sort of a consequence of a layout, but I think it's also generally makes refimages easier to check. 

If a refimg causes CI to fail (score > 0.05) the background becomes red, otherwise yellow (> 0.001) or light gray (else). This should make it easier to spot which test in a row is failing and it also differentiates the page/cell background from the figure background.

Sorting is now based on `maximum(row_scores)` to move all the worst scores to the top of the page.

![Screenshot 2024-09-21 160722](https://github.com/user-attachments/assets/a2ff2e20-489b-4d84-8ef4-525d1fc14de2)

## Type of change

- dev tools
