### PR TITLE
add backend and update_state kwargs to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added `backend` kwarg to `show` [#4558](https://github.com/MakieOrg/Makie.jl/pull/4558)
 - Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).
 - Fix an error in `convert_arguments` for PointBased plots and 3D polygons [#4585](https://github.com/MakieOrg/Makie.jl/pull/4585).
 - Fix polygon rendering issue of `crossbar(..., show_notch = true)` in CairoMakie [#4587](https://github.com/MakieOrg/Makie.jl/pull/4587).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added `backend` kwarg to `show` [#4558](https://github.com/MakieOrg/Makie.jl/pull/4558)
+- Added `backend` and `update_state` kwargs to `show` [#4558](https://github.com/MakieOrg/Makie.jl/pull/4558)
 - Fix uint16 overflow for over ~65k elements in WGLMakie picking [#4604](https://github.com/MakieOrg/Makie.jl/pull/4604).
 - Improve performance for line plot in CairoMakie [#4601](https://github.com/MakieOrg/Makie.jl/pull/4601).
 - Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added `backend` and `update_state` kwargs to `show` [#4558](https://github.com/MakieOrg/Makie.jl/pull/4558)
+- Added `backend` and `update` kwargs to `show` [#4558](https://github.com/MakieOrg/Makie.jl/pull/4558)
 - Fix uint16 overflow for over ~65k elements in WGLMakie picking [#4604](https://github.com/MakieOrg/Makie.jl/pull/4604).
 - Improve performance for line plot in CairoMakie [#4601](https://github.com/MakieOrg/Makie.jl/pull/4601).
 - Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).

--- a/src/display.jl
+++ b/src/display.jl
@@ -244,7 +244,7 @@ function Base.show(io::IO, m::MIME"text/markdown", fig::FigureLike)
     throw(MethodError(show, io, m, fig))
 end
 
-function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backend(), update_state=true)
+function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backend(), update=true)
     if ALWAYS_INLINE_PLOTS[] == false && m isa MIME_TO_TRICK_VSCODE
         # We use this mime to display the figure in a window here.
         # See declaration of MIME_TO_TRICK_VSCODE for more info
@@ -253,7 +253,7 @@ function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backe
     end
     scene = get_scene(figlike)
     # get current screen the scene is already displayed on, or create a new screen
-    update_state && update_state_before_display!(figlike)
+    update && update_state_before_display!(figlike)
     screen = getscreen(backend, scene, Dict(:visible=>false), io, m)
     backend_show(screen, io, m, scene)
     return screen

--- a/src/display.jl
+++ b/src/display.jl
@@ -244,7 +244,7 @@ function Base.show(io::IO, m::MIME"text/markdown", fig::FigureLike)
     throw(MethodError(show, io, m, fig))
 end
 
-function Base.show(io::IO, m::MIME, figlike::FigureLike)
+function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backend())
     if ALWAYS_INLINE_PLOTS[] == false && m isa MIME_TO_TRICK_VSCODE
         # We use this mime to display the figure in a window here.
         # See declaration of MIME_TO_TRICK_VSCODE for more info
@@ -252,7 +252,6 @@ function Base.show(io::IO, m::MIME, figlike::FigureLike)
         return () # this is a diagnostic vscode mime, so we can just return nothing
     end
     scene = get_scene(figlike)
-    backend = current_backend()
     # get current screen the scene is already displayed on, or create a new screen
     update_state_before_display!(figlike)
     screen = getscreen(backend, scene, Dict(:visible=>false), io, m)

--- a/src/display.jl
+++ b/src/display.jl
@@ -244,7 +244,7 @@ function Base.show(io::IO, m::MIME"text/markdown", fig::FigureLike)
     throw(MethodError(show, io, m, fig))
 end
 
-function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backend())
+function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backend(), update_state=true)
     if ALWAYS_INLINE_PLOTS[] == false && m isa MIME_TO_TRICK_VSCODE
         # We use this mime to display the figure in a window here.
         # See declaration of MIME_TO_TRICK_VSCODE for more info
@@ -253,7 +253,7 @@ function Base.show(io::IO, m::MIME, figlike::FigureLike; backend = current_backe
     end
     scene = get_scene(figlike)
     # get current screen the scene is already displayed on, or create a new screen
-    update_state_before_display!(figlike)
+    update_state && update_state_before_display!(figlike)
     screen = getscreen(backend, scene, Dict(:visible=>false), io, m)
     backend_show(screen, io, m, scene)
     return screen

--- a/test/figures.jl
+++ b/test/figures.jl
@@ -175,6 +175,6 @@ end
 @testset "show with a backend" begin
     fig = Figure()
     io = IOBuffer()
-    # if there were no show method with backend and update_state kwargs then MethodError would be thrown instead
-    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing, update_state=missing)
+    # if there were no show method with backend and update kwargs then MethodError would be thrown instead
+    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing, update=missing)
 end

--- a/test/figures.jl
+++ b/test/figures.jl
@@ -171,3 +171,10 @@ end
     @test_throws ArgumentError lines(f[1, 1], 1:10, axis = (aspect = DataAspect()))
     @test_throws ArgumentError lines(f[1, 1][2, 2], 1:10, axis = (aspect = DataAspect()))
 end
+
+@testset "show with a backend" begin
+    fig = Figure()
+    io = IOBuffer()
+    # if there were no show method with a backend kwarg then MethodError would be thrown instead
+    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing)
+end

--- a/test/figures.jl
+++ b/test/figures.jl
@@ -175,6 +175,6 @@ end
 @testset "show with a backend" begin
     fig = Figure()
     io = IOBuffer()
-    # if there were no show method with a backend kwarg then MethodError would be thrown instead
-    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing)
+    # if there were no show method with backend and update_state kwargs then MethodError would be thrown instead
+    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing, update_state=missing)
 end

--- a/test/figures.jl
+++ b/test/figures.jl
@@ -176,5 +176,5 @@ end
     fig = Figure()
     io = IOBuffer()
     # if there were no show method with backend and update kwargs then MethodError would be thrown instead
-    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing, update=missing)
+    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend=missing, update=false)
 end


### PR DESCRIPTION
as [discussed](https://discourse.julialang.org/t/correct-way-to-save-makie-plot-to-iobuffer/87793) `show` is the way to "save" a figure to an IOBuffer.  but if the figure was made with say WGLMakie and you want to save as say PDF then it's a bit cumbersome because you have to `CairoMakie.activate!` and then `WGLMakie.activate!` after `show`ing.  this PR make it more concise by adding a `backend` kwarg to `show`, just like `save` has one already.  so one can simply `show(...; backend=CairoMakie)` instead of activating and deactivating it.
 
## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.
