### PR TITLE
Fix misaligned colors in colorbar?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix an error in `convert_arguments` for PointBased plots and 3D polygons [#4585](https://github.com/MakieOrg/Makie.jl/pull/4585).
 - Fix polygon rendering issue of `crossbar(..., show_notch = true)` in CairoMakie [#4587](https://github.com/MakieOrg/Makie.jl/pull/4587).
 - Fix render order of Axis3 frame lines in CairoMakie [#4591](https://github.com/MakieOrg/Makie.jl/pull/4591)
+- Fix color mapping between contourf and colorbar [#4618](https://github.com/MakieOrg/Makie.jl/pull/4618)
 
 ## [0.21.16] - 2024-11-06
 

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -342,6 +342,17 @@ end
     fig
 end
 
+@reference_test "Colorbar mapping to contourf" begin
+    l = [1, 2, 5, 10, 20, 50]
+    x = 0:0.1:51
+    y = 0:0.1:51
+    z = [y for x in x, y in y]
+    fig, ax, plt = contourf(x, y, z; levels = l)
+    cb = Colorbar(fig[1, 2], plt; tellheight = false)
+
+    fig
+end
+
 @reference_test "datashader" begin
     airports = Point2f.(eachrow(readdlm(assetpath("airportlocations.csv"))))
     # Dont use the full dataset, since WGLMakie seems to time out if it's too big
@@ -459,31 +470,31 @@ end
 @reference_test "Button - Slider - Toggle - Textbox" begin
     f = Figure(size = (500, 250))
     Makie.Button(f[1, 1:2])
-    Makie.Button(f[2, 1:2], buttoncolor = :orange, cornerradius = 20, 
+    Makie.Button(f[2, 1:2], buttoncolor = :orange, cornerradius = 20,
         strokecolor = :red, strokewidth = 2, # TODO: allocate space for this
         fontsize = 16, labelcolor = :blue)
 
     IntervalSlider(f[1, 3])
-    sl = IntervalSlider(f[2, 3], range = 0:100, linewidth = 20, 
+    sl = IntervalSlider(f[2, 3], range = 0:100, linewidth = 20,
         color_inactive = :orange, color_active_dimmed = :lightgreen)
     Makie.set_close_to!(sl, 30, 70)
 
     Toggle(f[3, 1])
     Toggle(f[4, 1], framecolor_inactive = :lightblue, rimfraction = 0.6)
     Toggle(f[3, 2], active = true)
-    Toggle(f[4, 2], active = true, framecolor_inactive = :lightblue, 
+    Toggle(f[4, 2], active = true, framecolor_inactive = :lightblue,
         framecolor_active = :yellow, rimfraction = 0.6)
 
     Makie.Slider(f[3, 3])
-    sl = Makie.Slider(f[4, 3], range = 0:100, linewidth = 20, color_inactive = :cyan, 
+    sl = Makie.Slider(f[4, 3], range = 0:100, linewidth = 20, color_inactive = :cyan,
         color_active_dimmed = :lightgreen)
     Makie.set_close_to!(sl, 30)
 
     gl = GridLayout(f[5, 1:3])
     Textbox(gl[1, 1])
-    Textbox(gl[1, 2], bordercolor = :red, cornerradius = 0, 
+    Textbox(gl[1, 2], bordercolor = :red, cornerradius = 0,
         placeholder = "test string", fontsize = 16, textcolor_placeholder = :blue)
-    tb = Textbox(gl[1, 3], bordercolor = :black, cornerradius = 20, 
+    tb = Textbox(gl[1, 3], bordercolor = :black, cornerradius = 20,
         fontsize =10, textcolor = :red, boxcolor = :lightblue)
     Makie.set!(tb, "some string")
 

--- a/src/makielayout/blocks/colorbar.jl
+++ b/src/makielayout/blocks/colorbar.jl
@@ -247,14 +247,15 @@ function initialize_block!(cb::Colorbar)
     end
     heatmap!(blockscene,
         xrange, yrange, continuous_pixels;
-        colormap=colormap,
-        colorrange=limits,
-        visible=show_cats,
-        inspectable=false
+        colormap = colormap,
+        colorrange = limits,
+        visible = show_cats,
+        inspectable = false
     )
     image!(blockscene,
         lift(extrema, xrange), lift(extrema, yrange), continuous_pixels;
         colormap = colormap,
+        colorrange = limits,
         visible = show_continuous,
         inspectable = false
     )

--- a/src/makielayout/blocks/colorbar.jl
+++ b/src/makielayout/blocks/colorbar.jl
@@ -248,6 +248,7 @@ function initialize_block!(cb::Colorbar)
     heatmap!(blockscene,
         xrange, yrange, continuous_pixels;
         colormap=colormap,
+        colorrange=limits,
         visible=show_cats,
         inspectable=false
     )


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #4121? 

Currently the `Colorbar` built from a `contourf` may have misaligned colors. For a MWE see #4121 or
```julia
l = [1, 2, 5, 10, 20, 50]
x = 0:0.1:51
y = 0:0.1:51
z = [y for x in x, y in y]
fig, ax, plt = contourf(x, y, z; levels = l, extendhigh=:auto, extendlow=:auto)
cb = Colorbar(fig[1, 2], plt; tellheight = false)
```

which produces this misalignment (I edited the image in Preview to show the differences in colors):

![test](https://github.com/user-attachments/assets/f0d00eab-f794-4871-b9dc-1e13b604b20d)

The issue seems to be that the `continuous_pixels` (used to draw the heatmap for the colorbar) are not scaled properly. Simply adding the `colorrange` kwarg to that call fixes this issue for me, with properly matching colors:

<img width="580" alt="Screenshot 2024-11-22 at 1 27 43 pm" src="https://github.com/user-attachments/assets/3bf973f0-e6a7-4001-a20d-aecbcb80e871">

However, I'm not if this breaks other things elsewhere, so hopefully someone can hold my hand to finish this PR?

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
