### PR TITLE
Don't force triangle mesh in crossbar with notch to avoid CairoMakie artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix polygon rendering issue of `crossbar(..., show_notch = true)` in CairoMakie [#4587](https://github.com/MakieOrg/Makie.jl/pull/4587).
 
 ## [0.21.16] - 2024-11-06
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1668,7 +1668,7 @@ end
         show_notch = true, notchwidth = 0.3,
         notchmin = ys .- (0.05:0.05:0.3), notchmax = ys .+ (0.3:-0.05:0.05),
         strokewidth = 2, strokecolor = :black,
-        orientation = :horizontal, color = :lightblue
+        orientation = :horizontal, color = (:gray, 0.5)
     )
     fig
 end

--- a/src/stats/crossbar.jl
+++ b/src/stats/crossbar.jl
@@ -77,7 +77,7 @@ function Makie.plot!(plot::CrossBar)
             end
             # when notchmin = ymin || notchmax == ymax, fill disappears from
             # half the box. first ∘ StatsBase.rle removes adjacent duplicates.
-            points = first.(StatsBase.rle.(Base.vect.(fpoint.(l, ymin),
+            boxes = first.(StatsBase.rle.(Base.vect.(fpoint.(l, ymin),
                 fpoint.(r, ymin),
                 fpoint.(r, nmin),
                 fpoint.(m .+ nw .* hw, y), # notch right
@@ -89,11 +89,6 @@ function Makie.plot!(plot::CrossBar)
                 fpoint.(l, nmin),
                 fpoint.(l, ymin)
                )))
-            boxes = if points isa AbstractVector{<: Point} # poly
-                [GeometryBasics.triangle_mesh(points)]
-            else # multiple polys (Vector{Vector{<:Point}})
-                GeometryBasics.triangle_mesh.(points)
-            end
             midlines = Pair.(fpoint.(m .- nw .* hw, y), fpoint.(m .+ nw .* hw, y))
         else
             boxes = frect.(l, ymin, boxwidth, ymax .- ymin)


### PR DESCRIPTION
CairoMakie has to draw triangle meshes with ugly seam artifacts

<img width="444" alt="grafik" src="https://github.com/user-attachments/assets/9ca563f0-c08d-470c-948f-054ac0fba184">

It seems to me the necessity to do that transformation must've been lost in some refactors as this code path is more than 4 years old. Just not creating the triangle mesh seems to work for me locally.