### PR TITLE
Make textbox accept keypad enter as input confirmation as well.

### DIFF
--- a/src/makielayout/blocks/textbox.jl
+++ b/src/makielayout/blocks/textbox.jl
@@ -238,7 +238,7 @@ function initialize_block!(tbox::Textbox)
                     removechar!(cursorindex[])
                 elseif key == Keyboard.delete
                     removechar!(cursorindex[] + 1)
-                elseif key == Keyboard.enter
+                elseif key == Keyboard.enter || key == Keyboard.kp_enter
                     # don't do anything for invalid input which should stay red
                     if displayed_is_valid[]
                         # submit the written text


### PR DESCRIPTION
I noticed that textbox reacts differently to "enter" that is next to the letters on the keyboard than to "enter" that is on the keypad (number) block. The normal enter serves as input confirmation, while the other one doesn't do anything.

I would have expected them to show the same behavior for the purpose of "confirming input" to the textbox.

This simple PR addresses the issue.