### PR TITLE
Fix RPRMakie EnvironmentLight orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix orientation of environment light textures in RPRMakie [#4629](https://github.com/MakieOrg/Makie.jl/pull/4629).
 - Fix uint16 overflow for over ~65k elements in WGLMakie picking [#4604](https://github.com/MakieOrg/Makie.jl/pull/4604).
 - Improve performance for line plot in CairoMakie [#4601](https://github.com/MakieOrg/Makie.jl/pull/4601).
 - Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).

--- a/RPRMakie/src/scene.jl
+++ b/RPRMakie/src/scene.jl
@@ -126,9 +126,17 @@ end
 
 function to_rpr_light(context::RPR.Context, rpr_scene, light::Makie.EnvironmentLight)
     env_light = RPR.EnvironmentLight(context)
-    last_img = RPR.Image(context, light.image[])
+    last_img = RPR.Image(context, light.image[]')
     set!(env_light, last_img)
     setintensityscale!(env_light, light.intensity[])
+    # exchange y and z axis to align Makie's and RPR's representations
+    flipmat = Makie.Mat4f(
+        1, 0, 0, 0,
+        0, 0, 1, 0,
+        0, 1, 0, 0,
+        0, 0, 0, 1,
+    )
+    transform!(env_light, flipmat)
     on(light.intensity) do i
         setintensityscale!(env_light, i)
     end


### PR DESCRIPTION
A normal exr or hdri image read in with `FileIO.load` will have to be transposed to match RPRs expected orientation, so I do that for convenience so that `EnvironmentLight(1, load("some_file.exr"))` looks as expected. Also, our coordinate system doesn't match that of RPRMakie which matters for the env light, so I exchange the y and z axes. The result looks ok to me although I'm not sure if the azimuthal rotation should be different. At least everything is the right way up and not squished weirdly.

Here's a simple scene with a camera looking at 0, 0, 0 with azimuth and elevation = 0 with a wide field of view:

## Before

<img width="502" alt="grafik" src="https://github.com/user-attachments/assets/6e48f9fd-e73e-40dd-945f-5ce238e59890">

## After

<img width="503" alt="grafik" src="https://github.com/user-attachments/assets/79ecbbf7-66fd-41e5-ab11-515214d86b75">
