### PR TITLE
Legend overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix incorrect inverse transformation in `position_on_plot` for lines, causing incorrect tooltip placement in DataInspector [#4402](https://github.com/MakieOrg/Makie.jl/pull/4402)
+- Add `LegendOverride` object to override legend element attributes [#4427](https://github.com/MakieOrg/Makie.jl/pull/4427).
 
 ## [0.21.12] - 2024-09-28
 

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -172,7 +172,7 @@ end
 
     li = lines!(
         1:10,
-        label = "Line" => LegendOverride(linewidth = 4, color = :gray60, linestyle = :dot),
+        label = "Line" => (; linewidth = 4, color = :gray60, linestyle = :dot),
     )
     sc = scatter!(
         1:10,
@@ -182,16 +182,16 @@ end
         marker = :utriangle,
         markersize = 20,
         label = [
-            label => LegendOverride(; markersize = 30, color = i) for (i, label) in enumerate(["blue", "green", "yellow"])
+            label => (; markersize = 30, color = i) for (i, label) in enumerate(["blue", "green", "yellow"])
         ]
     )
     Legend(f[1, 2], ax)
     Legend(
         f[1, 3],
         [
-            sc => LegendOverride(markersize = 30),
-            [li => LegendOverride(color = :red), sc => LegendOverride(color = :cyan)],
-            [li, sc] => LegendOverride(color = :cyan),
+            sc => (; markersize = 30),
+            [li => (; color = :red), sc => (; color = :cyan)],
+            [li, sc] => Dict(:color => :cyan),
         ],
         ["Scatter", "Line and Scatter", "Another"],
         patchsize = (40, 20)

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -190,10 +190,11 @@ end
         f[1, 3],
         [
             sc => LegendOverride(markersize = 30),
-            [li => LegendOverride(color = :red), sc => LegendOverride(color = :cyan)]
+            [li => LegendOverride(color = :red), sc => LegendOverride(color = :cyan)],
+            [li, sc] => LegendOverride(color = :cyan),
         ],
-        ["Scatter", "Line and Scatter"],
-        patchsize = (40, 40)
+        ["Scatter", "Line and Scatter", "Another"],
+        patchsize = (40, 20)
     )
     f
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -166,6 +166,38 @@ end
     f
 end
 
+@reference_test "Legend overrides" begin
+    f = Figure()
+    ax = Axis(f[1, 1])
+
+    li = lines!(
+        1:10,
+        label = "Line" => LegendOverride(linewidth = 4, color = :gray60, linestyle = :dot),
+    )
+    sc = scatter!(
+        1:10,
+        2:11,
+        color = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1],
+        colorrange = (1, 3),
+        marker = :utriangle,
+        markersize = 20,
+        label = [
+            label => LegendOverride(; markersize = 30, color = i) for (i, label) in enumerate(["blue", "green", "yellow"])
+        ]
+    )
+    Legend(f[1, 2], ax)
+    Legend(
+        f[1, 3],
+        [
+            sc => LegendOverride(markersize = 30),
+            [li => LegendOverride(color = :red), sc => LegendOverride(color = :cyan)]
+        ],
+        ["Scatter", "Line and Scatter"],
+        patchsize = (40, 40)
+    )
+    f
+end
+
 @reference_test "LaTeXStrings in Axis3 plots" begin
     xs = LinRange(-10, 10, 100)
     ys = LinRange(0, 15, 100)

--- a/docs/src/reference/blocks/legend.md
+++ b/docs/src/reference/blocks/legend.md
@@ -204,6 +204,68 @@ f
 ```
 
 
+## Overriding legend entry attributes
+
+By default, legends inherit the visual attributes of the plots they belong to.
+Sometimes, it is necessary to override some of these attributes to make the legend more legible.
+You can pair a `LegendOverride` object to a plot's `label` to override its automatic legend entry, for example to increase the marker size of a `Scatter`:
+
+```@figure
+f, ax, sc = scatter(
+    cos.(range(0, 7pi, 100)),
+    color = :black,
+    markersize = 8,
+    label = "cos" => LegendOverride(markersize = 15)
+)
+scatter!(
+    sin.(range(0, 7pi, 100)),
+    color = :black,
+    marker = :utriangle,
+    markersize = 8,
+    label = "sin" => LegendOverride(markersize = 15)
+)
+Legend(f[1, 2], ax)
+f
+```
+
+Another common case is when you want to create a legend for a plot with a categorical colormap.
+By passing a vector of labels paired with `LegendOverride`s, you can create multiple entries with the correct colors:
+
+```@figure
+f, ax, bp = barplot(
+    1:5,
+    [1, 3, 2, 5, 4],
+    color = 1:5,
+    colorrange = (1, 5),
+    colormap = :Set1_5,
+    label = [label => LegendOverride(color = i)
+        for (i, label) in enumerate(["red", "blue", "green", "purple", "orange"])]
+)
+Legend(f[1, 2], ax)
+f
+```
+
+You may also override plots in the `Legend` constructor itself, in this case, you pair the `LegendOverride`s with the plots whose legend entries you want to override:
+
+```@figure
+f = Figure()
+ax = Axis(f[1, 1])
+li = lines!(ax, 1:5, linestyle = :dot)
+sc = scatter!(ax, 1:5, markersize = 10)
+Legend(
+    f[1, 2],
+    [
+        sc => LegendOverride(markersize = 20),
+        li => LegendOverride(linewidth = 3),
+        [li, sc] => LegendOverride(color = :red),
+        [li => LegendOverride(linewidth = 3), sc => LegendOverride(markersize = 20)],
+    ],
+    ["Scatter", "Line", "Both", "Both 2"],
+    patchsize = (40, 20),
+)
+f
+```
+
 ## Multi-Group Legends
 
 Sometimes a legend consists of multiple groups, for example in a plot where both

--- a/docs/src/reference/blocks/legend.md
+++ b/docs/src/reference/blocks/legend.md
@@ -208,28 +208,37 @@ f
 
 By default, legends inherit the visual attributes of the plots they belong to.
 Sometimes, it is necessary to override some of these attributes to make the legend more legible.
-You can pair a `LegendOverride` object to a plot's `label` to override its automatic legend entry, for example to increase the marker size of a `Scatter`:
+You can pair a key-value object like a `NamedTuple` or a `Dict{Symbol}` to a plot's `label` to override its automatic legend entry, for example to increase the marker size of a `Scatter`:
 
 ```@figure
 f, ax, sc = scatter(
     cos.(range(0, 7pi, 100)),
     color = :black,
     markersize = 8,
-    label = "cos" => LegendOverride(markersize = 15)
+    label = "cos" => (; markersize = 15)
 )
 scatter!(
     sin.(range(0, 7pi, 100)),
     color = :black,
     marker = :utriangle,
     markersize = 8,
-    label = "sin" => LegendOverride(markersize = 15)
+    label = "sin" => (; markersize = 15)
 )
 Legend(f[1, 2], ax)
 f
 ```
 
+These are the attributes you can override (note that some of them have convenience aliases like `color` which applies to all elements while `polycolor` only applies to `PolyElement`s):
+
+- `MarkerElement`
+  - `[marker]points`, `markersize`, `[marker]strokewidth`, `[marker]color`, `[marker]strokecolor`, `[marker]colorrange`, `[marker]colormap`
+- `LineElement`
+  - `[line]points`, `linewidth`, `[line]color`, `linestyle`, `[line]colorrange`, `[line]colormap`
+- `PolyElement`
+  - `[poly]points`, `[poly]strokewidth`, `[poly]color`, `[poly]strokecolor`, `[poly]colorrange`, `[poly]colormap`
+
 Another common case is when you want to create a legend for a plot with a categorical colormap.
-By passing a vector of labels paired with `LegendOverride`s, you can create multiple entries with the correct colors:
+By passing a vector of labels paired with overrides, you can create multiple entries with the correct colors:
 
 ```@figure
 f, ax, bp = barplot(
@@ -238,14 +247,14 @@ f, ax, bp = barplot(
     color = 1:5,
     colorrange = (1, 5),
     colormap = :Set1_5,
-    label = [label => LegendOverride(color = i)
+    label = [label => (; color = i)
         for (i, label) in enumerate(["red", "blue", "green", "purple", "orange"])]
 )
 Legend(f[1, 2], ax)
 f
 ```
 
-You may also override plots in the `Legend` constructor itself, in this case, you pair the `LegendOverride`s with the plots whose legend entries you want to override:
+You may also override plots in the `Legend` constructor itself, in this case, you pair the overrides with the plots whose legend entries you want to override:
 
 ```@figure
 f = Figure()
@@ -255,10 +264,10 @@ sc = scatter!(ax, 1:5, markersize = 10)
 Legend(
     f[1, 2],
     [
-        sc => LegendOverride(markersize = 20),
-        li => LegendOverride(linewidth = 3),
-        [li, sc] => LegendOverride(color = :red),
-        [li => LegendOverride(linewidth = 3), sc => LegendOverride(markersize = 20)],
+        sc => (; markersize = 20),
+        li => (; linewidth = 3),
+        [li, sc] => (; color = :red),
+        [li => (; linewidth = 3), sc => (; markersize = 20)],
     ],
     ["Scatter", "Line", "Both", "Both 2"],
     patchsize = (40, 20),

--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -46,7 +46,7 @@ export Label
 export Box
 export Toggle
 export Legend, axislegend
-export LegendEntry, MarkerElement, PolyElement, LineElement, LegendElement, LegendOverride
+export LegendEntry, MarkerElement, PolyElement, LineElement, LegendElement
 export LScene
 export Menu
 export Textbox

--- a/src/makielayout/MakieLayout.jl
+++ b/src/makielayout/MakieLayout.jl
@@ -46,7 +46,7 @@ export Label
 export Box
 export Toggle
 export Legend, axislegend
-export LegendEntry, MarkerElement, PolyElement, LineElement, LegendElement
+export LegendEntry, MarkerElement, PolyElement, LineElement, LegendElement, LegendOverride
 export LScene
 export Menu
 export Textbox

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -251,6 +251,9 @@ end
 
 struct LegendOverride
     overrides::Attributes
+    LegendOverride(attrs::Attributes) = new(attrs)
+    LegendOverride(l::LegendOverride) = l
+    LegendOverride(attrs) = new(Attributes(attrs))
 end
 
 LegendOverride(; kwargs...) = LegendOverride(Attributes(; kwargs...))
@@ -335,7 +338,7 @@ end
 legendelements(le::LegendElement, legend) = LegendElement[le]
 legendelements(les::AbstractArray{<:LegendElement}, legend) = LegendElement[les...]
 
-legendelements(p::Pair{<:Any, LegendOverride}, legend) = legendelements(p[1], legend, p[2])
+legendelements(p::Pair, legend) = legendelements(p[1], legend, LegendOverride(p[2]))
 
 function legendelements(any, legend, override::LegendOverride)
     les = legendelements(any, legend)
@@ -702,10 +705,7 @@ function get_labeled_plots(ax; merge::Bool, unique::Bool)
 
     lplots_with_overrides = map(lplots, labels) do plots, label
         if label isa Pair
-            if !(label[2] isa LegendOverride)
-                error("Found legend label in Pair form but the second element was not of type LegendOverride as expected, but was $(label[2])")
-            end
-            plots => label[2]
+            plots => LegendOverride(label[2])
         else
             plots
         end

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -363,6 +363,15 @@ function apply_legend_override!(le::LineElement, override::LegendOverride)
     end
 end
 
+function apply_legend_override!(le::PolyElement, override::LegendOverride)
+    renamed_attrs = _rename_attributes!(PolyElement, copy(override.overrides))
+    for sym in (:polypoints, :polycolor, :polystrokewidth, :polystrokecolor, :polycolormap, :polycolorrange, :polystrokestyle)
+        if haskey(renamed_attrs, sym)
+            le.attributes[sym] = renamed_attrs[sym]
+        end
+    end
+end
+
 function LegendEntry(label, contentelement, override::Attributes, legend; kwargs...)
     attrs = Attributes(; label)
 

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -249,6 +249,12 @@ function initialize_block!(leg::Legend; entrygroups)
     return
 end
 
+struct LegendOverride
+    overrides::Attributes
+end
+
+LegendOverride(; kwargs...) = LegendOverride(Attributes(; kwargs...))
+
 function connect_block_layoutobservables!(leg::Legend, layout_width, layout_height, layout_tellwidth, layout_tellheight, layout_halign, layout_valign, layout_alignmode)
     connect!(layout_width, leg.width)
     connect!(layout_height, leg.height)
@@ -329,6 +335,45 @@ end
 legendelements(le::LegendElement, legend) = LegendElement[le]
 legendelements(les::AbstractArray{<:LegendElement}, legend) = LegendElement[les...]
 
+function legendelements(any, legend, override::LegendOverride)
+    les = legendelements(any, legend)
+    for le in les
+        apply_legend_override!(le, override)
+    end
+    return les
+end
+
+function apply_legend_override!(le::MarkerElement, override::LegendOverride)
+    renamed_attrs = _rename_attributes!(MarkerElement, copy(override.overrides))
+    for sym in (:markerpoints, :markersize, :markercolor, :markerstrokewidth, :markerstrokecolor, :markercolormap, :markercolorrange)
+        if haskey(renamed_attrs, sym)
+            le.attributes[sym] = renamed_attrs[sym]
+        end
+    end
+end
+
+function apply_legend_override!(le::LineElement, override::LegendOverride)
+    renamed_attrs = _rename_attributes!(LineElement, copy(override.overrides))
+    for sym in (:linepoints, :linewidth, :linecolor, :linecolormap, :linecolorrange, :linestyle)
+        if haskey(renamed_attrs, sym)
+            le.attributes[sym] = renamed_attrs[sym]
+        end
+    end
+end
+
+function LegendEntry(label_and_override::Pair, contentelement, legend; kwargs...)
+    label, override = label_and_override
+    attrs = Attributes(; label)
+
+    kwargattrs = Attributes(kwargs)
+    merge!(attrs, kwargattrs)
+
+    elems = legendelements(contentelement, legend, override)
+    if isempty(elems)
+        error("`legendelements` returned an empty list for content element of type $(typeof(contentelement)). That could mean that neither this object nor any possible child objects had a method for `legendelements` defined that returned a non-empty result.")
+    end
+    LegendEntry(elems, attrs)
+end
 
 function LegendEntry(label, contentelements::AbstractArray, legend; kwargs...)
     attrs = Attributes(label = label)
@@ -609,6 +654,24 @@ function get_labeled_plots(ax; merge::Bool, unique::Bool)
     end
     labels = map(lplots) do l
         l.label[]
+    end
+
+    if any(x -> x isa AbstractVector, labels)
+        _lplots = []
+        _labels = []
+        for (lplot, label) in zip(lplots, labels)
+            if label isa AbstractVector
+                for lab in label
+                    push!(_lplots, lplot)
+                    push!(_labels, lab)
+                end
+            else
+                push!(_lplots, lplot)
+                push!(_labels, label)
+            end
+        end
+        lplots = _lplots
+        labels = _labels
     end
 
     # filter out plots with same plot type and label

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -376,25 +376,26 @@ function LegendEntry(label, contentelement, override::Attributes, legend; kwargs
     LegendEntry(elems, attrs)
 end
 
-function LegendEntry(label, contentelements::AbstractArray, legend; kwargs...)
+
+function LegendEntry(label, content, legend; kwargs...)
     attrs = Attributes(label = label)
 
     kwargattrs = Attributes(kwargs)
     merge!(attrs, kwargattrs)
 
-    elems = vcat(legendelements.(contentelements, Ref(legend))...)
-    LegendEntry(elems, attrs)
-end
-
-function LegendEntry(label, contentelement, legend; kwargs...)
-    attrs = Attributes(label = label)
-
-    kwargattrs = Attributes(kwargs)
-    merge!(attrs, kwargattrs)
-
-    elems = legendelements(contentelement, legend)
+    if content isa AbstractArray
+        elems = vcat(legendelements.(content, Ref(legend))...)
+    elseif content isa Pair
+        if content[1] isa AbstractArray
+            elems = vcat(legendelements.(content[1] .=> Ref(content[2]), Ref(legend))...)
+        else
+            elems = legendelements(content, legend)
+        end
+    else
+        elems = legendelements(content, legend)
+    end
     if isempty(elems)
-        error("`legendelements` returned an empty list for content element of type $(typeof(contentelement)). That could mean that neither this object nor any possible child objects had a method for `legendelements` defined that returned a non-empty result.")
+        error("`legendelements` returned an empty list for content element of type $(typeof(content)). That could mean that neither this object nor any possible child objects had a method for `legendelements` defined that returned a non-empty result.")
     end
     LegendEntry(elems, attrs)
 end


### PR DESCRIPTION
Implements a mechanism to override legend element attributes that are normally set by copying them from the respective plot objects. ~Introduces the `LegendOverride` object, although I'm not 100% sure if we really need that as API, or should just use whatever key-value pairs we can get.~ Now uses any key-value object.

The overrides can either be paired to `label` keywords (as that's the legend interface for plotting functions), or to the plotting functions themselves in the `Legend` constructor (there I don't think it makes sense to pair to labels although it might be perceived as inconsistent?).

## Examples

```julia
f, ax, sc = scatter(
    cos.(range(0, 7pi, 100)),
    color = :black,
    markersize = 8,
    label = "cos" => (; markersize = 15)
)
scatter!(
    sin.(range(0, 7pi, 100)),
    color = :black,
    marker = :utriangle,
    markersize = 8,
    label = "sin" => (; markersize = 15)
)
Legend(f[1, 2], ax)
f
```

<img width="591" alt="grafik" src="https://github.com/user-attachments/assets/60a63c40-999f-4598-a6b7-4b9e467333f9">


```julia
f = Figure()
ax = Axis(f[1, 1])
li = lines!(ax, 1:5, linestyle = :dot)
sc = scatter!(ax, 1:5, markersize = 10)
Legend(
    f[1, 2],
    [
        sc => (; markersize = 20),
        li => (; linewidth = 3),
        [li, sc] => (; color = :red),
        [li => (; linewidth = 3), sc => (; markersize = 20)],
    ],
    ["Scatter", "Line", "Both", "Both 2"],
    patchsize = (40, 20),
)
f
```
<img width="602" alt="grafik" src="https://github.com/user-attachments/assets/7b40e77a-769b-4a96-aa00-9a62ebb40e73">


```julia
f, ax, bp = barplot(
    1:5,
    [1, 3, 2, 5, 4],
    color = 1:5,
    colorrange = (1, 5),
    colormap = :Set1_5,
    label = [label => (; color = i)
        for (i, label) in enumerate(["red", "blue", "green", "purple", "orange"])]
)
Legend(f[1, 2], ax)
f
```
<img width="592" alt="grafik" src="https://github.com/user-attachments/assets/d7028ea3-7f24-45e6-a934-5c0f961673fe">
