### PR TITLE
Fix Axis3 frameline z-sorting in CairoMakie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 - Fix an error in `convert_arguments` for PointBased plots and 3D polygons [#4585](https://github.com/MakieOrg/Makie.jl/pull/4585).
 - Fix polygon rendering issue of `crossbar(..., show_notch = true)` in CairoMakie [#4587](https://github.com/MakieOrg/Makie.jl/pull/4587).
+- Fix render order of Axis3 frame lines in CairoMakie [#4591](https://github.com/MakieOrg/Makie.jl/pull/4591)
 
 ## [0.21.16] - 2024-11-06
 

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -427,25 +427,22 @@ function add_gridlines_and_frames!(topscene, scene, ax, dim::Int, limits, tickno
         # we are going to transform the 3d frame points into 2d of the topscene
         # because otherwise the frame lines can
         # be cut when they lie directly on the scene boundary
-        to_topscene_z_2d.([p1, p2, p3, p4, p5, p6], Ref(scene))
+        o = scene.viewport[].origin
+        return map([p1, p2, p3, p4, p5, p6]) do p3d
+            # This strip z here (set it to 0) and translate to coerce z sorting
+            # to be correct in CairoMakie (which is based on plot.transformation)
+            return Point2f(o + Makie.project(scene, p3d))
+        end
     end
     colors = Observable{Any}()
     map!(vcat, colors, attr(:spinecolor_1), attr(:spinecolor_2), attr(:spinecolor_3))
     framelines = linesegments!(topscene, framepoints, color = colors, linewidth = attr(:spinewidth),
         # transparency = true,
         visible = attr(:spinesvisible), inspectable = false)
+    # -10000 is the far value in campixel
+    translate!(framelines, 0, 0, -10000)
 
     return gridline1, gridline2, framelines
-end
-
-# this function projects a point from a 3d subscene into the parent space with a really
-# small z value
-function to_topscene_z_2d(p3d, scene)
-    o = scene.viewport[].origin
-    p2d = Point2f(o + Makie.project(scene, p3d))
-    # -10000 is an arbitrary weird constant that in preliminary testing didn't seem
-    # to clip into plot objects anymore
-    Point3f(p2d..., -10000)
 end
 
 function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, ticknode, miv, min1, min2, azimuth, xreversed, yreversed, zreversed)
@@ -502,21 +499,12 @@ function add_ticks_and_ticklabels!(topscene, scene, ax, dim::Int, limits, tickno
             return (pp1, pp1 .+ Float32(tsize) .* diff_pp)
          end
     end
-    # we are going to transform the 3d tick segments into 2d of the topscene
-    # because otherwise they
-    # be cut when they extend beyond the scene boundary
-    tick_segments_2dz = lift(topscene, tick_segments, scene.camera.projectionview, scene.viewport) do ts, _, _
-        map(ts) do p1_p2
-            to_topscene_z_2d.(p1_p2, Ref(scene))
-        end
-    end
 
     ticks = linesegments!(topscene, tick_segments,
         xautolimits = false, yautolimits = false, zautolimits = false,
         transparency = true, inspectable = false,
         color = attr(:tickcolor), linewidth = attr(:tickwidth), visible = attr(:ticksvisible))
-    # -10000 is an arbitrary weird constant that in preliminary testing didn't seem
-    # to clip into plot objects anymore
+    # -10000 is the far value in campixel
     translate!(ticks, 0, 0, -10000)
 
     labels_positions = Observable{Any}()


### PR DESCRIPTION
# Description

#4485 changed `zvalue2d` to read `transformation.model` instead of `transformation.translation`, which causes it to include changes made to model directly. `Axis3` does that, so the results of plots under `ax.scene` changed. 

A few cases:
- Frame lines are part of the `ax.blockscene` so they don't see the model change from Axis3. Instead of getting translated, they have their input shifted. So before and after they have `zvalue2d() = 0`.
- Plots added to an Axis3 end up in `ax.scene`. Previously they had a default translation of `0`, now some other value based on the scenes model matrix. Since the scene centers its 3d boundingbox around 0, plots that have positive z values get shifted back and thus get a `zvalue2d < 0`
- Grid lines are also drawn to `ax.scene` and experience the same change as user plots. They end up at the same z value as them but earlier in the `scene.plots` array, so they draw first.

This pr should undo the change introduced in #4485 for CairoMakie by translating the frame lines plot instead of setting their data z-value to -10k.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
