### PR TITLE
add kwarg to rotate Toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add kwarg to rotate Toggle [#4445](https://github.com/MakieOrg/Makie.jl/pull/4445)
 - Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).
 - Fix an error in `convert_arguments` for PointBased plots and 3D polygons [#4585](https://github.com/MakieOrg/Makie.jl/pull/4585).
 - Fix polygon rendering issue of `crossbar(..., show_notch = true)` in CairoMakie [#4587](https://github.com/MakieOrg/Makie.jl/pull/4587).

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -490,9 +490,10 @@ end
 
 @reference_test "Toggle" begin
     f = Figure()
-    th = Makie.Toggle(f[1,1])
+    scatter(f[1,1], [1,2,3], axis = (; height=200))
+    th = Makie.Toggle(f[1,2], valign=:top)
     th.orientation[] = pi/2
-    tv = Makie.Toggle(f[2,1], orientation=pi/2)
+    tv = Makie.Toggle(f[1,3], valign=:top, orientation=pi/2)
     tv.orientation[] = 0
     f
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -487,5 +487,11 @@ end
         fontsize =10, textcolor = :red, boxcolor = :lightblue)
     Makie.set!(tb, "some string")
 
+@reference_test "Toggle" begin
+    f = Figure()
+    th = Makie.Toggle(f[1,1])
+    th.orientation[] = pi/2
+    tv = Makie.Toggle(f[2,1], orientation=pi/2)
+    tv.orientation[] = 0
     f
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -489,3 +489,13 @@ end
     Makie.set!(tb, "some string")
     f
 end
+
+@reference_test "Toggle orientation" begin
+    f = Figure()
+    for x=1:3, y=1:3
+        x==y==2 && continue
+        Box(f[x, y], color = :tomato)
+        Toggle(f[x, y], orientation = atan(x-2,2-y))
+    end
+    f
+end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -459,41 +459,33 @@ end
 @reference_test "Button - Slider - Toggle - Textbox" begin
     f = Figure(size = (500, 250))
     Makie.Button(f[1, 1:2])
-    Makie.Button(f[2, 1:2], buttoncolor = :orange, cornerradius = 20, 
+    Makie.Button(f[2, 1:2], buttoncolor = :orange, cornerradius = 20,
         strokecolor = :red, strokewidth = 2, # TODO: allocate space for this
         fontsize = 16, labelcolor = :blue)
 
     IntervalSlider(f[1, 3])
-    sl = IntervalSlider(f[2, 3], range = 0:100, linewidth = 20, 
+    sl = IntervalSlider(f[2, 3], range = 0:100, linewidth = 20,
         color_inactive = :orange, color_active_dimmed = :lightgreen)
     Makie.set_close_to!(sl, 30, 70)
 
     Toggle(f[3, 1])
-    Toggle(f[4, 1], framecolor_inactive = :lightblue, rimfraction = 0.6)
-    Toggle(f[3, 2], active = true)
-    Toggle(f[4, 2], active = true, framecolor_inactive = :lightblue, 
-        framecolor_active = :yellow, rimfraction = 0.6)
+    t = Toggle(f[4, 1], framecolor_inactive = :lightblue, rimfraction = 0.6)
+    t.orientation = 3pi/4
+    Toggle(f[3, 2], active = true, orientation = :horizontal)
+    Toggle(f[4, 2], active = true, framecolor_inactive = :lightblue,
+        framecolor_active = :yellow, rimfraction = 0.6, orientation = :vertical)
 
     Makie.Slider(f[3, 3])
-    sl = Makie.Slider(f[4, 3], range = 0:100, linewidth = 20, color_inactive = :cyan, 
+    sl = Makie.Slider(f[4, 3], range = 0:100, linewidth = 20, color_inactive = :cyan,
         color_active_dimmed = :lightgreen)
     Makie.set_close_to!(sl, 30)
 
     gl = GridLayout(f[5, 1:3])
     Textbox(gl[1, 1])
-    Textbox(gl[1, 2], bordercolor = :red, cornerradius = 0, 
+    Textbox(gl[1, 2], bordercolor = :red, cornerradius = 0,
         placeholder = "test string", fontsize = 16, textcolor_placeholder = :blue)
-    tb = Textbox(gl[1, 3], bordercolor = :black, cornerradius = 20, 
+    tb = Textbox(gl[1, 3], bordercolor = :black, cornerradius = 20,
         fontsize =10, textcolor = :red, boxcolor = :lightblue)
     Makie.set!(tb, "some string")
-end
-
-@reference_test "Toggle" begin
-    f = Figure()
-    scatter(f[1,1], [1,2,3], axis = (; height=200))
-    th = Makie.Toggle(f[1,2], valign=:top)
-    th.orientation[] = pi/2
-    tv = Makie.Toggle(f[1,3], valign=:top, orientation=pi/2)
-    tv.orientation[] = 0
     f
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -486,6 +486,7 @@ end
     tb = Textbox(gl[1, 3], bordercolor = :black, cornerradius = 20, 
         fontsize =10, textcolor = :red, boxcolor = :lightblue)
     Makie.set!(tb, "some string")
+end
 
 @reference_test "Toggle" begin
     f = Figure()

--- a/src/makielayout/blocks/toggle.jl
+++ b/src/makielayout/blocks/toggle.jl
@@ -44,7 +44,8 @@ function initialize_block!(t::Toggle)
     button = scatter!(topscene, buttonpos, markersize = buttonsize,
         color = t.buttoncolor, strokewidth = 0, inspectable = false, marker = Circle)
 
-    onany(topscene, t.orientation, t.layoutobservables.computedbbox) do angle_rad, bbox
+    onany(topscene, t.orientation, t.layoutobservables.computedbbox) do or, bbox
+        angle_rad = or == :horizontal ? 0 : or == :vertical ? pi/2 : or
         center = Vec3f(bbox.origin[1]+bbox.widths[1]/2, bbox.origin[2]+bbox.widths[2]/2, 0)
         R = Makie.rotationmatrix_z(angle_rad)
         T = Makie.translationmatrix(-center)

--- a/src/makielayout/blocks/toggle.jl
+++ b/src/makielayout/blocks/toggle.jl
@@ -44,6 +44,14 @@ function initialize_block!(t::Toggle)
     button = scatter!(topscene, buttonpos, markersize = buttonsize,
         color = t.buttoncolor, strokewidth = 0, inspectable = false, marker = Circle)
 
+    onany(topscene, t.orientation, t.layoutobservables.computedbbox) do angle_rad, bbox
+        center = Vec3f(bbox.origin[1]+bbox.widths[1]/2, bbox.origin[2]+bbox.widths[2]/2, 0)
+        R = Makie.rotationmatrix_z(angle_rad)
+        T = Makie.translationmatrix(-center)
+        Tinv = Makie.translationmatrix(center)
+        topscene.transformation.model[] = Tinv * R * T
+    end
+
     mouseevents = addmouseevents!(topscene, t.layoutobservables.computedbbox)
 
     updatefunc = Ref{Any}(nothing)

--- a/src/makielayout/blocks/toggle.jl
+++ b/src/makielayout/blocks/toggle.jl
@@ -24,7 +24,8 @@ function initialize_block!(t::Toggle)
         costheta, sintheta = cos(theta), sin(theta)
         rotmatrix = GeometryBasics.@SMatrix [costheta -sintheta
                                              sintheta  costheta]
-        Ref(rotmatrix) .* rrv .+ Ref(GeometryBasics.@SVector [left(bbox)+ms/2, bottom(bbox)+ms/2])
+        tranvector = Ref(GeometryBasics.@SVector [left(bbox)+ms/2, bottom(bbox)+ms/2])
+        Ref(rotmatrix) .* rrv .+ tranvector
     end
 
     # trigger bbox

--- a/src/makielayout/blocks/toggle.jl
+++ b/src/makielayout/blocks/toggle.jl
@@ -4,8 +4,9 @@ function initialize_block!(t::Toggle)
 
     onany(topscene, t.orientation, t.length, t.markersize) do or, len, ms
         theta = or == :horizontal ? 0 : or == :vertical ? pi/2 : or
-        t.width[] = (len - ms) * cos(theta) + ms
-        t.height[] = (len - ms)  * sin(theta) + ms
+        autowidth = (len - ms) * cos(theta) + ms
+        autoheight = (len - ms)  * sin(theta) + ms
+        t.layoutobservables.autosize[] = (autowidth, autoheight)
     end
 
     button_endpoint_inactive = lift(topscene, t.markersize, t.layoutobservables.computedbbox) do ms, bbox

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1165,7 +1165,11 @@ Toggle(fig_or_scene; kwargs...)
 
 ```julia
 t_horizontal = Toggle(fig[1, 1])
-t_vertical = Toggle(fig[2, 1], orientation = pi/2)
+t_vertical = Toggle(fig[2, 1], orientation = :vertical)
+t_diagonal = Toggle(fig[3, 1], orientation = pi/4)
+on(t_vertical.active) do switch_is_on
+    switch_is_on ? println("good morning!") : println("good night")
+end
 ```
 
 """

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1206,8 +1206,8 @@ end
         rimfraction = 0.33
         "The align mode of the toggle in its parent GridLayout."
         alignmode = Inside()
-        "The orientation of the toggle (-pi to pi; 0 is horizontal with \"on\" being to the right)."
-        orientation = 0
+        "The orientation of the toggle.  Can be :horizontal, :vertical, or -pi to pi.  0 is horizontal with \"on\" being to the right."
+        orientation = :horizontal
     end
 end
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1179,10 +1179,10 @@ end
         halign = :center
         "The vertical alignment of the toggle in its suggested bounding box."
         valign = :center
-        "The width (ie longitudinal length) of the toggle."
-        width = 32
-        "The height (ie transverse length) of the toggle."
-        height = 18
+        "The width of the bounding box.  Use `length` and `markersize` to set the dimensions of the toggle."
+        width = Auto()
+        "The height of the bounding box.  Use `length` and `markersize` to set the dimensions of the toggle."
+        height = Auto()
         "Controls if the parent layout can adjust to this element's width"
         tellwidth = true
         "Controls if the parent layout can adjust to this element's height"
@@ -1208,6 +1208,10 @@ end
         alignmode = Inside()
         "The orientation of the toggle.  Can be :horizontal, :vertical, or -pi to pi.  0 is horizontal with \"on\" being to the right."
         orientation = :horizontal
+        "The length of the toggle."
+        length = 32
+        "The size of the button."
+        markersize = 18
     end
 end
 

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1152,15 +1152,32 @@ const CHECKMARK_BEZIER = scale(BezierPath(
     end
 end
 
+"""
+A switch with two states.
+
+## Constructors
+
+```julia
+Toggle(fig_or_scene; kwargs...)
+```
+
+## Examples
+
+```julia
+t_horizontal = Toggle(fig[1, 1])
+t_vertical = Toggle(fig[2, 1], orientation = pi/2)
+```
+
+"""
 @Block Toggle begin
     @attributes begin
         "The horizontal alignment of the toggle in its suggested bounding box."
         halign = :center
         "The vertical alignment of the toggle in its suggested bounding box."
         valign = :center
-        "The width of the toggle."
+        "The width (ie longitudinal length) of the toggle."
         width = 32
-        "The height of the toggle."
+        "The height (ie transverse length) of the toggle."
         height = 18
         "Controls if the parent layout can adjust to this element's width"
         tellwidth = true
@@ -1185,6 +1202,8 @@ end
         rimfraction = 0.33
         "The align mode of the toggle in its parent GridLayout."
         alignmode = Inside()
+        "The orientation of the toggle (-pi to pi; 0 is horizontal with \"on\" being to the right)."
+        orientation = 0
     end
 end
 

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -551,5 +551,6 @@ end
 @testset "Toggle" begin
     f = Figure()
     Toggle(f[1,1])
-    Toggle(f[2,1], orientation=pi/2)
+    Toggle(f[2,1], orientation=:vertical)
+    Toggle(f[3,1], orientation=pi/4)
 end

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -547,3 +547,9 @@ end
     end
     @test isempty(limits.listeners)
 end
+
+@testset "Toggle" begin
+    f = Figure()
+    Toggle(f[1,1])
+    Toggle(f[2,1], orientation=pi/2)
+end


### PR DESCRIPTION
# Description

fixes https://github.com/MakieOrg/Makie.jl/issues/4378; supersedes https://github.com/MakieOrg/Makie.jl/pull/4445.

adds `orientation` kwarg to `Toggle` that specifies the angle in radians to rotate the toggle.  default of 0 is horizontal with active being to the right.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
