### PR TITLE
fix: reintroduce vmin, vmax into get_ticks; addresses #4441

### DIFF
--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -628,8 +628,7 @@ get_tickvalues(lt::LinearTicks, vmin, vmax) = locateticks(vmin, vmax, lt.n_ideal
 
 Convert tickvalues to a float array by default.
 """
-get_tickvalues(tickvalues, vmin, vmax) = convert(Vector{Float64}, tickvalues)
-
+get_tickvalues(tickvalues, vmin, vmax) = filter(p -> p >= vmin && p <= vmax, convert(Vector{Float64}, tickvalues))
 
 # function get_tickvalues(l::LogitTicks, vmin, vmax)
 #     ticks_scaled = get_tickvalues(l.linear_ticks, identity, logit_10(vmin), logit_10(vmax))

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -209,6 +209,11 @@ end
         @test get_ticks(numbers, func, xs -> string.(xs) .* "kg", 0, 5) == (numbers, ["1.0kg", "1.5kg", "2.0kg"])
 
         @test get_ticks(WilkinsonTicks(5), identity, automatic, 1, 5) == ([1, 2, 3, 4, 5], ["1", "2", "3", "4", "5"])
+
+        #Check that ticks outside supplied limits are filtered out
+        ticks = [-0.2, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+        limits = (0.0, 0.6)
+        @test get_ticks(ticks, identity, automatic, limits...) == ([0.0, 0.2, 0.4, 0.6], ["0.0", "0.2", "0.4", "0.6"])
     end
 end
 


### PR DESCRIPTION
# Description

Fixes #4441 
get_ticks now filters out values that are below vmin and vmax supplied to it. 

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- added appropriate test.
- other options seemed not relevant.