### PR TITLE
Custom interactions

### DIFF
--- a/src/interaction/events.jl
+++ b/src/interaction/events.jl
@@ -288,6 +288,7 @@ See also: [`And`](@ref), [`Or`](@ref), [`Not`](@ref), [`Exclusively`](@ref),
 ispressed(events::Events, mb::Mouse.Button, waspressed = nothing) = mb in events.mousebuttonstate || mb == waspressed
 ispressed(events::Events, key::Keyboard.Button, waspressed = nothing) = key in events.keyboardstate || key == waspressed
 ispressed(parent, result::Bool, waspressed = nothing) = result
+ispressed(parent, result::Nothing, waspressed = nothing) = true
 
 ispressed(parent, mb::Mouse.Button, waspressed = nothing) = ispressed(events(parent), mb, waspressed)
 ispressed(parent, key::Keyboard.Button, waspressed = nothing) = ispressed(events(parent), key, waspressed)

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1,3 +1,10 @@
+const DEFAULT_AXIS_INTERACTIONS = Dict(
+    :rectanglezoom => RectangleZoom(),
+    :limitreset => LimitReset(),
+    :scrollzoom => ScrollZoom(0.1, 0.2),
+    :dragpan => DragPan(0.2),
+)
+
 function update_gridlines!(grid_obs::Observable{Vector{Point2f}}, offset::Point2f, tickpositions::Vector{Point2f})
     result = grid_obs[]
     empty!(result) # reuse array for less allocations
@@ -49,13 +56,9 @@ function register_events!(ax, scene)
     onany(process_axis_event, scene, ax, scrollevents)
     onany(process_axis_event, scene, ax, keysevents)
 
-    register_interaction!(ax, :rectanglezoom, RectangleZoom(ax))
-
-    register_interaction!(ax, :limitreset, LimitReset())
-
-    register_interaction!(ax, :scrollzoom, ScrollZoom(0.1, 0.2))
-
-    register_interaction!(ax, :dragpan, DragPan(0.2))
+    for (name, interaction) in DEFAULT_AXIS_INTERACTIONS
+        register_interaction!(ax, name, interaction)
+    end
 
     return
 end

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -1,3 +1,7 @@
+const DEFAULT_AXIS_3D_INTERACTIONS = Dict(
+    :dragrotate => DragRotate(),
+)
+
 struct OrthographicCamera <: AbstractCamera end
 
 function initialize_block!(ax::Axis3)
@@ -158,10 +162,9 @@ function initialize_block!(ax::Axis3)
     on(process_event, scene, ax.scrollevents)
     on(process_event, scene, ax.keysevents)
 
-    register_interaction!(ax,
-        :dragrotate,
-        DragRotate())
-
+    for (name, interaction) in DEFAULT_AXIS_3D_INTERACTIONS
+        register_interaction!(ax, name, interaction)
+    end
 
     # in case the user set limits already
     notify(ax.limits)

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -216,11 +216,11 @@ function positivize(r::Rect2)
     return Rect2(newori, newwidths)
 end
 
-function process_interaction(::LimitReset, event::MouseEvent, ax::Axis)
+function process_interaction(l::LimitReset, event::MouseEvent, ax::Axis)
 
-    if event.type === MouseEventTypes.leftclick
-        if ispressed(ax.scene, Keyboard.left_control)
-            if ispressed(ax.scene, Keyboard.left_shift)
+    if event.type === l.mouseevent
+        if ispressed(ax.scene, l.modifier1)
+            if ispressed(ax.scene, l.modifier2)
                 autolimits!(ax)
             else
                 reset_limits!(ax)

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -54,11 +54,11 @@ function deregister_interaction!(parent, name::Symbol)
 end
 
 function registration_setup!(parent, interaction)
-    # do nothing in the default case
+    return parent # do nothing in the default case
 end
 
 function deregistration_cleanup!(parent, interaction)
-    # do nothing in the default case
+    return parent # do nothing in the default case
 end
 
 """
@@ -177,10 +177,9 @@ function process_interaction(r::RectangleZoom, event::MouseEvent, ax::Axis)
         return Consume(true)
 
     elseif event.type === MouseEventTypes.leftdragstop
-        try
-            r.callback(r.rectnode[])
-        catch e
-            @warn "error in rectangle zoom" exception=(e, Base.catch_backtrace())
+        newlims = r.rectnode[]
+        if !(0 in widths(newlims))
+            ax.targetlimits[] = newlims
         end
         r.active[] = false
         return Consume(true)

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -199,6 +199,12 @@ function process_interaction(r::RectangleZoom, event::KeysEvent, ax::Axis)
     r.restrict_x = Keyboard.y in event.keys
     r.active[] || return Consume(false)
 
+    # Deactivate when modifier is released before the mouse.
+    if r.modifier !== true && r.modifier ∉ event.keys
+        r.active[] = false
+        return Consume(true)
+    end
+
     r.rectnode[] = _chosen_limits(r, ax)
     return Consume(true)
 end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -150,7 +150,19 @@ mutable struct LineAxis
 end
 
 
-struct LimitReset end
+struct LimitReset
+    mouseevent::MouseEventTypes.MouseEventType # e.g. MouseEventTypes.leftclick, or some other mouse event to start limit reset.
+    modifier1::Optional{Keyboard.Button} # e.g. Keyboard.left_control, or some other keyboard button to reset limits.
+    modifier2::Optional{Keyboard.Button} # e.g. Keyboard.left_shift, or some other keyboard button to auto limits.
+
+    function LimitReset(
+        mouseevent = MouseEventTypes.leftclick,
+        modifier1 = Keyboard.left_control,
+        modifier2 = Keyboard.left_shift,
+    )
+        new(mouseevent, modifier1, modifier2)
+    end
+end
 
 mutable struct RectangleZoom
     active::Observable{Bool}


### PR DESCRIPTION
# Description

Partially Fixes #3950

The goal of this PR is to allow users to change default interactions, by modifying a global registry.

- Define a global registry of default interactions for Axis and Axis3D.
- Update `RectangleZoom` to use the registration functions `registration_setup!` and `deregistration_cleanup!`.
- Update `RectangleZoom` deactivate when modifier key (if one is defined) is released before the mouse.
- Allow `LimitReset` to be customizable.

## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
