### PR TITLE
More improvements for ReferenceUpdater

### DIFF
--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -198,9 +198,10 @@ jobs:
 
           # Loop through the directories and concatenate the files, and copy recorded folders
           for dir in WGLMakie CairoMakie GLMakie; do
-              # Concatenate scores.tsv and new_files.txt
+              # Concatenate scores.tsv, new_files.txt and missing_files.txt
               cat "${baseDir}/${dir}/scores.tsv" >> "./ReferenceImagesCombined/scores.tsv"
               cat "${baseDir}/${dir}/new_files.txt" >> "./ReferenceImagesCombined/new_files.txt"
+              cat "${baseDir}/${dir}/missing_files.txt" >> "./ReferenceImagesCombined/missing_files.txt"
 
               # Copy recorded folder
               mkdir -p "./ReferenceImagesCombined/recorded/${dir}/"

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -193,7 +193,7 @@ functions = [:volume, :volume!, :uv_mesh]
     CairoMakie.activate!(type = "png", px_per_unit = 1)
     ReferenceTests.mark_broken_tests(excludes, functions=functions)
     recorded_files, recording_dir = @include_reference_tests CairoMakie "refimages.jl"
-    missing_images, scores = ReferenceTests.record_comparison(recording_dir)
+    missing_images, scores = ReferenceTests.record_comparison(recording_dir, "CairoMakie")
     ReferenceTests.test_comparison(scores; threshold = 0.05)
 end
 

--- a/GLMakie/test/runtests.jl
+++ b/GLMakie/test/runtests.jl
@@ -30,7 +30,7 @@ include("unit_tests.jl")
     @testset "refimages" begin
         ReferenceTests.mark_broken_tests()
         recorded_files, recording_dir = @include_reference_tests GLMakie "refimages.jl" joinpath(@__DIR__, "glmakie_refimages.jl")
-        missing_images, scores = ReferenceTests.record_comparison(recording_dir)
+        missing_images, scores = ReferenceTests.record_comparison(recording_dir, "GLMakie")
         ReferenceTests.test_comparison(scores; threshold = 0.05)
     end
 

--- a/ReferenceTests/src/database.jl
+++ b/ReferenceTests/src/database.jl
@@ -17,6 +17,7 @@ const RECORDING_DIR = Base.RefValue{String}()
 const SKIP_TITLES = Set{String}()
 const SKIP_FUNCTIONS = Set{Symbol}()
 const COUNTER = Ref(0)
