### PR TITLE
Compute Graph Improvements

### DIFF
--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -129,7 +129,6 @@ mutable struct Input <: AbstractEdge
     f::Function
     output::ComputedValue
     dirty::Bool
-    output_dirty::Bool
     dependents::Vector{ComputeEdge}
 end
 
@@ -264,10 +263,7 @@ function mark_dirty!(computed::Computed)
 end
 
 function resolve!(input::Input)
-    if !input.dirty
-        input.output_dirty = false
-        return
-    end
+    input.dirty || return
     value = input.f(input.value)
     if isassigned(input.output.value)
         input.output.value[] = value
@@ -285,7 +281,6 @@ end
 
 function mark_dirty!(input::Input)
     input.dirty = true
-    input.output_dirty = false
     for edge in input.dependents
         mark_dirty!(edge)
     end

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -95,13 +95,20 @@ end
 function Base.show(io::IO, ::MIME"text/plain", edge::ComputeEdge)
     println(io, "ComputeEdge{$(edge.callback)}:")
     print(io, "  inputs:")
+    output_dirty = !(edge.got_resolved[])
     for (dirty, v) in zip(edge.inputs_dirty, edge.inputs)
         print(io, "\n    ", dirty ? '↻' : '✓', ' ')
         show(io, v)
+        output_dirty |= dirty
     end
     print(io, "\n  outputs:")
     for v in edge.outputs
-        print(io, "\n    ")
+        print(io, "\n    ", output_dirty ? '↻' : '✓', ' ')
+        show(io, v)
+    end
+    print(io, "\n  dependents:")
+    for v in edge.dependents
+        print(io, "\n    ", isdirty(v) ? '↻' : '✓', ' ')
         show(io, v)
     end
 end

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -134,7 +134,7 @@ end
 
 function Input(value, f, output)
     @assert !(value isa ComputedValue)
-    return Input(value, f, output, true, true, ComputeEdge[])
+    return Input(value, f, output, true, ComputeEdge[])
 end
 
 struct ComputeGraph

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -1044,8 +1044,10 @@ function render_asap(f::Function, screen::Screen, N::Integer)
     stop_renderloop!(screen)
     yield()
     GLFW.SwapInterval(0)
+    ts = Vector{Float64}(undef, N)
 
-    for _ in 1:N
+    for i in 1:N
+        t = time()
         pollevents(screen, Makie.RegularRenderTick)
         f()
         for plot in values(screen.cache2plot)
@@ -1057,8 +1059,10 @@ function render_asap(f::Function, screen::Screen, N::Integer)
         render_frame(screen)
         GLFW.SwapBuffers(to_native(screen))
         GC.safepoint()
+        ts[i] = time() - t
     end
 
     screen.close_after_renderloop = true
     start_renderloop!(screen)
+    return ts
 end

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -380,7 +380,7 @@ function Base.getproperty(plot::ComputePlots, key::Symbol)
     return plot.args[1][key]
 end
 
-Observables.to_value(computed::ComputePipeline.ComputedValue) = computed[]
+Observables.to_value(computed::ComputePipeline.Computed) = computed[]
 
 
 function Scatter(args::Tuple, user_kw::Dict{Symbol,Any})


### PR DESCRIPTION
In my benchmarks the compute graph spends at least 30% of the full `attr[:gl_renderobject][]` time on `mark_input_dirty!(parent, edge)`.

## Improvement 1

I first tried avoiding all the back and forth in that function. Effectively the old version does:
```julia
for i in eachindex(edge.inputs)
    if edge.input[i].parent == parent
        edge.inputs_dirty[i] = isdirty(edge.inputs[i]) # effectively returns edge.inputs[i].outputs_dirty[i]
    end
end
```
To simplify this I allowed `ComputedValue` to be set `dirty` so this becomes:
```julia
for i in eachindex(edge.inputs)
    edge.inputs_dirty[i] = edge.inputs[i].dirty
end
```
which helped a bit but not that much.

## Improvement 2

The next thing I tried was to make `edge.inputs::Vector{ComputedValue}` type stable. This helped a lot and after tying a couple of things the most important change seems to be removing the type parameter. I.e. going from
```julia
struct ComputedValue{P}
    parent::P
    ...
end
```
to
```julia
struct ComputedValue
    parent::AbstractEdge
    ...
end
```
Together with the previous change this practically eliminated `mark_input_dirty!()` from `@profview`.

#### Notes (2.5)

