### PR TITLE
Add drag threshold to improve click experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix incorrect inverse transformation in `position_on_plot` for lines, causing incorrect tooltip placement in DataInspector [#4402](https://github.com/MakieOrg/Makie.jl/pull/4402)
+- Added threshold before a drag starts which improves false negative rates for clicks. `Button` can now trigger on click and not mouse-down which is the canonical behavior in other GUI systems [#4336](https://github.com/MakieOrg/Makie.jl/pull/4336).
 
 ## [0.21.12] - 2024-09-28
 

--- a/src/makielayout/blocks/button.jl
+++ b/src/makielayout/blocks/button.jl
@@ -65,6 +65,10 @@ function initialize_block!(b::Button)
 
     onmouseleftdown(mouseevents) do _
         mousestate[] = :active
+        return Consume(true)
+    end
+
+    onmouseleftclick(mouseevents) do _
         b.clicks[] = b.clicks[] + 1
         return Consume(true)
     end

--- a/src/makielayout/mousestatemachine.jl
+++ b/src/makielayout/mousestatemachine.jl
@@ -199,6 +199,8 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
     mouse_downed_inside = Ref(false)
     mouse_downed_button = Ref{Optional{Mouse.Button}}(nothing)
     drag_ongoing = Ref(false)
+    mouse_downed_at = Ref(Point2d(0, 0)) # store the position of mouse down so drags only start after some threshold
+    drag_threshold = 2.0 # mouse needs to move this distance before a drag starts, otherwise it's easy to drag instead of click on trackpads
     mouse_was_inside = Ref(false)
     prev_t = Ref(0.0)
     t_last_click = Ref(0.0)
@@ -231,7 +233,7 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
             else
                 # mouse was downed inside but no drag is ongoing
                 # that means a drag started
-                if mouse_downed_inside[]
+                if mouse_downed_inside[] && norm(mouse_downed_at[] - px) >= drag_threshold
                     drag_ongoing[] = true
                     event = to_drag_start_event(mouse_downed_button[])
                     x = setindex!(mouseevent,
@@ -294,6 +296,7 @@ function _addmouseevents!(scene, is_mouse_over_relevant_area, priority)
                 mouse_downed_button[] = button
 
                 if mouse_was_inside[]
+                    mouse_downed_at[] = px
                     event = to_down_event(mouse_downed_button[])
                     x = setindex!(mouseevent,
                         MouseEvent(event, t, data, px, prev_t[], prev_data[], prev_px[])

--- a/test/events.jl
+++ b/test/events.jl
@@ -321,6 +321,8 @@ Base.:(==)(l::Or, r::Or) = l.left == r.left && l.right == r.right
         for button in (:left, :middle, :right)
             # click
             e.mousebutton[] = MouseButtonEvent(getfield(Mouse, button), Mouse.press)
+            e.mouseposition[] = (301, 301) # small mouse deviations with pressed button shouldn't register as a drag and prohibit a click
+            e.mouseposition[] = (300, 300)
             e.mousebutton[] = MouseButtonEvent(getfield(Mouse, button), Mouse.release)
             @test length(eventlog) == 3
             for (i, t) in enumerate((


### PR DESCRIPTION
It has been a problem for a long time which I've also seen in many user recordings that a drag starts when any distance is travelled by the mouse after mouse down. This means that for a click to register, the mouse has to stay perfectly still between mouse down and up. That's hard to do with precision input devices like my Macbook's trackpad. When implementing this code, I frequently see difference values like 0.1 or 0.2 pixels, you don't even see the cursor move (as it's snapped to the pixel grid) but no click is happening.

This PR adds a small threshold in pixels that the mouse has to travel before a drag starts. Until then, if the mouse goes up, a click will be registered. For me this is immediately noticeable in usability. The threshold value 2 that I chose is kind of arbitrary but seemed to work well enough, at some point higher values feel weird as dragging a slider, for example, seems to start too late.