### PR TITLE
Write colorbuffer directly to io if it fits in format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Improved performance of `record` by avoiding unnecessary copying in common cases [#4475](https://github.com/MakieOrg/Makie.jl/pull/4475).
+
 ## [0.21.14] - 2024-10-11
 
 - Fixed relocatability of GLMakie [#4461](https://github.com/MakieOrg/Makie.jl/pull/4461).

--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -286,8 +286,12 @@ function recordframe!(io::VideoStream)
     # Make no copy if already Matrix{RGB{N0f8}}
     # There may be a 1px padding for odd dimensions
     xdim, ydim = size(glnative)
-    copy!(view(io.buffer, 1:xdim, 1:ydim), glnative)
-    write(io.io, io.buffer)
+    if eltype(glnative) == eltype(io.buffer) && size(glnative) == size(io.buffer)
+        write(io.io, glnative)
+    else
+        copy!(view(io.buffer, 1:xdim, 1:ydim), glnative)
+        write(io.io, io.buffer)
+    end
     next_tick!(io.tick_controller)
     return
 end


### PR DESCRIPTION
Noticed with `@profview` that `record` seemed to spend quite a bit of time in a `copy!` call. As this might not be necessary under many circumstances, I've added a branch that avoids `copy!`, leading to a nice speedup of about 20% in this simple example:

```julia
using GLMakie

# before
julia> @time record(lines(cumsum(randn(1000))), "test.mp4", 1:1000, framerate = 60) do i
       end
  6.611545 seconds (1.05 M allocations: 38.077 MiB, 0.24% gc time, 0.28% compilation time)

# after
julia> @time record(lines(cumsum(randn(1000))), "test.mp4", 1:1000, framerate = 60) do i
       end
  5.553962 seconds (1.05 M allocations: 37.878 MiB, 0.33% compilation time)
"test.mp4"
```
