### PR TITLE
fix bug merging themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Show DataInspector tooltip on NaN values if `nan_color` has been set to other than `:transparent` [#4310](https://github.com/MakieOrg/Makie.jl/pull/4310)
 - Fix `linestyle` not being used in `triplot` [#4332](https://github.com/MakieOrg/Makie.jl/pull/4332)
 - Fix voxel clipping not being based on voxel centers [#4397](https://github.com/MakieOrg/Makie.jl/pull/4397)
+- Fix `merge(attr1, attr2)` modifying nested attributes in `attr1` [#4416](https://github.com/MakieOrg/Makie.jl/pull/4416)
 
 ## [0.21.11] - 2024-09-13
 

--- a/MakieCore/src/attributes.jl
+++ b/MakieCore/src/attributes.jl
@@ -77,7 +77,7 @@ function Base.merge!(target::Attributes, args::Attributes...)
     return target
 end
 
-Base.merge(target::Attributes, args::Attributes...) = merge!(copy(target), args...)
+Base.merge(target::Attributes, args::Attributes...) = merge!(deepcopy(target), args...)
 
 function Base.getproperty(x::Union{Attributes, AbstractPlot}, key::Symbol)
     if hasfield(typeof(x), key)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -20,4 +20,14 @@
         M = Makie.clip_to_space(a.scene.camera, :data) * Makie.space_to_clip(a.scene.camera, :data)
         @test M ≈ I atol = 1e-4
     end
+    
+    @testset "#4416 Merging attributes" begin
+        # See https://github.com/MakieOrg/Makie.jl/pull/4416
+        theme1 = Theme(Axis = (; titlesize = 10))
+        theme2 = Theme(Axis = (; xgridvisible = false))
+        merged_theme = merge(theme1, theme2)
+        # Test that merging themes does not modify leftmost argument
+        @test !haskey(theme1.Axis, :xgridvisible)
+        @test !haskey(theme2.Axis, :titlesize)  # sanity check other argument
+    end
 end


### PR DESCRIPTION
`deepcopy` correctly handles copying of non-toplevel attributes like `Theme(Axis = (; titlesize=10))`, otherwise leftmost argument to `merge` is modified.

# Description

Fixes the following bug in which `theme1` is being modified by `merge`:
```julia
julia> theme1 = Theme(Axis = (; titlesize = 10))
Attributes with 1 entry:
  Axis => Attributes with 1 entry:
    titlesize => 10

julia> theme2 = Theme(Axis = (; xgridvisible = false))
Attributes with 1 entry:
  Axis => Attributes with 1 entry:
    xgridvisible => false

julia> merge(theme1, theme2)
Attributes with 1 entry:
  Axis => Attributes with 2 entries:
    titlesize => 10
    xgridvisible => false

julia> theme1
Attributes with 1 entry:
  Axis => Attributes with 2 entries:
    titlesize => 10
    xgridvisible => false
```

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
