### PR TITLE
Make all backends support Screen() constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added empty constructor to all backends for `Screen` allowing `display(Makie.current_backend().Screen(), fig)` [#4561](https://github.com/MakieOrg/Makie.jl/pull/4561).
 - Added `subsup` and `left_subsup` functions that offer stacked sub- and superscripts for `rich` text which means this style can be used with arbitrary fonts and is not limited to fonts supported by MathTeXEngine.jl [#4489](https://github.com/MakieOrg/Makie.jl/pull/4489).
 - Added the `jitter_width` and `side_nudge` attributes to the `raincloud` plot definition, so that they can be used as kwargs [#4517]https://github.com/MakieOrg/Makie.jl/pull/4517)
 - Expand PlotList plots to expose their child plots to the legend interface, allowing `axislegend`show plots within PlotSpecs as individual entries. [#4546](https://github.com/MakieOrg/Makie.jl/pull/4546)

--- a/CairoMakie/src/display.jl
+++ b/CairoMakie/src/display.jl
@@ -37,7 +37,9 @@ function Base.display(screen::Screen, scene::Scene; connect=false)
     return screen
 end
 
-function Base.display(screen::Screen{IMAGE}, scene::Scene; connect=false)
+function Base.display(screen::Screen{IMAGE}, scene::Scene; connect=false, screen_config...)
+    config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol,Any}(screen_config))
+    screen = Makie.apply_screen_config!(screen, config, scene)
     path = joinpath(mktempdir(), "display.png")
     Makie.push_screen!(scene, screen)
     cairo_draw(screen, scene)
@@ -80,7 +82,7 @@ function Makie.backend_show(screen::Screen{SVG}, io::IO, ::MIME"image/svg+xml", 
     # xlink:href="someid" (but not xlink:href="data:someothercontent" which is how image data is attached)
     # url(#someid)
     svg = replace(svg, r"((?:(?:id|xlink:href)=\"(?!data:)[^\"]+)|url\(#[^)]+)" => SubstitutionString("\\1-$salt"))
-    
+
     print(io, svg)
     return screen
 end

--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -175,6 +175,31 @@ mutable struct Screen{SurfaceRenderType} <: Makie.MakieScreen
     antialias::Int # cairo_antialias_t
     visible::Bool
     config::ScreenConfig
+
+    function Screen()
+        return new{IMAGE}()
+    end
+    function Screen{SurfaceRenderType}(
+            scene::Scene,
+            surface::Cairo.CairoSurface,
+            context::Cairo.CairoContext,
+            device_scaling_factor::Float64,
+            antialias::Int,
+            visible::Bool,
+            config::ScreenConfig
+        ) where {SurfaceRenderType}
+
+        return new{SurfaceRenderType}(
+            scene,
+            surface,
+            context,
+            device_scaling_factor,
+            antialias,
+            visible,
+            config,
+        )
+    end
+
 end
 
 function Base.empty!(screen::Screen)
@@ -192,6 +217,7 @@ end
 Base.close(screen::Screen) = empty!(screen)
 
 function destroy!(screen::Screen)
+    isdefined(screen, :surface) || return
     Cairo.destroy(screen.surface)
     Cairo.destroy(screen.context)
 end
@@ -200,7 +226,10 @@ function Base.isopen(screen::Screen)
     return !(screen.surface.ptr == C_NULL || screen.context.ptr == C_NULL)
 end
 
-Base.size(screen::Screen) = round.(Int, (screen.surface.width, screen.surface.height))
+function Base.size(screen::Screen)
+    isdefined(screen, :surface) || return (0, 0)
+    round.(Int, (screen.surface.width, screen.surface.height))
+end
 # we render the scene directly, since we have
 # no screen dependent state like in e.g. opengl
 Base.insert!(screen::Screen, scene::Scene, plot) = nothing
@@ -267,6 +296,7 @@ function Makie.apply_screen_config!(
         destroy!(old_screen)
     end
     apply_config!(screen, config)
+    screen.scene = scene
     return screen
 end
 
@@ -274,6 +304,7 @@ function Makie.apply_screen_config!(screen::Screen, config::ScreenConfig, scene:
     # No mime as an argument implies we want an image based surface
     Makie.apply_screen_config!(screen, config, scene, nothing, MIME"image/png"())
 end
+
 
 function Screen(scene::Scene; screen_config...)
     config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol, Any}(screen_config))

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -66,6 +66,12 @@ mutable struct Screen <: Makie.MakieScreen
     end
 end
 
+function Screen(; config...)
+    config = Makie.merge_screen_config(ScreenConfig, Dict{Symbol,Any}(config))
+    return Screen(nothing, config)
+end
+
+
 function scene_already_displayed(screen::Screen, scene=screen.scene)
     scene === nothing && return false
     screen.scene === scene || return false


### PR DESCRIPTION
so one can write:
```julia
display(Makie.current_backend().Screen(), fig)
```