### PR TITLE
Improvements to relocatability test script

### DIFF
--- a/relocatability.jl
+++ b/relocatability.jl
@@ -41,15 +41,17 @@ using PackageCompiler
 
 create_app(joinpath(pwd(), "MakieApp"), "executable"; force=true, incremental=true, include_transitive_dependencies=false)
 exe = joinpath(pwd(), "executable", "bin", "MakieApp")
-@test success(`$(exe)`)
+# `run` allows to see potential informative printouts, `success` swallows those
+p = run(`$(exe)`)
+@test p.exitcode == 0
 julia_pkg_dir = joinpath(Base.DEPOT_PATH[1], "packages")
 @test isdir(julia_pkg_dir)
 mvd_julia_pkg_dir = julia_pkg_dir * ".old"
-mv(julia_pkg_dir, mvd_julia_pkg_dir)
+mv(julia_pkg_dir, mvd_julia_pkg_dir, force = true)
 # Move package dir so that we can test relocatability (hardcoded paths to package dir being invalid now)
 try
-    mv(julia_pkg_dir, mvd_julia_pkg_dir)
-    @test success(`$(exe)`)
-catch e
+    p2 = run(`$(exe)`)
+    @test p2.exitcode == 0
+finally
     mv(mvd_julia_pkg_dir, julia_pkg_dir)
 end


### PR DESCRIPTION
Allows for better diagnostics when things go wrong as error messages aren't swallowed