### PR TITLE
Add `:solid_pattern` linestyle to allow switching between patterned and solid lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 - Allow plots to move between scenes in SpecApi [#4132](https://github.com/MakieOrg/Makie.jl/pull/4132).
 - Added empty constructor to all backends for `Screen` allowing `display(Makie.current_backend().Screen(), fig)` [#4561](https://github.com/MakieOrg/Makie.jl/pull/4561).
 - Added `subsup` and `left_subsup` functions that offer stacked sub- and superscripts for `rich` text which means this style can be used with arbitrary fonts and is not limited to fonts supported by MathTeXEngine.jl [#4489](https://github.com/MakieOrg/Makie.jl/pull/4489).
-- Added the `jitter_width` and `side_nudge` attributes to the `raincloud` plot definition, so that they can be used as kwargs [#4517]https://github.com/MakieOrg/Makie.jl/pull/4517)
+- Added the `jitter_width` and `side_nudge` attributes to the `raincloud` plot definition, so that they can be used as kwargs [#4517](https://github.com/MakieOrg/Makie.jl/pull/4517)
 - Expand PlotList plots to expose their child plots to the legend interface, allowing `axislegend`show plots within PlotSpecs as individual entries. [#4546](https://github.com/MakieOrg/Makie.jl/pull/4546)
 - Implement S.Colorbar(plotspec) [#4520](https://github.com/MakieOrg/Makie.jl/pull/4520).
 - Fixed a hang when `Record` was created inside a closure passed to `IOCapture.capture` [#4562](https://github.com/MakieOrg/Makie.jl/pull/4562).
+- Added `linestyle = :solid_pattern` to allow switching between non-solid and (effectively) solid linestyles. [#4570](https://github.com/MakieOrg/Makie.jl/pull/4570)
 
 ## [0.21.15] - 2024-10-25
 

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -351,7 +351,7 @@ Creates a connected line plot for each element in `(x, y, z)`, `(x, y)` or `posi
     "Sets the width of the line in screen units"
     linewidth = @inherit linewidth
     """
-    Sets the dash pattern of the line. Options are `:solid` (equivalent to `nothing`), `:dot`, `:dash`, `:dashdot` and `:dashdotdot`.
+    Sets the dash pattern of the line. Options are `:solid` (equivalent to `nothing`), `:solid_pattern` (can change to non-solid linestyles), `:dot`, `:dash`, `:dashdot` and `:dashdotdot`.
     These can also be given in a tuple with a gap style modifier, either `:normal`, `:dense` or `:loose`.
     For example, `(:dot, :loose)` or `(:dashdot, :dense)`.
 
@@ -392,7 +392,7 @@ Plots a line for each pair of points in `(x, y, z)`, `(x, y)`, or `positions`.
     "Sets the width of the line in pixel units"
     linewidth = @inherit linewidth
     """
-    Sets the dash pattern of the line. Options are `:solid` (equivalent to `nothing`), `:dot`, `:dash`, `:dashdot` and `:dashdotdot`.
+    Sets the dash pattern of the line. Options are `:solid` (equivalent to `nothing`), `:solid_pattern` (can change to non-solid linestyles), `:dot`, `:dash`, `:dashdot` and `:dashdotdot`.
     These can also be given in a tuple with a gap style modifier, either `:normal`, `:dense` or `:loose`.
     For example, `(:dot, :loose)` or `(:dashdot, :dense)`.
 

--- a/ReferenceTests/src/tests/updating.jl
+++ b/ReferenceTests/src/tests/updating.jl
@@ -278,3 +278,22 @@ end
     notify(Z)
     Makie.step!(st)
 end
+
+@reference_test "updating linestyles" begin
+    scene = Scene(size = (300, 100))
+    p1 = lines!(scene, [-0.8, 0.8], [0.4, 0.4], linestyle = :solid_pattern, linewidth = 10)
+    p2 = lines!(scene, [-0.8, 0.8], [0, 0], linestyle = :dash, linewidth = 10)
+    p3 = linesegments!(scene, [-0.8, -0.25, 0.25, 0.8], [-0.5, -0.5, -0.5, -0.5], linestyle = :solid_pattern, linewidth = 10)
+    p4 = lines!(scene, Point2f[(-0.95, 0.9), (-0.9, -0.9), (-0.85, 0.8), (0.9, 0.8), (0.9, -0.9)], linestyle = :solid_pattern, linewidth = 10)
+    scene
+
+    st = Stepper(scene)
+    Makie.step!(st)
+
+    p1.linestyle[] = :dashdot
+    p2.linestyle[] = :solid_pattern
+    p3.linestyle[] = :dot
+    p4.linestyle[] = Linestyle([0.0, 1.0, 2.0])
+    
+    Makie.step!(st)
+end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1126,7 +1126,7 @@ function line_diff_pattern(ls::Symbol, gaps::GapType = :normal)
     if ls === :solid
         return nothing
     elseif ls === :solid_pattern
-        return Float64[]
+        return Float64[1.0e30, 0.0]
     elseif ls === :dash
         return line_diff_pattern("-", gaps)
     elseif ls === :dot

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1125,6 +1125,8 @@ end
 function line_diff_pattern(ls::Symbol, gaps::GapType = :normal)
     if ls === :solid
         return nothing
+    elseif ls === :solid_pattern
+        return Float64[]
     elseif ls === :dash
         return line_diff_pattern("-", gaps)
     elseif ls === :dot


### PR DESCRIPTION
# Description

Fixes #3693
Fixes #803

This linestyle generates a solid line pattern so it renders with shaders used for linestyles but never actually stops drawing. This enables switching between a solid pattern and other patterns (e.g. :dot, :dash, etc).

We could also adjust `:solid` to do that, though that would make `linestyle = :solid` slower than `nothing` (and potentially different if there are any bugs/peculiarities in the linestyle shaders).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
