### PR TITLE
Fix legend for plotlist with multiple plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Added `subsup` and `left_subsup` functions that offer stacked sub- and superscripts for `rich` text which means this style can be used with arbitrary fonts and is not limited to fonts supported by MathTeXEngine.jl [#4489](https://github.com/MakieOrg/Makie.jl/pull/4489).
+- Expand PlotList plots to expose their child plots to the legend interface, allowing `axislegend` to once again show plots within PlotSpecs as individual entries. [#4546](https://github.com/MakieOrg/Makie.jl/pull/4546)
 
 ## [0.21.15] - 2024-10-25
 

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -664,7 +664,8 @@ end
 
 function get_labeled_plots(ax; merge::Bool, unique::Bool)
     lplots = filter(get_plots(ax)) do plot
-        haskey(plot.attributes, :label)
+        haskey(plot.attributes, :label) ||
+        plot isa PlotList && any(x -> haskey(x.attributes, :label), plot.plots)
     end
     labels = map(lplots) do l
         l.label[]
@@ -716,6 +717,11 @@ function get_labeled_plots(ax; merge::Bool, unique::Bool)
 end
 
 get_plots(p::AbstractPlot) = [p]
+# NOTE: this is important, since we know that `get_plots` is only ever called on the toplevel, 
+# we can assume that any plotlist on the toplevel should be decomposed into individual plots.
+# However, if the user passes a label argument with a legend override, what do we do?
+get_plots(p::PlotList) = haskey(p.attributes, :label) && p.attributes[:label] isa Pair ? [p] : p.plots
+
 get_plots(ax::Union{Axis, Axis3}) = get_plots(ax.scene)
 get_plots(lscene::LScene) = get_plots(lscene.scene)
 function get_plots(scene::Scene)

--- a/test/specapi.jl
+++ b/test/specapi.jl
@@ -170,3 +170,20 @@ end
     @test isempty(f.content)
     @test isempty(f.layout.content)
 end
+
+@testset "Legend construction" begin
+    f, ax, pl = plotlist([S.Scatter(1:4, 1:4; marker = :circle, label="A"), S.Scatter(1:6, 1:6; marker = :rect, label="B")])
+    leg = axislegend(ax)
+    # Test that the legend has two scatter plots
+    @test count(x -> x isa Makie.Scatter, leg.scene.plots) == 2
+
+    # Test that the scatter plots have the correct markers
+    # This is too internal and fragile, so we won't actually test this
+    # @test leg.scene.plots[2].marker[] == :circle
+    # @test leg.scene.plots[3].marker[] == :rect
+    
+    # Test that the legend has the correct labels.
+    # Again, I consider this too fragile to work with!
+    # @test contents(contents(leg.grid)[1])[2].text[] == "A"
+    # @test contents(contents(leg.grid)[2])[4].text[] == "B"
+end


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

PlotLists with multiple subsidiary plots weren't getting decomposed to their individual plots in `get_plots`, this fixes that.

Fixes https://github.com/SciML/SciMLBase.jl/issues/833

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [X] Added unit tests for new algorithms, conversion methods, etc.