+const SKIPPED_NAMES = Set{String}() # names skipped due to title exclusion or function exclusion
 
 """
     @reference_test(name, code)
@@ -32,6 +33,7 @@ macro reference_test(name, code)
         @testset $(title) begin
             if $skip
                 @test_broken false
+                mark_skipped!($title)
             else
                 t1 = time()
                 if $title in $REGISTERED_TESTS
@@ -84,9 +86,12 @@ end
 function mark_broken_tests(title_excludes = []; functions=[])
     empty!(SKIP_TITLES)
     empty!(SKIP_FUNCTIONS)
+    empty!(SKIPPED_NAMES)
     union!(SKIP_TITLES, title_excludes)
     union!(SKIP_FUNCTIONS, functions)
 end
+
+mark_skipped!(name::String) = push!(SKIPPED_NAMES, name)
 
 macro include_reference_tests(backend::Symbol, path, paths...)
     toplevel_folder = dirname(string(__source__.file))

--- a/ReferenceTests/src/runtests.jl
+++ b/ReferenceTests/src/runtests.jl
@@ -92,10 +92,16 @@ function record_comparison(base_folder::String; record_folder_name="recorded", t
     end
     cp(reference_folder, local_reference_copy_dir)
     testimage_paths = get_all_relative_filepaths_recursively(record_folder)
-    missing_refimages, scores = compare(testimage_paths, reference_folder, record_folder)
+    missing_refimages, missing_recordings, scores = compare(testimage_paths, reference_folder, record_folder)
 
     open(joinpath(base_folder, "new_files.txt"), "w") do file
         for path in missing_refimages
+            println(file, path)
+        end
+    end
+
+    open(joinpath(base_folder, "missing_files.txt"), "w") do file
+        for path in missing_recordings
             println(file, path)
         end
     end
@@ -120,12 +126,19 @@ function test_comparison(scores; threshold)
     end
 end
 
-function compare(relative_test_paths::Vector{String}, reference_dir::String, record_dir; o_refdir=reference_dir, missing_refimages=String[], scores=Dict{String,Float64}())
+function compare(
+        relative_test_paths::Vector{String}, reference_dir::String, record_dir; 
+        o_refdir = reference_dir, missing_refimages = String[], 
+        missing_recordings = String[], scores = Dict{String,Float64}()
+    )
+
     for relative_test_path in relative_test_paths
         ref_path = joinpath(reference_dir, relative_test_path)
         rec_path = joinpath(record_dir, relative_test_path)
         if !isfile(ref_path)
             push!(missing_refimages, relative_test_path)
+        elseif !isfile(rec_path)
+            push!(missing_recordings, relative_test_path)
         elseif endswith(ref_path, ".html")
             # ignore
         else
@@ -133,5 +146,5 @@ function compare(relative_test_paths::Vector{String}, reference_dir::String, rec
             scores[relative_test_path] = diff
         end
     end
-    return missing_refimages, scores
+    return missing_refimages, missing_recordings, scores
 end

--- a/ReferenceTests/src/runtests.jl
+++ b/ReferenceTests/src/runtests.jl
@@ -81,7 +81,7 @@ function get_all_relative_filepaths_recursively(dir)
     end
 end
 
-function record_comparison(base_folder::String; record_folder_name="recorded", tag=last_major_version())
+function record_comparison(base_folder::String, backend::String; record_folder_name="recorded", tag=last_major_version())
     record_folder = joinpath(base_folder, record_folder_name)
     @info "Downloading reference images"
     reference_folder = download_refimages(tag)
@@ -92,15 +92,22 @@ function record_comparison(base_folder::String; record_folder_name="recorded", t
     end
     cp(reference_folder, local_reference_copy_dir)
     testimage_paths = get_all_relative_filepaths_recursively(record_folder)
-    missing_refimages, missing_recordings, scores = compare(testimage_paths, reference_folder, record_folder)
+    missing_refimages, scores = compare(testimage_paths, reference_folder, record_folder)
 
     open(joinpath(base_folder, "new_files.txt"), "w") do file
         for path in missing_refimages
             println(file, path)
         end
     end
-
+    
     open(joinpath(base_folder, "missing_files.txt"), "w") do file
+        backend_ref_dir = joinpath(reference_folder, backend)
+        recorded_paths = mapreduce(vcat, walkdir(backend_ref_dir)) do (root, dirs, files)
+            relpath.(joinpath.(root, files), reference_folder)
+        end
+        skipped = Set([joinpath(backend, "$name.png") for name in SKIPPED_NAMES])
+        missing_recordings = setdiff(Set(recorded_paths), Set(testimage_paths), skipped)
+
         for path in missing_recordings
             println(file, path)
         end
@@ -129,7 +136,7 @@ end
 function compare(
         relative_test_paths::Vector{String}, reference_dir::String, record_dir; 
         o_refdir = reference_dir, missing_refimages = String[], 
-        missing_recordings = String[], scores = Dict{String,Float64}()
+        scores = Dict{String,Float64}()
     )
 
     for relative_test_path in relative_test_paths
@@ -137,8 +144,6 @@ function compare(
         rec_path = joinpath(record_dir, relative_test_path)
         if !isfile(ref_path)
             push!(missing_refimages, relative_test_path)
-        elseif !isfile(rec_path)
-            push!(missing_recordings, relative_test_path)
         elseif endswith(ref_path, ".html")
             # ignore
         else
@@ -146,5 +151,5 @@ function compare(
             scores[relative_test_path] = diff
         end
     end
-    return missing_refimages, missing_recordings, scores
+    return missing_refimages, scores
 end

--- a/ReferenceTests/src/tests/dates.jl
+++ b/ReferenceTests/src/tests/dates.jl
@@ -15,7 +15,7 @@ date_time_range = range(date_time, step=Week(5), length=10)
     f
 end
 
-@reference_test "Don't sometimes allow mixing units incorrectly" begin
+@reference_test "Don'some_time allow mixing units incorrectly" begin
     date_time_range = range(date_time, step=Second(5), length=10)
     f, ax, pl = scatter(date_time_range, 1:10)
     @test_throws ErrorException scatter!(time_range, 1:10)

--- a/ReferenceTests/src/tests/dates.jl
+++ b/ReferenceTests/src/tests/dates.jl
@@ -15,7 +15,7 @@ date_time_range = range(date_time, step=Week(5), length=10)
     f
 end
 
-@reference_test "Don'some_time allow mixing units incorrectly" begin
+@reference_test "Don't sometimes allow mixing units incorrectly" begin
     date_time_range = range(date_time, step=Second(5), length=10)
     f, ax, pl = scatter(date_time_range, 1:10)
     @test_throws ErrorException scatter!(time_range, 1:10)

--- a/ReferenceUpdater/Project.toml
+++ b/ReferenceUpdater/Project.toml
@@ -4,6 +4,7 @@ authors = ["Julius Krumbiegel <julius.krumbiegel@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/ReferenceUpdater/src/ReferenceUpdater.jl
+++ b/ReferenceUpdater/src/ReferenceUpdater.jl
@@ -8,6 +8,7 @@ import JSON3
 import ZipFile
 import REPL
 import TOML
+using Dates
 
 function github_token()
     get(ENV, "GITHUB_TOKEN") do

--- a/ReferenceUpdater/src/image_download.jl
+++ b/ReferenceUpdater/src/image_download.jl
@@ -18,3 +18,13 @@ function upload_reference_images(path=basedir("recorded"), tag=last_major_versio
         upload_release("MakieOrg", "Makie.jl", github_token(), tag, tarfile)
     end
 end
+
+function download_refimages(tag=last_major_version())
+    url = "https://github.com/MakieOrg/Makie.jl/releases/download/$(tag)/reference_images.tar"
+    images_tar = Downloads.download(url)
+    images = tempname()
+    isdir(images) && rm(images, recursive=true, force=true)
+    Tar.extract(images_tar, images)
+    rm(images_tar)
+    return images
+end

--- a/ReferenceUpdater/src/local_server.jl
+++ b/ReferenceUpdater/src/local_server.jl
@@ -17,7 +17,8 @@ function serve_update_page_from_dir(folder)
 
     function receive_update(req)
         data = JSON3.read(req.body)
-        images = data["images"]
+        images_to_update = data["images_to_update"]
+        images_to_delete = data["images_to_delete"]
         tag = data["tag"]
 
         tempdir = tempname()
@@ -27,13 +28,19 @@ function serve_update_page_from_dir(folder)
         @info "Copying reference folder to \"$tempdir\""
         cp(reference_folder, tempdir)
 
-        for image in images
+        for image in images_to_update
             @info "Overwriting \"$image\" in new reference folder"
             copy_filepath = joinpath(tempdir, image)
             copy_dir = splitdir(copy_filepath)[1]
             # make the path in case a new refimage is in a not yet existing folder
             mkpath(copy_dir)
             cp(joinpath(recorded_folder, image), copy_filepath, force = true)
+        end
+
+        for image in images_to_delete
+            @info "Deleting \"$image\" from new reference folder"
+            copy_filepath = joinpath(tempdir, image)
+            rm(copy_filepath, recursive = true)
         end
 
         @info "Uploading updated reference images under tag \"$tag\""

--- a/ReferenceUpdater/src/local_server.jl
+++ b/ReferenceUpdater/src/local_server.jl
@@ -120,14 +120,20 @@ function serve_update_page(; commit = nothing, pr = nothing)
             return false
         end
     end
+
     if isempty(checkruns)
         error("\"Merge artifacts\" run is not available.")
     end
     if length(checkruns) > 1
-        error("Found multiple checkruns for \"Merge artifacts\", this is unexpected.")
-    end
-
+        datetimes = map(checkruns) do checkrun
+            DateTime(checkrun["completed_at"], dateformat"y-m-dTH:M:SZ")
+        end
+        datetime, idx = findmax(datetimes)
+        @warn("Found multiple checkruns for \"Merge artifacts\". Using latest with timestamp: $datetime")
+        check = checkruns[idx]
+    else
     check = only(checkruns)
+    end
 
     job = JSON3.read(authget("https://api.github.com/repos/MakieOrg/Makie.jl/actions/jobs/$(check["id"])").body)
     run = JSON3.read(authget(job["run_url"]).body)

--- a/ReferenceUpdater/src/reference_images.html
+++ b/ReferenceUpdater/src/reference_images.html
@@ -249,11 +249,7 @@
         }
 
         function toggle_all(source, group) {
-            console.log(source)
-            console.log(group)
-            
             checkboxes = document.querySelectorAll(group)
-            console.log(checkboxes)
             checkboxes.forEach(checkbox => { checkbox.checked = source.checked })
         }
 

--- a/ReferenceUpdater/src/reference_images.html
+++ b/ReferenceUpdater/src/reference_images.html
@@ -37,11 +37,26 @@
         <h3 id="delete-counter"></h3>
         <ul id="delete-list">
         </ul>
-        <h2>New images without references (Adding selected)</h2>
+        
+        <h2>New images without references</h2>
+        The selected CI run produced an image for which no reference image exists. 
+        Selected images will be added as new reference images.
+        <br><br>
         <div id="new-images-list" class="image-list"></div>
-        <h2>Reference images that have no been tested (Deleting selected)</h2>
+
+        <h2>Old reference images without recordings</h2>
+        The selected CI run did not produce an image, but a reference image exists. 
+        This implies that a reference test was deleted or renamed. 
+        Selected images will be deleted from the reference images.
+        <br><br>
         <div id="missing-images-list" class="image-list"></div>
-        <h2>Images with references (Updating selected)</h2>
+
+        <h2>Images with references</h2>
+        This is the normal case where the selected CI run produced an image and the reference image exists.
+        Each row shows one image per backend from the same reference image test, which can be compared with its reference image.
+        Rows are sorted based on the maximum row score (bigger = more different).
+        Red cells fail CI (assuming the thresholds are up to date), yellow cells may but likely don't have signficant visual difference and gray cells are visually equivalent.
+        <br><br>
         <div id="refimage-list" class="image-list"></div>
     </body>
 
@@ -116,25 +131,42 @@
                 })
             })
 
-        fetch('new_files.txt')
+        fetch('new_files_grouped.txt')
             .then(response => response.text())
             .then(data => {
                 di = document.querySelector("#new-images-list")
-                data.split(/\r?\n/).forEach(path => {
-                    if (path == ""){
+                data.split(/\r?\n/).forEach(line => {
+                    if (line == ""){
                         return
                     }
+                    parts = line.split('\t')
                     
-                    div = document.createElement("div")
-                    di.append(div)
-                    div.innerHTML = `
-                    <input type="checkbox" class="update-checkbox" data-image="${path}"></input>
-                    <span>${path}</span><br>
-                    `
-                    if (path.endsWith(".png")){
-                        div.innerHTML += `<img class="refimage" data-version="recorded" data-image="${path}" src="recorded/${encodeURIComponent(path)}">`
-                    } else if (path.endsWith(".mp4")){
-                        div.innerHTML += `<video class="refimage" data-version="recorded" data-image="${path}" controls src="recorded/${encodeURIComponent(path)}">`
+                    // row
+                    row = document.createElement("div") 
+                    di.append(row)
+
+                     // Cells
+                     for (let i = 0; i < 3; i++) {
+                        let path = parts[i]
+
+                        cell = document.createElement("td")
+                        row.append(cell)
+
+                        if (path == "")
+                            continue;
+           
+                        div = document.createElement("div")
+                        cell.append(div)
+                        div.innerHTML = `
+                        <input type="checkbox" class="update-checkbox" data-image="${path}"></input>
+                        <span>${path}</span>
+                        <br>
+                        `
+                        if (path.endsWith(".png")){
+                            div.innerHTML += `<img class="refimage" data-version="recorded" data-image="${path}" src="recorded/${encodeURIComponent(path)}">`
+                        } else if (path.endsWith(".mp4")){
+                            div.innerHTML += `<video class="refimage" data-version="recorded" data-image="${path}" controls src="recorded/${encodeURIComponent(path)}">`
+                        }
                     }
                 })
 
@@ -147,7 +179,7 @@
             checked = Array.from(document.querySelectorAll(".update-checkbox")).filter(inp => inp.checked)
             n_checked = checked.length
 
-            document.querySelector("#update-counter").innerHTML = `${n_checked} images selected for updating.`
+            document.querySelector("#update-counter").innerHTML = `${n_checked} images selected for updating:`
 
             
             listitems = checked.map(c => {
@@ -156,25 +188,42 @@
             document.querySelector("#update-list").innerHTML = listitems
         }
 
-        fetch('missing_files.txt')
+        fetch('missing_files_grouped.txt')
             .then(response => response.text())
             .then(data => {
                 di = document.querySelector("#missing-images-list")
-                data.split(/\r?\n/).forEach(path => {
-                    if (path == ""){
+                data.split(/\r?\n/).forEach(line => {
+                    if (line == ""){
                         return
                     }
+                    parts = line.split('\t')
                     
-                    div = document.createElement("div")
-                    di.append(div)
-                    div.innerHTML = `
-                    <input type="checkbox" class="delete-checkbox" data-image="${path}"></input>
-                    <span>${path}</span><br>
-                    `
-                    if (path.endsWith(".png")){
-                        div.innerHTML += `<img class="refimage" data-version="reference" data-image="${path}" src="reference/${encodeURIComponent(path)}">`
-                    } else if (path.endsWith(".mp4")){
-                        div.innerHTML += `<video class="refimage" data-version="reference" data-image="${path}" controls src="reference/${encodeURIComponent(path)}">`
+                    // row
+                    row = document.createElement("div") 
+                    di.append(row)
+
+                     // Cells
+                     for (let i = 0; i < 3; i++) {
+                        let path = parts[i]
+
+                        cell = document.createElement("td")
+                        row.append(cell)
+
+                        if (path == "")
+                            continue;
+           
+                        div = document.createElement("div")
+                        cell.append(div)
+                        div.innerHTML = `
+                        <input type="checkbox" class="delete-checkbox" data-image="${path}"></input>
+                        <span>${path}</span>
+                        <br>
+                        `
+                        if (path.endsWith(".png")){
+                            div.innerHTML += `<img class="refimage" data-version="reference" data-image="${path}" src="reference/${encodeURIComponent(path)}">`
+                        } else if (path.endsWith(".mp4")){
+                            div.innerHTML += `<video class="refimage" data-version="reference" data-image="${path}" controls src="reference/${encodeURIComponent(path)}">`
+                        }
                     }
                 })
 
@@ -187,7 +236,7 @@
             checked = Array.from(document.querySelectorAll(".delete-checkbox")).filter(inp => inp.checked)
             n_checked = checked.length
 
-            document.querySelector("#delete-counter").innerHTML = `${n_checked} images selected for removal.`
+            document.querySelector("#delete-counter").innerHTML = `${n_checked} images selected for removal:`
 
             
             listitems = checked.map(c => {

--- a/ReferenceUpdater/src/reference_images.html
+++ b/ReferenceUpdater/src/reference_images.html
@@ -42,6 +42,7 @@
         The selected CI run produced an image for which no reference image exists. 
         Selected images will be added as new reference images.
         <br><br>
+        <input type="checkbox" id='toggle-all-add' onClick="toggle_all(this, '.add-checkbox'); update_list();"></input>Toggle All<br>
         <div id="new-images-list" class="image-list"></div>
 
         <h2>Old reference images without recordings</h2>
@@ -49,6 +50,7 @@
         This implies that a reference test was deleted or renamed. 
         Selected images will be deleted from the reference images.
         <br><br>
+        <input type="checkbox" id='toggle-all-delete' onClick="toggle_all(this, '.delete-checkbox'); delete_list();"></input>Toggle All<br>
         <div id="missing-images-list" class="image-list"></div>
 
         <h2>Images with references</h2>
@@ -158,7 +160,7 @@
                         div = document.createElement("div")
                         cell.append(div)
                         div.innerHTML = `
-                        <input type="checkbox" class="update-checkbox" data-image="${path}"></input>
+                        <input type="checkbox" class="add-checkbox" data-image="${path}"></input>
                         <span>${path}</span>
                         <br>
                         `
@@ -170,18 +172,20 @@
                     }
                 })
 
-                document.querySelectorAll(".update-checkbox").forEach(inp => {
+                document.querySelectorAll(".add-checkbox").forEach(inp => {
                     inp.onclick = update_list
                 })
             })
 
         function update_list(){
-            checked = Array.from(document.querySelectorAll(".update-checkbox")).filter(inp => inp.checked)
+            updated = Array.from(document.querySelectorAll(".update-checkbox")).filter(inp => inp.checked)
+            added = Array.from(document.querySelectorAll(".add-checkbox")).filter(inp => inp.checked)
+            checked = updated.concat(added)
+            
             n_checked = checked.length
 
             document.querySelector("#update-counter").innerHTML = `${n_checked} images selected for updating:`
 
-            
             listitems = checked.map(c => {
                 return `<li>${c.dataset.image}</li>`
             }).join("")
@@ -238,11 +242,19 @@
 
             document.querySelector("#delete-counter").innerHTML = `${n_checked} images selected for removal:`
 
-            
             listitems = checked.map(c => {
                 return `<li>${c.dataset.image}</li>`
             }).join("")
             document.querySelector("#delete-list").innerHTML = listitems
+        }
+
+        function toggle_all(source, group) {
+            console.log(source)
+            console.log(group)
+            
+            checkboxes = document.querySelectorAll(group)
+            console.log(checkboxes)
+            checkboxes.forEach(checkbox => { checkbox.checked = source.checked })
         }
 
         document.querySelector("#update-reference").onclick = function(){
@@ -280,6 +292,8 @@
         }
 
         window.onload = () => {
+            document.querySelector("#toggle-all-add").checked = false;
+            document.querySelector("#toggle-all-delete").checked = false;
             update_list()
             delete_list()
         }

--- a/ReferenceUpdater/src/reference_images.html
+++ b/ReferenceUpdater/src/reference_images.html
@@ -34,9 +34,14 @@
         <h3 id="update-counter"></h3>
         <ul id="update-list">
         </ul>
-        <h2>New images without references</h2>
+        <h3 id="delete-counter"></h3>
+        <ul id="delete-list">
+        </ul>
+        <h2>New images without references (Adding selected)</h2>
         <div id="new-images-list" class="image-list"></div>
-        <h2>Images with references</h2>
+        <h2>Reference images that have no been tested (Deleting selected)</h2>
+        <div id="missing-images-list" class="image-list"></div>
+        <h2>Images with references (Updating selected)</h2>
         <div id="refimage-list" class="image-list"></div>
     </body>
 
@@ -124,7 +129,7 @@
                     di.append(div)
                     div.innerHTML = `
                     <input type="checkbox" class="update-checkbox" data-image="${path}"></input>
-                    <span>${path}</span>
+                    <span>${path}</span><br>
                     `
                     if (path.endsWith(".png")){
                         div.innerHTML += `<img class="refimage" data-version="recorded" data-image="${path}" src="recorded/${encodeURIComponent(path)}">`
@@ -151,13 +156,57 @@
             document.querySelector("#update-list").innerHTML = listitems
         }
 
+        fetch('missing_files.txt')
+            .then(response => response.text())
+            .then(data => {
+                di = document.querySelector("#missing-images-list")
+                data.split(/\r?\n/).forEach(path => {
+                    if (path == ""){
+                        return
+                    }
+                    
+                    div = document.createElement("div")
+                    di.append(div)
+                    div.innerHTML = `
+                    <input type="checkbox" class="delete-checkbox" data-image="${path}"></input>
+                    <span>${path}</span><br>
+                    `
+                    if (path.endsWith(".png")){
+                        div.innerHTML += `<img class="refimage" data-version="reference" data-image="${path}" src="reference/${encodeURIComponent(path)}">`
+                    } else if (path.endsWith(".mp4")){
+                        div.innerHTML += `<video class="refimage" data-version="reference" data-image="${path}" controls src="reference/${encodeURIComponent(path)}">`
+                    }
+                })
+
+                document.querySelectorAll(".delete-checkbox").forEach(inp => {
+                    inp.onclick = delete_list
+                })
+            })
+
+        function delete_list(){
+            checked = Array.from(document.querySelectorAll(".delete-checkbox")).filter(inp => inp.checked)
+            n_checked = checked.length
+
+            document.querySelector("#delete-counter").innerHTML = `${n_checked} images selected for removal.`
+
+            
+            listitems = checked.map(c => {
+                return `<li>${c.dataset.image}</li>`
+            }).join("")
+            document.querySelector("#delete-list").innerHTML = listitems
+        }
+
         document.querySelector("#update-reference").onclick = function(){
 
-            images = Array.from(document.querySelectorAll(".update-checkbox"))
+            images_to_update = Array.from(document.querySelectorAll(".update-checkbox"))
                 .filter(inp => inp.checked)
                 .map(inp => inp.dataset.image)
 
-            if (images.length == 0){
+            images_to_delete = Array.from(document.querySelectorAll(".delete-checkbox"))
+                .filter(inp => inp.checked)
+                .map(inp => inp.dataset.image)
+
+            if (images_to_update.length + images_to_delete.length == 0){
                 alert("No images selected for update.")
                 return
             }
@@ -166,7 +215,8 @@
 
             if (chosen_tag != null){
                 data = {
-                    images: images,
+                    images_to_update: images_to_update,
+                    images_to_delete: images_to_delete,
                     tag: chosen_tag,
                 }
                 fetch(window.location, {
@@ -180,6 +230,9 @@
             }
         }
 
-        window.onload = update_list
+        window.onload = () => {
+            update_list()
+            delete_list()
+        }
     </script>
 </html>

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -35,7 +35,7 @@ edisplay = Bonito.use_electron_display(devtools=true)
     WGLMakie.activate!()
     ReferenceTests.mark_broken_tests(excludes)
     recorded_files, recording_dir = @include_reference_tests WGLMakie "refimages.jl"
-    missing_images, scores = ReferenceTests.record_comparison(recording_dir)
+    missing_images, scores = ReferenceTests.record_comparison(recording_dir, "WGLMakie")
     ReferenceTests.test_comparison(scores; threshold = 0.05)
 end
 


### PR DESCRIPTION
# Description

Changes:
- [x] pick latest CI run if multiple are present (e.g. due to closing and reopening a pr)
- [x] add tab for removing reference images of missing recordings (e.g. to clean up reference images for renamed or deleted tests)
- [x] Use latest reference images when updating, rather than the ones bundled with the CI run. This should prevent reference images from getting overwritten for outdated CI runs. ~~make ReferenceUpdater safe to use from an outdated CI run (currently this uses old reference images from the CI run, rather than the latest uploaded ones.)~~
- [x] use table layout for new (and missing) ref images
- [x] add some documentation to the page
- [x] add a "toggle all" for added and removed refimgs

## Type of change

- tooling
