### PR TITLE
Add attributes to the Raincloud definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 - Improved performance of `record` by avoiding unnecessary copying in common cases [#4475](https://github.com/MakieOrg/Makie.jl/pull/4475).
 - Fix usage of `AggMean()` and other aggregations operating on 3d data for `datashader` [#4346](https://github.com/MakieOrg/Makie.jl/pull/4346).
 - Use polys for axis3 [#4463](https://github.com/MakieOrg/Makie.jl/pull/4463).
-- Changed default for `circular_rotation` in Camera3D to false, so that the camera doesn't change rotation direction anymore [4492](https://github.com/MakieOrg/Makie.jl/pull/4492)
+- Changed default for `circular_rotation` in Camera3D to false, so that the camera doesn't change rotation direction anymore [#4492](https://github.com/MakieOrg/Makie.jl/pull/4492)
 - Fixed `pick(scene, rect2)` in WGLMakie [#4488](https://github.com/MakieOrg/Makie.jl/pull/4488)
+- Added the `jitter_width` and `side_nudge` attributes to the `raincloud` plot definition, so that they can be used as kwargs [#4517]https://github.com/MakieOrg/Makie.jl/pull/4517)
 
 ## [0.21.14] - 2024-10-11
 

--- a/src/basic_recipes/raincloud.jl
+++ b/src/basic_recipes/raincloud.jl
@@ -29,12 +29,6 @@ between each.
 
 # Keywords
 
-## Violin/Histogram Plot Specific Keywords
-
-## Scatter Plot Specific Keywords
-- `side_nudge`: Default value is 0.02 if `plot_boxplots` is true, otherwise `0.075` default.
-- `jitter_width=0.05`: Determines the width of the scatter-plot bar in category x-axis
-  absolute terms.
 """
 @recipe RainClouds (category_labels, data_array) begin
     """
@@ -116,6 +110,14 @@ between each.
     If `clouds=hist`, this passes down the number of bins to the histogram call.
     """
     hist_bins = 30
+    """
+    Scatter plot specific.  Default value is 0.02 if `plot_boxplots` is true, otherwise `0.075` default.
+    """
+    side_nudge = automatic
+    """
+     Determines the width of the scatter-plot bar in category x-axis absolute terms.
+    """
+    jitter_width = 0.05
 
     """
     A single color, or a vector of colors, one for each point.
@@ -246,12 +248,11 @@ function plot!(plot::RainClouds)
 
     # Scatter Plot defaults dependent on if there is a boxplot
     side_scatter_nudge_default = plot_boxplots ? 0.2 : 0.075
-    jitter_width_default = 0.05
 
     # Scatter Plot Settings
-    side_scatter_nudge = to_value(get(plot, :side_nudge, side_scatter_nudge_default))
+    side_scatter_nudge = plot.side_nudge[] isa Makie.Automatic ? side_scatter_nudge_default : plot.side_nudge[]
     side_scatter_nudge < 0 && ArgumentError("`side_nudge` should be positive. Change `side` to :left, :right if you wish.")
-    jitter_width = abs(to_value(get(plot, :jitter_width, jitter_width_default)))
+    jitter_width = plot.jitter_width[]
     jitter_width < 0 && ArgumentError("`jitter_width` should be positive.")
     markersize = plot.markersize[]
 


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #3981 

Adds the attributes listed as "custom attributes" to the recipe definition for rainclouds.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
cc @ericphanson
