### PR TITLE
prevent more default actions when canvas has focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+- Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).
 - Fix an error in `convert_arguments` for PointBased plots and 3D polygons [#4585](https://github.com/MakieOrg/Makie.jl/pull/4585).
 - Fix polygon rendering issue of `crossbar(..., show_notch = true)` in CairoMakie [#4587](https://github.com/MakieOrg/Makie.jl/pull/4587).
 - Fix render order of Axis3 frame lines in CairoMakie [#4591](https://github.com/MakieOrg/Makie.jl/pull/4591)

--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -23037,9 +23037,7 @@ function add_canvas_events(screen, comm, resize_to) {
     }
     canvas.addEventListener("wheel", wheel);
     function keydown(event) {
-        if (event.code === "Space") {
-            event.preventDefault();
-        }
+        event.preventDefault();
         comm.notify({
             keydown: [
                 event.code,
@@ -23050,6 +23048,7 @@ function add_canvas_events(screen, comm, resize_to) {
     }
     canvas.addEventListener("keydown", keydown);
     function keyup(event) {
+        event.preventDefault();
         comm.notify({
             keyup: event.code
         });

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -237,9 +237,7 @@ function add_canvas_events(screen, comm, resize_to) {
 
     function keydown(event) {
         // Prevent the default browser behavior for `Space`, which is to scroll.
-        if (event.code === "Space") {
-            event.preventDefault();
-        }
+        event.preventDefault();
         comm.notify({
             keydown: [event.code, event.key],
         });
@@ -249,6 +247,7 @@ function add_canvas_events(screen, comm, resize_to) {
     canvas.addEventListener("keydown", keydown);
 
     function keyup(event) {
+        event.preventDefault();
         comm.notify({
             keyup: event.code,
         });


### PR DESCRIPTION
This tries to fix the issue with pressing arrow keys leading to loosing focus.
It seems reasonable, the way Makie is setup, that the canvas eats up all events.