My first version of this reworked `Input` to wrap ComputedValue and ComputedEdge so that every `computed.parent` is just a ComputedEdge. That way I could add `edge.parents::Vector{ComputedEdge}` and use them during resolve instead of having to go through `isdefined(computed, :parent)` checks and the associated abstract type. That turned out to be a fairly significant hit on plot create time (19.7µs -> 26.8µs mean time for Scatter()) without improving resolve time much (share in `@profview` changed from ~46% -> ~43%)

## Improvement 3

The `edge.outputs_dirty` field is now redundant with `computed.dirty` so I tried removing it/replacing it with `edge.outsputs::Vector{ComputedValue}`. This resulted in no performance penalty in resolve while marginally improving create time (19.7µs -> 19.3µs mean)

---

## Benchmarks

<details>
<summary>
Create time
</summary>

```julia
let
    args = (1:10,)
    kwargs = Dict{Symbol, Any}()
    display(@benchmark Scatter($args, $kwargs))
    @benchmark Scatter($args, $kwargs)
end
```

</details>

<details>
<summary>
Resolve/frame time (profview)
</summary>

```julia
begin
    scene = Scene()
    cam_relative!(scene)
    for _ in 1:20
        scatterlines!(scene, rand(Point2f, 10), color = rand(10), markersize = 10 .* rand(10))
    end

    screen = display(scene)

    cb = () -> begin
        for p in scene.plots
            attr = p.args[1]
            Makie.update!(attr, arg1 = rand(Point2f, 10), color = rand(10), markersize = 10 .* rand(10))
            # Makie.update!(attr, arg1 = attr[:arg1][], color = attr[:color][], markersize = attr[:markersize][])
        end
        return
    end

    GLMakie.render_asap(cb, screen, 10)
    GC.gc()

    @profview @time ts = GLMakie.render_asap(cb, screen, 2000)
end
```

</details>

<details>
<summary>
Resolve/frame time (benchmark + plot)
</summary>

```julia
ts = let
    GLMakie.closeall()
    scene = Scene()
    cam_relative!(scene)
    for _ in 1:20
        scatterlines!(scene, rand(Point2f, 10), color = rand(10), markersize = 10 .* rand(10))
    end

    screen = display(scene)

    cb = () -> begin
        for p in scene.plots
            attr = p.args[1]
            Makie.update!(attr, arg1 = rand(Point2f, 10), color = rand(10), markersize = 10 .* rand(10))
            # Makie.update!(attr, arg1 = attr[:arg1][], color = attr[:color][], markersize = attr[:markersize][])
        end
        return
    end

    GLMakie.render_asap(cb, screen, 10)
    GC.gc()

    @time ts = GLMakie.render_asap(cb, screen, 2000)
    ts
end

begin
    using Statistics
    f = Figure()
    a = Axis(f[1, 1], xlabel = "frametime [ms]", ylabel = "count",
        title = "2000 frames, experiments2, no outputs_dirty")
    xlims!(a, 0, 10); a.xticks = 0:1:10
    ylims!(a, 0, 500)
    hist!(a, 1000 .* ts, bins = 0:0.1:10)

    stats = [1000 * median(ts), 1000 * mean(ts)]
    vlines!(a, stats, color = [:orange, :red])
    text!(a, stats[1], 450, text = "median", color = :orange, strokecolor = :black, strokewidth = 2, offset = (5,0))
    text!(a, stats[2], 400, text = "mean", color = :red, strokecolor = :black, strokewidth = 2, offset = (5,0))
    f
end
```

</details>

The frametime benchmark plots are a bit cherry-picked. They often get a spike of frametimes around 1ms. I've chosen runs that don't have this to make things easier to compare. (I'm pretty sure the trend is the same either way)

### Compute-graph 
![Screenshot from 2024-12-09 18-16-03](https://github.com/user-attachments/assets/d40389cb-cfd7-4a29-ba56-7f2d530749ae)

### (2) dirty Computed
![Screenshot from 2024-12-09 18-23-59](https://github.com/user-attachments/assets/05e736ee-8858-469d-81e1-92da8a0658bb)

### (2.5) reworked Inputs
 ![Screenshot from 2024-12-09 15-32-43](https://github.com/user-attachments/assets/5d15bb4b-c3ee-42eb-b85d-516949a526fa)

### (3) no outputs_dirty
![Screenshot from 2024-12-09 20-43-12](https://github.com/user-attachments/assets/9f1cab39-3a2c-4542-b8a4-e73f9b2600e7) |
