### PR TITLE
Add linkaxes to S.GridLayout and make sure limits don't reset for axislinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed heatmap cells being 0.5px/units too large in CairoMakie [4633](https://github.com/MakieOrg/Makie.jl/pull/4633)
 - Fix bounds error when recording video with WGLMakie [#4639](https://github.com/MakieOrg/Makie.jl/pull/4639).
 - Add `axis.(x/y)ticklabelspace = :max_auto`, to only grow tickspace but never shrink to reduce jitter [#4642](https://github.com/MakieOrg/Makie.jl/pull/4642).
+- Add (x/y)axislinks to S.GridLayout and make sure limits don't reset when linking axes [#4643](https://github.com/MakieOrg/Makie.jl/pull/4643).
 
 ## [0.21.16] - 2024-11-06
 

--- a/ReferenceTests/src/tests/specapi.jl
+++ b/ReferenceTests/src/tests/specapi.jl
@@ -183,3 +183,31 @@ end
     image!(s, imgs; space=:pixel)
     s
 end
+
+@reference_test "Axis links" begin
+    axiis = broadcast(1:2, (1:2)') do x, y
+        S.Axis(; title="$x, $y")
+    end
+    f, _, pl = plot(
+        S.GridLayout(axiis; xaxislinks=vec(axiis[1:2, 1]), yaxislinks=vec(axiis[1:2, 2]));
+        figure=(; size=(500, 250)),
+    )
+    for ax in f.content[[1, 3]]
+        limits!(ax, 2, 3, 2, 3)
+    end
+
+    img1 = rotr90(colorbuffer(f; update=false))
+    for ax in f.content
+        limits!(ax, 0, 10, 0, 10)
+    end
+    pl[1] = S.GridLayout(axiis; xaxislinks=vec(axiis[1:2, 2]), yaxislinks=vec(axiis[1:2, 1]))
+    for ax in f.content[[1, 3]]
+        limits!(ax, 2, 3, 2, 3)
+    end
+    sleep(0.1)
+    img2 = rotr90(colorbuffer(f; update=false))
+    large = hcat(img2, img1)
+    s = Scene(; size=size(large))
+    image!(s, large; space=:pixel)
+    s
+end

--- a/docs/src/explanations/specapi.md
+++ b/docs/src/explanations/specapi.md
@@ -153,6 +153,7 @@ S.GridLayout([...],
 Axis links are also supported, but they're not part of Axis, but rather the surrounding `GridLayout`, since when constructing the axis you usually don't yet have the other Axes you want to link them to.
 
 ```@figure
+import Makie.SpecApi as S
 axis_matrix = broadcast(1:2, (1:2)') do x, y
     S.Axis(; title="$x, $y")
 end

--- a/docs/src/explanations/specapi.md
+++ b/docs/src/explanations/specapi.md
@@ -150,6 +150,26 @@ S.GridLayout([...],
 )
 ```
 
+Axis links are also supported, but they're not part of Axis, but rather the surrounding `GridLayout`, since when constructing the axis you usually don't yet have the other Axes you want to link them to.
+
+```@figure
+axis_matrix = broadcast(1:2, (1:2)') do x, y
+    S.Axis(; title="$x, $y")
+end
+layout = S.GridLayout(
+    axis_matrix;
+    xaxislinks=vec(axis_matrix[1:2, 1]),
+    yaxislinks=vec(axis_matrix[1:2, 2])
+)
+f, _, pl = plot(layout)
+# Change limits to see the links in action
+for ax in f.content[[1, 3]]
+    limits!(ax, 2, 3, 2, 3)
+end
+f
+```
+
+
 ## Using specs in `convert_arguments`
 
 !!! warning

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1053,9 +1053,7 @@ function linkaxes!(dir::Symbol, axes::Vector{Axis})
             end
         end
     end
-    if links_changed
-        notify(first(axes).targetlimits)
-    end
+    reset_limits!(first(axes))
     return
 end
 

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -975,9 +975,13 @@ yautolimits(ax::Axis) = autolimits(ax, 2)
 
 Link both x and y axes of all given `Axis` so that they stay synchronized.
 """
+function linkaxes!(axes::Vector{<:Axis})
+    linkxaxes!(axes)
+    linkyaxes!(axes)
+end
+
 function linkaxes!(a::Axis, others...)
-    linkxaxes!(a, others...)
-    linkyaxes!(a, others...)
+    linkaxes!([a, others...])
 end
 
 function adjustlimits!(la)
@@ -1029,26 +1033,30 @@ function adjustlimits!(la)
     return
 end
 
-function linkaxes!(dir::Union{Val{:x}, Val{:y}}, a::Axis, others...)
-    axes = Axis[a; others...]
+linkaxes!(dir::Symbol, a::Axis, others...) = linkaxes!(dir, [a, others...])
 
+function linkaxes!(dir::Symbol, axes::Vector{Axis})
     all_links = Set{Axis}(axes)
     for ax in axes
-        links = dir isa Val{:x} ? ax.xaxislinks : ax.yaxislinks
+        links = dir === :x ? ax.xaxislinks : ax.yaxislinks
         for ax in links
             push!(all_links, ax)
         end
     end
-
+    links_changed = false
     for ax in all_links
-        links = (dir isa Val{:x} ? ax.xaxislinks : ax.yaxislinks)
+        links = dir === :x ? ax.xaxislinks : ax.yaxislinks
         for linked_ax in all_links
-            if linked_ax !== ax && linked_ax ∉ links
+            if linked_ax !== ax && !(linked_ax in links)
+                links_changed = true
                 push!(links, linked_ax)
             end
         end
     end
-    reset_limits!(a)
+    if links_changed
+        reset_limits!(first(axes))
+    end
+    return
 end
 
 """
@@ -1056,14 +1064,16 @@ end
 
 Link the x axes of all given `Axis` so that they stay synchronized.
 """
-linkxaxes!(a::Axis, others...) = linkaxes!(Val(:x), a, others...)
+linkxaxes!(axes::Vector{Axis}) = linkaxes!(:x, axes)
+linkxaxes!(a::Axis, others...) = linkaxes!(:x, [a, others...])
 
 """
     linkyaxes!(a::Axis, others...)
 
 Link the y axes of all given `Axis` so that they stay synchronized.
 """
-linkyaxes!(a::Axis, others...) = linkaxes!(Val(:y), a, others...)
+linkyaxes!(axes::Vector{Axis}) = linkaxes!(:y, axes)
+linkyaxes!(a::Axis, others...) = linkaxes!(:y, [a, others...])
 
 """
 Keeps the ticklabelspace static for a short duration and then resets it to its previous

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -1054,7 +1054,7 @@ function linkaxes!(dir::Symbol, axes::Vector{Axis})
         end
     end
     if links_changed
-        reset_limits!(first(axes))
+        notify(first(axes).targetlimits)
     end
     return
 end

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -10,6 +10,7 @@ function update_gridlines!(grid_obs::Observable{Vector{Point2f}}, offset::Point2
 end
 
 function process_axis_event(ax, event)
+    ax.scene.visible[] || return Consume(false)
     for (active, interaction) in values(ax.interactions)
         if active
             maybe_consume = process_interaction(interaction, event, ax)

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -145,6 +145,7 @@ function initialize_block!(ax::Axis3)
     end
 
     function process_event(event)
+        ax.scene.visible[] || return Consume(false)
         for (active, interaction) in values(ax.interactions)
             if active
                 maybe_consume = process_interaction(interaction, event, ax)

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -134,6 +134,9 @@ function calculate_real_ticklabel_align(al, horizontal, fl::Bool, rot::Number)
     end
 end
 
+max_auto_ticklabel_spacing!(ax) = nothing
+
+
 function update_ticklabel_node(
         closure_args,
         ticklabel_annotation_obs::Observable,

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -781,7 +781,6 @@ function to_layoutable(parent, position::GridLayoutPosition, spec::GridLayoutSpe
 end
 
 function update_layoutable!(block::T, plot_obs, old_spec::BlockSpec, spec::BlockSpec) where T <: Block
-    unhide!(block)
     if spec.type === :Colorbar
         # To get plot defaults for Colorbar(specapi), we need a theme / scene
         # So we have to look up the kwargs here instead of the BlockSpec constructor.
@@ -816,6 +815,13 @@ function update_layoutable!(block::T, plot_obs, old_spec::BlockSpec, spec::Block
     end
     if T <: AbstractAxis
         plot_obs[] = spec.plots
+        score = distance_score(old_spec.plots, spec.plots, Dict())
+        if score >= 1.0
+            scene = get_scene(block)
+            if any(needs_tight_limits, scene.plots)
+                tightlimits!(block)
+            end
+        end
     end
     for observer in old_spec.then_observers
         Observables.off(observer)
@@ -826,6 +832,7 @@ function update_layoutable!(block::T, plot_obs, old_spec::BlockSpec, spec::Block
         observers = func(block)
         add_observer!(spec, observers)
     end
+    unhide!(block)
     return to_update, reset_to_defaults
 end
 

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -874,7 +874,7 @@ end
 
 
 function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::Union{Nothing, GridLayoutSpec},
-                            gridspec::GridLayoutSpec, previous_contents, new_layoutables, global_unused_plots, new_plots)
+                            gridspec::GridLayoutSpec, previous_contents, new_layoutables)
 
     update_layoutable!(gridlayout, nothing, oldgridspec, gridspec)
     scores = IdDict{Any, Float64}()
@@ -890,7 +890,7 @@ function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::U
             if new_layoutable isa AbstractAxis
                 obs = Observable(spec.plots)
                 scene = get_scene(new_layoutable)
-                update_plotspecs!(scene, obs, nothing, global_unused_plots, new_plots, false)
+                update_plotspecs!(scene, obs)
                 if any(needs_tight_limits, scene.plots)
                     tightlimits!(new_layoutable)
                 end
@@ -898,7 +898,7 @@ function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::U
             elseif new_layoutable isa GridLayout
                 # Make sure all plots & blocks are inserted
                 update_gridlayout!(new_layoutable, nesting + 1, spec, spec, previous_contents,
-                                   new_layoutables, global_unused_plots, new_plots)
+                                   new_layoutables)
             end
             push!(new_layoutables, (nesting, position, spec) => (new_layoutable, obs))
         else
@@ -910,7 +910,7 @@ function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::U
             gridlayout[position...] = layoutable
             if layoutable isa GridLayout
                 update_gridlayout!(layoutable, nesting + 1, old_spec, spec, previous_contents,
-                                   new_layoutables, global_unused_plots, new_plots)
+                                   new_layoutables)
             else
                 update_layoutable!(layoutable, plot_obs, old_spec, spec)
                 update_state_before_display!(layoutable)

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -801,19 +801,19 @@ function update_layoutable!(block::T, plot_obs, old_spec::BlockSpec, spec::Block
         plot_obs[] = spec.plots
         scene = get_scene(block)
         if any(needs_tight_limits, scene.plots)
-            tightlimits!(block)
+            # tightlimits!(block)
         end
     end
     for observer in old_spec.then_observers
         Observables.off(observer)
     end
     empty!(old_spec.then_observers)
-    if hasproperty(spec, :xaxislinks)
-        empty!(spec.xaxislinks)
-    end
-    if hasproperty(spec, :yaxislinks)
-        empty!(spec.yaxislinks)
-    end
+    # if hasproperty(spec, :xaxislinks)
+    #     empty!(spec.xaxislinks)
+    # end
+    # if hasproperty(spec, :yaxislinks)
+    #     empty!(spec.yaxislinks)
+    # end
     for func in spec.then_funcs
         observers = func(block)
         add_observer!(spec, observers)
@@ -902,7 +902,7 @@ function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::U
                                    new_layoutables)
             else
                 update_layoutable!(layoutable, plot_obs, old_spec, spec)
-                update_state_before_display!(layoutable)
+                # update_state_before_display!(layoutable)
             end
             # Carry over to cache it in new_layoutables
             push!(new_layoutables, (nesting, position, spec) => (layoutable, plot_obs))

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -293,7 +293,7 @@ function distance_score(a::BlockSpec, b::BlockSpec, scores_dict)
         scores = Float64[
             distance_score(a.kwargs, b.kwargs, scores_dict),
             distance_score(a.plots, b.plots, scores_dict),
-            distance_score(a.then_funcs, b.then_funcs, scores_dict)
+            # distance_score(a.then_funcs, b.then_funcs, scores_dict)
         ]
         return norm(scores)
     end
@@ -305,8 +305,8 @@ function distance_score(at::Tuple{Int,GP,BS}, bt::Tuple{Int,GP,BS},
     (anesting, ap, a) = at
     (bnesting, bp, b) = bt
     scores = Float64[
-        abs(anesting - bnesting) * 2,
-        distance_score(ap, bp, scores_dict) * 2,
+        abs(anesting - bnesting) * 0.5,
+        distance_score(ap, bp, scores_dict) * 0.5,
         distance_score(a, b, scores_dict)
     ]
     return norm(scores)

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -355,14 +355,7 @@ function find_layoutable(
 end
 
 function find_reusable_plot(scene::Scene, plotspec::PlotSpec, plots::IdDict{PlotSpec,Plot}, scores)
-    function penalty(key, score)
-        # penalize plots with different parents
-        # needs to be implemented via this penalty function, since parent scenes arent part of the spec
-        plot = plots[key]
-        move_to_penalty = ((!Makie.supports_move_to(plot)) * 100) + 1
-        return norm(Float64[plot.parent !== scene, score]) * move_to_penalty
-    end
-    idx = find_min_distance((_, spec) -> spec, plotspec, plots, scores, penalty)
+    idx = find_min_distance((_, spec) -> spec, plotspec, plots, scores)
     idx == -1 && return nothing, nothing
     return plots[idx], idx
 end
@@ -612,10 +605,6 @@ function diff_plotlist!(
             @debug("updating old plot with spec")
             # Delete the plots from reusable_plots, so that we don't re-use it multiple times!
             delete!(reusable_plots, old_spec)
-            if reused_plot.parent !== scene
-                @assert Makie.supports_move_to(reused_plot)
-                move_to!(reused_plot, scene)
-            end
             update_plot!(obs_to_notify, reused_plot, old_spec, plotspec)
             new_plots[plotspec] = reused_plot
 

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -875,7 +875,7 @@ function update_axis_links!(gridspec, all_layoutables)
     # axes that should be linked
     axes = Dict{BlockSpec, Axis}()
     for ((_, _, ax_spec), (ax_object, _)) in all_layoutables
-        if ax_spec.type === :Axis
+        if ax_spec isa BlockSpec && ax_spec.type === :Axis
             axes[ax_spec] = ax_object
         end
     end

--- a/src/specapi.jl
+++ b/src/specapi.jl
@@ -872,7 +872,7 @@ function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::U
 
         idx, old_key, layoutable_obs = find_layoutable((nesting, position, spec), previous_contents, scores)
         if isnothing(layoutable_obs)
-            @debug("Creating new content for spec")
+            @info("Creating new content for spec")
             # Create new plot, store it into `new_layoutables`
             new_layoutable = to_layoutable(gridlayout, position, spec)
             obs = Observable(PlotSpec[])
@@ -891,7 +891,7 @@ function update_gridlayout!(gridlayout::GridLayout, nesting::Int, oldgridspec::U
             end
             push!(new_layoutables, (nesting, position, spec) => (new_layoutable, obs))
         else
-            @debug("updating old block with spec")
+            @info("updating old block with spec")
             # Make sure we don't double re-use a layoutable
             splice!(previous_contents, idx)
             (_, _, old_spec) = old_key


### PR DESCRIPTION
This PR does two things:
1) Implement S.GridLayout(...; xaxislinks=[...], yaxislinks=[...])
2) Doesn't reset zoom when axes are swapped (see https://github.com/MakieOrg/Makie.jl/pull/4589)