### PR TITLE
Allow creation of `Legend` with entries that have no legend elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Allowed creation of `Legend` with entries that have no legend elements [#4526](https://github.com/MakieOrg/Makie.jl/pull/4526).
 - Improved CairoMakie's 2D mesh drawing performance by ~30% [#4132](https://github.com/MakieOrg/Makie.jl/pull/4132).
 - Allow `width` to be set per box in `boxplot` [#4447](https://github.com/MakieOrg/Makie.jl/pull/4447).
 - For `Textbox`es in which a fixed width is specified, the text is now scrolled

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -406,9 +406,6 @@ function LegendEntry(label, content, legend; kwargs...)
     else
         elems = legendelements(content, legend)
     end
-    if isempty(elems)
-        error("`legendelements` returned an empty list for content element of type $(typeof(content)). That could mean that neither this object nor any possible child objects had a method for `legendelements` defined that returned a non-empty result.")
-    end
     LegendEntry(elems, attrs)
 end
 

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -476,6 +476,11 @@ end
     @test_nowarn axislegend()
 end
 
+@testset "Legend with empty element" begin
+    f = Figure()
+    @test_nowarn Legend(f[1, 1], [[]], ["No legend elements"])
+end
+
 @testset "ReversibleScale" begin
     @test ReversibleScale(identity).inverse === identity
     @test ReversibleScale(log).inverse === exp


### PR DESCRIPTION
Hit a use case in the wild where the error was pointless as the legend was explicitly constructed this way. In general, I think the utility of the error was pretty low to begin with, so it seems fine to remove it.