### PR TITLE
Fix the docs build folder artifact

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -50,4 +50,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Docs build
-        path: ./docs/__site
+        path: ./docs/build


### PR DESCRIPTION
This has been incorrect since the switch to DocumenterVitepress