### PR TITLE
speed up apply_theme

### DIFF
--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -426,16 +426,15 @@ end
 
 function default_theme(scene, T::Type{<: Plot})
     metas = documented_attributes(T)
-    attr = Attributes()
+    attr = Dict{Symbol, Any}()
     isnothing(metas) && return attr
     thm = theme(scene)
-    _attr = attr.attributes
     for (k, meta) in metas.d
-        _attr[k] = lookup_default(meta, thm)
+        attr[k] = lookup_default(meta, thm)
     end
     return attr
 end
-      
+
 function extract_docstring(str)
     if VERSION >= v"1.11" && str isa Base.Docs.DocStr
         return only(str.text::Core.SimpleVector)

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -429,5 +429,5 @@ function apply_theme!(scene::Scene, plot::P) where {P<: Plot}
             raw_attr[k] = convert(Observable{Any}, v)
         end
     end
-    return merge!(plot.attributes, plot_theme)
+    return merge_without_obs!(plot.attributes, plot_theme)
 end

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -149,7 +149,7 @@ const CURRENT_DEFAULT_THEME = deepcopy(MAKIE_DEFAULT_THEME)
 const THEME_LOCK = Base.ReentrantLock()
 
 # Basically like deepcopy but while merging it into another Attribute dict
-function merge_without_obs!(result::Attributes, theme::Attributes)
+function merge_without_obs!(result::Attributes, theme)
     dict = attributes(result)
     for (key, value) in theme
         if !haskey(dict, key)


### PR DESCRIPTION
After [#S.Colorbar](https://github.com/MakieOrg/Makie.jl/pull/4520) sped up default_theme, we can save a bit more time by not creating attributes.
May be slightly breaking and could go into https://github.com/MakieOrg/Makie.jl/pull/4550