### PR TITLE
Introduce isclosed(scene), conditionally use `Bonito.LargeUpdate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Introduce `isclosed(scene)`, conditionally use `Bonito.LargeUpdate` [#4569](https://github.com/MakieOrg/Makie.jl/pull/4569).
 - Allow plots to move between scenes in SpecApi [#4132](https://github.com/MakieOrg/Makie.jl/pull/4132).
 - Added empty constructor to all backends for `Screen` allowing `display(Makie.current_backend().Screen(), fig)` [#4561](https://github.com/MakieOrg/Makie.jl/pull/4561).
 - Added `subsup` and `left_subsup` functions that offer stacked sub- and superscripts for `rich` text which means this style can be used with arbitrary fonts and is not limited to fonts supported by MathTeXEngine.jl [#4489](https://github.com/MakieOrg/Makie.jl/pull/4489).

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -89,6 +89,9 @@ end
         # assure we correctly close screen and remove it from plot
         @test getscreen(ax.scene) === nothing
         @test !events(ax.scene).window_open[]
+        # Because of on(scene.events.window_open) in scene, we need to free all scenes first
+        # to have 0 listeners
+        empty!(fig)
         @test isempty(events(ax.scene).window_open.listeners)
 
         # Test singleton screen replacement

--- a/WGLMakie/Project.toml
+++ b/WGLMakie/Project.toml
@@ -20,7 +20,7 @@ ShaderAbstractions = "65257c39-d410-5151-9873-9b3e5be5013e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bonito = "3.2.4"
+Bonito = "3.2.4, 4"
 Colors = "0.11, 0.12, 0.13"
 FileIO = "1.1"
 FreeTypeAbstraction = "0.10"

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -227,7 +227,8 @@ function uniform_updater(@nospecialize(plot), uniforms::Dict)
         if value isa Sampler
             on(plot, ShaderAbstractions.updater(value).update) do (f, args)
                 if f === ShaderAbstractions.update!
-                    updater[] = Bonito.LargeUpdate([name, [Int32[size(value.data)...], serialize_three(args[1])]])
+                    update = [name, [Int32[size(value.data)...], serialize_three(args[1])]]
+                    updater[] = isdefined(Bonito, :LargeUpdate) ? Bonito.LargeUpdate(update) : update
                 end
                 return
             end

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -222,12 +222,12 @@ function register_geometry_updates(@nospecialize(plot), update_buffer::Observabl
 end
 
 function uniform_updater(@nospecialize(plot), uniforms::Dict)
-    updater = Observable(Any[:none, []])
+    updater = Observable{Any}(Any[:none, []])
     for (name, value) in uniforms
         if value isa Sampler
             on(plot, ShaderAbstractions.updater(value).update) do (f, args)
                 if f === ShaderAbstractions.update!
-                    updater[] = [name, [Int32[size(value.data)...], serialize_three(args[1])]]
+                    updater[] = Bonito.LargeUpdate([name, [Int32[size(value.data)...], serialize_three(args[1])]])
                 end
                 return
             end

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -93,6 +93,7 @@ mutable struct Scene <: AbstractScene
     cycler::Cycler
 
     conversions::DimConversions
+    isclosed::Bool
 
     function Scene(
             parent::Union{Nothing, Scene},
@@ -131,12 +132,20 @@ mutable struct Scene <: AbstractScene
             convert(Vector{AbstractLight}, lights),
             deregister_callbacks,
             Cycler(),
-            DimConversions()
+            DimConversions(),
+            false
         )
+        on(scene, events.window_open) do open
+            if !open
+                scene.isclosed = true
+            end
+        end
         finalizer(free, scene)
         return scene
     end
 end
+
+isclosed(scene::Scene) = scene.isclosed
 
 # on & map versions that deregister when scene closes!
 function Observables.on(@nospecialize(f), @nospecialize(scene::Union{Plot,Scene}), @nospecialize(observable::Observable); update=false, priority=0)
@@ -537,7 +546,6 @@ end
 #     insert!(screen, scene, plot)
 #     return
 # end
-
 
 function move_to!(plot::Plot, scene::Scene)
     if plot.parent === scene


### PR DESCRIPTION
Bonito will introduce the experimental `LargeUpdate` for supported connections, which is a no-op for the default connection types.
To better test this in the real world, we'll try to use it here if available, which shouldn't change much unless one uses `Bonito.force_connection!(Bonito.DualWebsocket)`, which introduces a second websocket connection to send large data without obstructing high frequency updates like window events.
This can be merged before the new Bonito version, since it's only used if available in Bonito.

This PR also introduces `isclosed(scene)`, which I've been wanting for a long time for event loops like this:
```julia
scene = Scene()

@async while !isclosed(scene)
    ... # do something while scene is open 
end

display(scene)
```
Since a scene starts with `isopen(scene) == false`, `isopen` can't be used in this case and one needs to manually check for the moment the scene actually gets displayed.


