### PR TITLE
try self hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,13 @@ concurrency:
 jobs:
   makie:
     name: Julia ${{ matrix.version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.6'
           - '1'
-        os:
-          - ubuntu-20.04
         arch:
           - x64
     steps:

--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   cairomakie:
     name: CairoMakie Julia ${{ matrix.version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, ubuntu-20.04]
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
     name: GLMakie Julia ${{ matrix.version }}
     env:
       MODERNGL_DEBUGGING: "true" # turn on errors when running OpenGL tests
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, ubuntu-20.04]
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
 
   wglmakie:
     name: WGLMakie Julia ${{ matrix.version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, ubuntu-20.04]
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +166,7 @@ jobs:
 
   consolidation:
     name: Merge artifacts
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, ubuntu-20.04]
     if: ${{ always() }} # run even if any of the three backend test jobs failed
     needs: [cairomakie, glmakie, wglmakie]
     steps:

--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   cairomakie:
     name: CairoMakie Julia ${{ matrix.version }}
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
     name: GLMakie Julia ${{ matrix.version }}
     env:
       MODERNGL_DEBUGGING: "true" # turn on errors when running OpenGL tests
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
 
   wglmakie:
     name: WGLMakie Julia ${{ matrix.version }}
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +166,7 @@ jobs:
 
   consolidation:
     name: Merge artifacts
-    runs-on: [self-hosted]
+    runs-on: self-hosted
     if: ${{ always() }} # run even if any of the three backend test jobs failed
     needs: [cairomakie, glmakie, wglmakie]
     steps:

--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   cairomakie:
     name: CairoMakie Julia ${{ matrix.version }}
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted]
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +68,7 @@ jobs:
     name: GLMakie Julia ${{ matrix.version }}
     env:
       MODERNGL_DEBUGGING: "true" # turn on errors when running OpenGL tests
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted]
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
 
   wglmakie:
     name: WGLMakie Julia ${{ matrix.version }}
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted]
     strategy:
       fail-fast: false
       matrix:
@@ -166,7 +166,7 @@ jobs:
 
   consolidation:
     name: Merge artifacts
-    runs-on: [self-hosted, ubuntu-20.04]
+    runs-on: [self-hosted]
     if: ${{ always() }} # run even if any of the three backend test jobs failed
     needs: [cairomakie, glmakie, wglmakie]
     steps:


### PR DESCRIPTION
This should run on self hosted runner if available.