### PR TITLE
IOCapture VideoStream hang fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added `subsup` and `left_subsup` functions that offer stacked sub- and superscripts for `rich` text which means this style can be used with arbitrary fonts and is not limited to fonts supported by MathTeXEngine.jl [#4489](https://github.com/MakieOrg/Makie.jl/pull/4489).
 - Expand PlotList plots to expose their child plots to the legend interface, allowing `axislegend`show plots within PlotSpecs as individual entries. [#4546](https://github.com/MakieOrg/Makie.jl/pull/4546)
 - Implement S.Colorbar(plotspec) [#4520](https://github.com/MakieOrg/Makie.jl/pull/4520).
+- Fixed a hang when `Record` was created inside a closure passed to `IOCapture.capture` [#4562](https://github.com/MakieOrg/Makie.jl/pull/4562).
 
 ## [0.21.15] - 2024-10-25
 

--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -266,7 +266,9 @@ function VideoStream(fig::FigureLike;
     buffer = Matrix{RGB{N0f8}}(undef, xdim, ydim)
     vso = VideoStreamOptions(format, framerate, compression, profile, pixel_format, loop, loglevel, "pipe:0", true)
     cmd = to_ffmpeg_cmd(vso, xdim, ydim)
-    process = open(`$(FFMPEG_jll.ffmpeg()) $cmd $path`, "w")
+    # a plain `open` without the `pipeline` causes hangs when IOCapture.capture closes over a function that creates
+    # a `VideoStream` without closing the process explicitly, such as when returning `Record` in a cell in Documenter or quarto
+    process = open(pipeline(`$(FFMPEG_jll.ffmpeg()) $cmd $path`; stdout = devnull, stderr = devnull), "w")
     tick_controller = TickController(fig, 1.0 / vso.framerate, filter_ticks)
     result = VideoStream(process.in, process, screen, tick_controller, buffer, abspath(path), vso)
     finalizer(result) do x

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,7 @@
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/record.jl
+++ b/test/record.jl
@@ -1,4 +1,5 @@
 using Logging
+using IOCapture: IOCapture
 
 module VideoBackend
     using Makie
@@ -78,3 +79,10 @@ mktempdir() do tempdir
     end
 end
 Makie.set_active_backend!(missing)
+
+@testset "No hang when closing IOCapture.capture over VideoStream" begin
+    @test_nowarn IOCapture.capture() do
+        f = Figure()
+        Makie.VideoStream(f)
+    end
+end

--- a/test/record.jl
+++ b/test/record.jl
@@ -78,7 +78,6 @@ mktempdir() do tempdir
         end
     end
 end
-Makie.set_active_backend!(missing)
 
 @testset "No hang when closing IOCapture.capture over VideoStream" begin
     @test_nowarn IOCapture.capture() do
@@ -86,3 +85,5 @@ Makie.set_active_backend!(missing)
         Makie.VideoStream(f)
     end
 end
+
+Makie.set_active_backend!(missing)


### PR DESCRIPTION
The trigger for this fix was https://github.com/quarto-dev/quarto-cli/issues/11248. After excluding QuartoNotebookRunner as the culprit I could simplify that MWE down to:

```julia
IOCapture.capture() do
    f = Figure()
    Makie.VideoStream(f)
end
```

or even more simplified

```julia
IOCapture.capture() do
    cmd = `$(FFMPEG_jll.ffmpeg()) -y -f rawvideo -i pipe:0`
    open(cmd, "w")
end
```

The problem is that when a user creates or returns a `Record` (which uses `VideoStream`) in a cell, the open pipes of the process we create cause this interaction problem. The simplest fix to me seemed to be to wrap in `pipeline` and explicitly pipe outputs into `devnull`. I can't say I 100% understand the fix as `open(cmd, string)` is documented to also set `stdio` to `devnull` but anyway, this should work for users.

The test I added hangs indefinitely without the fix.

A similar issue is https://github.com/JuliaDocs/IOCapture.jl/issues/17