### PR TITLE
Fix CairoMakie heatmap offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix orientation of environment light textures in RPRMakie [#4629](https://github.com/MakieOrg/Makie.jl/pull/4629).
 - Fix uint16 overflow for over ~65k elements in WGLMakie picking [#4604](https://github.com/MakieOrg/Makie.jl/pull/4604).
 - Improve performance for line plot in CairoMakie [#4601](https://github.com/MakieOrg/Makie.jl/pull/4601).
 - Prevent more default actions when canvas has focus [#4602](https://github.com/MakieOrg/Makie.jl/pull/4602).

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -852,6 +852,8 @@ function draw_atomic(scene::Scene, screen::Screen{RT}, @nospecialize(primitive::
 end
 
 function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
+    mini = min.(xys[1, 1], xys[end, end])
+    maxi = max.(xys[1, 1], xys[end, end])
     @inbounds for i in 1:ni, j in 1:nj
         p1 = xys[i, j]
         p2 = xys[i+1, j]
@@ -873,9 +875,9 @@ function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
             # To avoid shifting the cell border we skip extensions at (i, j), i.e.
             # we only extend the sides that will be covered by other cells.
             center = 0.25f0 * (p1 + p2 + p3 + p4)
-            p2 += sign.(p2 - center) .* Point2f(i != ni, 0)
-            p3 += sign.(p3 - center) .* Point2f(i != ni, j != nj)
-            p4 += sign.(p4 - center) .* Point2f(0,       j != nj)
+            p2 = clamp.(p2 + sign.(p2 - center) .* 2f0 * Point2f(i != ni, 0),       mini, maxi)
+            p3 = clamp.(p3 + sign.(p3 - center) .* 2f0 * Point2f(i != ni, j != nj), mini, maxi)
+            p4 = clamp.(p4 + sign.(p4 - center) .* 2f0 * Point2f(0,       j != nj), mini, maxi)
         end
 
         Cairo.set_line_width(ctx, 0)

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -870,11 +870,12 @@ function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
             # extend the polygon. (Which may change due to rotations in the
             # model matrix.) (i!=1) etc is used to avoid increasing the
             # outer extent of the heatmap.
+            # To avoid shifting the cell border we skip extensions at (i, j), i.e.
+            # we only extend the sides that will be covered by other cells.
             center = 0.25f0 * (p1 + p2 + p3 + p4)
-            p1 += sign.(p1 - center) .* Point2f(0.5f0 * (i!=1),  0.5f0 * (j!=1))
-            p2 += sign.(p2 - center) .* Point2f(0.5f0 * (i!=ni), 0.5f0 * (j!=1))
+            p2 += sign.(p2 - center) .* Point2f(0.5f0 * (i!=ni), 0)
             p3 += sign.(p3 - center) .* Point2f(0.5f0 * (i!=ni), 0.5f0 * (j!=nj))
-            p4 += sign.(p4 - center) .* Point2f(0.5f0 * (i!=1),  0.5f0 * (j!=nj))
+            p4 += sign.(p4 - center) .* Point2f(0,               0.5f0 * (j!=nj))
         end
 
         Cairo.set_line_width(ctx, 0)
@@ -1254,7 +1255,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Maki
     scale = Makie.voxel_size(primitive)
     colors = Makie.voxel_colors(primitive)
     marker = GeometryBasics.normal_mesh(Rect3f(Point3f(-0.5), Vec3f(1)))
-    
+
     # Face culling
     if !isempty(primitive.clip_planes[]) && Makie.is_data_space(primitive.space[])
         valid = [is_visible(primitive.clip_planes[], p) for p in pos]

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -852,8 +852,6 @@ function draw_atomic(scene::Scene, screen::Screen{RT}, @nospecialize(primitive::
 end
 
 function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
-    mini = min.(xys[1, 1], xys[end, end])
-    maxi = max.(xys[1, 1], xys[end, end])
     @inbounds for i in 1:ni, j in 1:nj
         p1 = xys[i, j]
         p2 = xys[i+1, j]
@@ -868,16 +866,18 @@ function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
         # increase their size slightly.
 
         if alpha(colors[i, j]) == 1
-            # sign.(p - center) gives the direction in which we need to
-            # extend the polygon. (Which may change due to rotations in the
-            # model matrix.) (i!=1) etc is used to avoid increasing the
-            # outer extent of the heatmap.
-            # To avoid shifting the cell border we skip extensions at (i, j), i.e.
-            # we only extend the sides that will be covered by other cells.
-            center = 0.25f0 * (p1 + p2 + p3 + p4)
-            p2 = clamp.(p2 + sign.(p2 - center) .* 2f0 * Point2f(i != ni, 0),       mini, maxi)
-            p3 = clamp.(p3 + sign.(p3 - center) .* 2f0 * Point2f(i != ni, j != nj), mini, maxi)
-            p4 = clamp.(p4 + sign.(p4 - center) .* 2f0 * Point2f(0,       j != nj), mini, maxi)
+            # To avoid gaps between heatmap cells we pad cells.
+            # For 3D compatability (and rotation, inversion/mirror) we pad cells
+            # using directional vectors, not along x/y directions.
+            v1 = normalize(p2 - p1)
+            v2 = normalize(p4 - p1)
+            # To avoid shifting cells we only pad them on the +i, +j side, which
+            # gets covered by later cells.
+            # To avoid enlarging the final column and row of the heatmap, the
+            # last set of cells is not padded. (i != ni), (j != nj)
+            p2 += Float32(i != ni) * v1
+            p3 += Float32(i != ni) * v1 + Float32(j != nj) * v2
+            p4 += Float32(j != nj) * v2
         end
 
         Cairo.set_line_width(ctx, 0)

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -873,9 +873,9 @@ function _draw_rect_heatmap(ctx, xys, ni, nj, colors)
             # To avoid shifting the cell border we skip extensions at (i, j), i.e.
             # we only extend the sides that will be covered by other cells.
             center = 0.25f0 * (p1 + p2 + p3 + p4)
-            p2 += sign.(p2 - center) .* Point2f(0.5f0 * (i!=ni), 0)
-            p3 += sign.(p3 - center) .* Point2f(0.5f0 * (i!=ni), 0.5f0 * (j!=nj))
-            p4 += sign.(p4 - center) .* Point2f(0,               0.5f0 * (j!=nj))
+            p2 += sign.(p2 - center) .* Point2f(i != ni, 0)
+            p3 += sign.(p3 - center) .* Point2f(i != ni, j != nj)
+            p4 += sign.(p4 - center) .* Point2f(0,       j != nj)
         end
 
         Cairo.set_line_width(ctx, 0)

--- a/RPRMakie/src/scene.jl
+++ b/RPRMakie/src/scene.jl
@@ -126,9 +126,17 @@ end
 
 function to_rpr_light(context::RPR.Context, rpr_scene, light::Makie.EnvironmentLight)
     env_light = RPR.EnvironmentLight(context)
-    last_img = RPR.Image(context, light.image[])
+    last_img = RPR.Image(context, light.image[]')
     set!(env_light, last_img)
     setintensityscale!(env_light, light.intensity[])
+    # exchange y and z axis to align Makie's and RPR's representations
+    flipmat = Makie.Mat4f(
+        1, 0, 0, 0,
+        0, 0, 1, 0,
+        0, 1, 0, 0,
+        0, 0, 0, 1,
+    )
+    transform!(env_light, flipmat)
     on(light.intensity) do i
         setintensityscale!(env_light, i)
     end


### PR DESCRIPTION
# Description

Fixes #4053

We extend heatmap cells by half a pixel in every direction when `alpha == 1` to avoid gaps opening. This shifts the borders by half a pixel. I removed the padding for the side that covers other cells which fixes things for me. The other 0.5 padding is still there so this should still close gaps.

![image](https://github.com/user-attachments/assets/45306693-872e-4490-84f1-3b17549b49b0)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
