### PR TITLE
fix: correctly render the tooltip triangle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Correctly render the tooltip triangle [#4560](https://github.com/MakieOrg/Makie.jl/pull/4560).
 - Added `subsup` and `left_subsup` functions that offer stacked sub- and superscripts for `rich` text which means this style can be used with arbitrary fonts and is not limited to fonts supported by MathTeXEngine.jl [#4489](https://github.com/MakieOrg/Makie.jl/pull/4489).
 - Added the `jitter_width` and `side_nudge` attributes to the `raincloud` plot definition, so that they can be used as kwargs [#4517]https://github.com/MakieOrg/Makie.jl/pull/4517)
 - Expand PlotList plots to expose their child plots to the legend interface, allowing `axislegend`show plots within PlotSpecs as individual entries. [#4546](https://github.com/MakieOrg/Makie.jl/pull/4546)

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -707,10 +707,10 @@ end
         strokewidth = 2f0, strokecolor = :cyan
     )
     # Test depth (this part is expected to fail in CairoMakie)
-    p = tooltip!(ax, -5, -1, "test line\ntest line", backgroundcolor = :lightblue)
+    p = tooltip!(ax, -5, -4, "test line\ntest line", backgroundcolor = :lightblue)
     translate!(p, 0, 0, 100)
     mesh!(ax, 
-        Point3f.([-7, -7, -3, -3], [-1, 1, -1, 1], [99, 99, 101, 101]), [1 2 3; 2 3 4], 
+        Point3f.([-7, -7, -3, -3], [-4, -2, -4, -2], [99, 99, 101, 101]), [1 2 3; 2 3 4], 
         shading = NoShading, color = :orange)
     fig
 end

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -706,6 +706,12 @@ end
         outline_linewidth = 5, offset = 30, triangle_size = 15,
         strokewidth = 2f0, strokecolor = :cyan
     )
+    # Test depth (this part is expected to fail in CairoMakie)
+    p = tooltip!(ax, -5, -1, "test line\ntest line", backgroundcolor = :lightblue)
+    translate!(p, 0, 0, 100)
+    mesh!(ax, 
+        Point3f.([-7, -7, -3, -3], [-1, 1, -1, 1], [99, 99, 101, 101]), [1 2 3; 2 3 4], 
+        shading = NoShading, color = :orange)
     fig
 end
 

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -173,16 +173,16 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         scale!(mp, s, s, s)
 
         if placement === :left
-            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + w[1] - 0.5s, o[2] + align * w[2], o[3]))
             rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
         elseif placement === :right
-            translate!(mp, Vec3f(o[1], o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + 0.5s, o[2] + align * w[2], o[3]))
             rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
         elseif placement in (:below, :down, :bottom)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2] - 0.5s, o[3]))
             rotate!(mp, Quaternionf(0,0,1,0)) # pi
         elseif placement in (:above, :up, :top)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + 0.5s, o[3]))
             rotate!(mp, Quaternionf(0,0,0,1)) # 0
         else
             @error "Tooltip placement $placement invalid. Assuming :above"

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -173,20 +173,20 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         scale!(mp, s, s, s)
 
         if placement === :left
-            translate!(mp, Vec3f(o[1] + w[1] - 0.25s, o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], 1))
             rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
         elseif placement === :right
-            translate!(mp, Vec3f(o[1] + 0.25s, o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1], o[2] + align * w[2], 1))
             rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
         elseif placement in (:below, :down, :bottom)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2] - 0.25s, o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], 1))
             rotate!(mp, Quaternionf(0,0,1,0)) # pi
         elseif placement in (:above, :up, :top)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + 0.25s, o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2], 1))
             rotate!(mp, Quaternionf(0,0,0,1)) # 0
         else
             @error "Tooltip placement $placement invalid. Assuming :above"
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2], 1))
             rotate!(mp, Quaternionf(0,0,0,1))
         end
         return

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -133,7 +133,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         overdraw = p.overdraw, depth_shift = p.depth_shift,
         inspectable = p.inspectable, space = :pixel, transformation = Transformation()
     )
-    translate!(tp, 0, 0, 1)
+    translate!(tp, 0, 0, 0.01) # must be larger than eps(1f4) to prevent float precision issues
 
     # TODO react to glyphcollection instead
     bbox = map(
@@ -156,41 +156,50 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
 
     # Triangle mesh
 
-    triangle = GeometryBasics.Mesh(
-        Point2f[(-0.5, 0), (0.5, 0), (0, -1)],
-        GLTriangleFace[(1,2,3)]
-    )
+    tri_points = map(p, bbox, p.triangle_size, p.placement, p.align) do bb, s, placement, align
+        l, b, z = origin(bb); w, h, _ = widths(bb)
+        r, t = (l, b) .+ (w, h)
+        if placement === :left
+            return Point3f[
+                (r,     b + align * h + 0.5s, z),
+                (r + s, b + align * h,        z),
+                (r,     b + align * h - 0.5s, z),
+            ]
+        elseif placement === :right
+            return Point3f[
+                (l,   b + align * h - 0.5s, z),
+                (l-s, b + align * h,        z),
+                (l,   b + align * h + 0.5s, z),
+            ]
+        elseif placement in (:below, :down, :bottom)
+            return Point3f[
+                (l + align * w - 0.5s, t,   z),
+                (l + align * w,        t+s, z),
+                (l + align * w + 0.5s, t,   z),
+            ]
+        elseif placement in (:above, :up, :top)
+            return Point3f[
+                (l + align * w + 0.5s, b,   z),
+                (l + align * w,        b-s, z),
+                (l + align * w - 0.5s, b,   z),
+            ]
+        else
+            @error "Tooltip placement $placement invalid. Assuming :above"
+            return Point3f[
+                (l + align * w + 0.5s, b,   z),
+                (l + align * w,        b-s, z),
+                (l + align * w - 0.5s, b,   z),
+            ]
+        end
+    end
 
-    mp = mesh!(
-        p, triangle, shading = NoShading, space = :pixel,
-        color = p.backgroundcolor,
+    mesh!(
+        p, tri_points, [1 2 3], shading = NoShading, space = :pixel,
+        color = p.backgroundcolor, fxaa = false, 
         transparency = p.transparency, visible = p.visible,
         overdraw = p.overdraw, depth_shift = p.depth_shift,
         inspectable = p.inspectable, transformation = Transformation()
     )
-    onany(p, bbox, p.triangle_size, p.placement, p.align) do bb, s, placement, align
-        o = origin(bb); w = widths(bb)
-        scale!(mp, s, s, s)
-
-        if placement === :left
-            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], o[3]))
-            rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
-        elseif placement === :right
-            translate!(mp, Vec3f(o[1], o[2] + align * w[2], o[3]))
-            rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
-        elseif placement in (:below, :down, :bottom)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], o[3]))
-            rotate!(mp, Quaternionf(0,0,1,0)) # pi
-        elseif placement in (:above, :up, :top)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
-            rotate!(mp, Quaternionf(0,0,0,1)) # 0
-        else
-            @error "Tooltip placement $placement invalid. Assuming :above"
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
-            rotate!(mp, Quaternionf(0,0,0,1))
-        end
-        return
-    end
 
     # Outline
 
