### PR TITLE
Correct CPU architecture name

### DIFF
--- a/docs/src/explanations/backends/rprmakie.md
+++ b/docs/src/explanations/backends/rprmakie.md
@@ -11,7 +11,7 @@ using RadeonProRender
 RadeonProRender.Context()
 ```
 
-To use RPRMakie on a Mac with an M-series chip, for now, you need to use the x84 build of Julia (not the ARM build, you may have to download this manually).  RadeonProRender does not distribute binaries built for the ARM architecture of the M-series processors yet.
+To use RPRMakie on a Mac with an M-series chip, for now, you need to use the x86_64 build of Julia (not the ARM build, you may have to download this manually).  RadeonProRender does not distribute binaries built for the ARM architecture of the M-series processors yet.
 
 ## Activation and screen config
 


### PR DESCRIPTION
Correct a small error in the documentation.