@@ -247,10 +256,10 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
             ]
         end
 
-        return to_ndim.(Vec3f, shift, z + 1.0f0)
+        return to_ndim.(Vec3f, shift, z)
     end
 
-    lines!(
+    lp = lines!(
         p, outline,
         color = p.outline_color, space = :pixel, miter_limit = pi/18,
         linewidth = p.outline_linewidth, linestyle = p.outline_linestyle,
@@ -258,6 +267,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         overdraw = p.overdraw, depth_shift = p.depth_shift,
         inspectable = p.inspectable, transformation = Transformation()
     )
+    translate!(lp, 0, 0, 0.01)
 
     notify(p[1])
 

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -173,16 +173,16 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         scale!(mp, s, s, s)
 
         if placement === :left
-            translate!(mp, Vec3f(o[1] + w[1] - 0.5s, o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + w[1] - 0.25s, o[2] + align * w[2], o[3]))
             rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
         elseif placement === :right
-            translate!(mp, Vec3f(o[1] + 0.5s, o[2] + align * w[2], o[3]))
+            translate!(mp, Vec3f(o[1] + 0.25s, o[2] + align * w[2], o[3]))
             rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
         elseif placement in (:below, :down, :bottom)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2] - 0.5s, o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2] - 0.25s, o[3]))
             rotate!(mp, Quaternionf(0,0,1,0)) # pi
         elseif placement in (:above, :up, :top)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + 0.5s, o[3]))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + 0.25s, o[3]))
             rotate!(mp, Quaternionf(0,0,0,1)) # 0
         else
             @error "Tooltip placement $placement invalid. Assuming :above"

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -139,7 +139,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
     bbox = map(
             p, px_pos, p.text, text_align, text_offset, textpadding, p.align
         ) do p, s, _, o, pad, align
-        bb = boundingbox(tp, :pixel) + to_ndim(Vec3f, o, 0)
+        bb = string_boundingbox(tp) + to_ndim(Vec3f, o, 0)
         l, r, b, t = pad
         return Rect3f(origin(bb) .- (l, b, 0), widths(bb) .+ (l+r, b+t, 0))
     end

--- a/src/basic_recipes/tooltip.jl
+++ b/src/basic_recipes/tooltip.jl
@@ -173,20 +173,20 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
         scale!(mp, s, s, s)
 
         if placement === :left
-            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], 1))
+            translate!(mp, Vec3f(o[1] + w[1], o[2] + align * w[2], o[3]))
             rotate!(mp, qrotation(Vec3f(0,0,1), 0.5pi))
         elseif placement === :right
-            translate!(mp, Vec3f(o[1], o[2] + align * w[2], 1))
+            translate!(mp, Vec3f(o[1], o[2] + align * w[2], o[3]))
             rotate!(mp, qrotation(Vec3f(0,0,1), -0.5pi))
         elseif placement in (:below, :down, :bottom)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], 1))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2] + w[2], o[3]))
             rotate!(mp, Quaternionf(0,0,1,0)) # pi
         elseif placement in (:above, :up, :top)
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], 1))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
             rotate!(mp, Quaternionf(0,0,0,1)) # 0
         else
             @error "Tooltip placement $placement invalid. Assuming :above"
-            translate!(mp, Vec3f(o[1] + align * w[1], o[2], 1))
+            translate!(mp, Vec3f(o[1] + align * w[1], o[2], o[3]))
             rotate!(mp, Quaternionf(0,0,0,1))
         end
         return
@@ -247,7 +247,7 @@ function plot!(p::Tooltip{<:Tuple{<:VecTypes}})
             ]
         end
 
-        return to_ndim.(Vec3f, shift, z)
+        return to_ndim.(Vec3f, shift, z + 1.0f0)
     end
 
     lines!(


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes tooltip triangle rendering.

Before this PR:
<img width="111" alt="before" src="https://github.com/user-attachments/assets/fab6e2a2-e2c0-494a-bde6-7e0b129fb068">

After this PR:
<img width="111" alt="after" src="https://github.com/user-attachments/assets/571b2031-318e-4c5f-9e32-651f3b30d36f">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
