### PR TITLE
add test for Billboard + transform_marker & fix CairoMakie scatter with markerspace = :data, rotation, transform_marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed `poly` pipeline for 3D and/or Float64 polygons that begin from an empty vector [#4615](https://github.com/MakieOrg/Makie.jl/pull/4615).
 - Fixed gaps in corners of `poly(Rect2(...))` stroke [#4664](https://github.com/MakieOrg/Makie.jl/pull/4664)
 - Fixed an issue where `reinterpret`ed arrays of line points were not handled correctly in CairoMakie [#4668](https://github.com/MakieOrg/Makie.jl/pull/4668).
+- Fixed various issues with `markerspace = :data`, `transform_marker = true` and `rotation` for scatter in CairoMakie (incorrect marker transformations, ignored transformations, Cairo state corruption) [#4663](https://github.com/MakieOrg/Makie.jl/pull/4663)
 
 ## [0.21.18] - 2024-12-12
 

--- a/CairoMakie/src/cairo-extension.jl
+++ b/CairoMakie/src/cairo-extension.jl
@@ -28,6 +28,14 @@ function cairo_font_face_destroy(font_face)
     )
 end
 
+function cairo_transform(ctx, cairo_matrix)
+    ccall(
+        (:cairo_transform, Cairo.libcairo),
+        Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}),
+        ctx.ptr, Ref(cairo_matrix)
+    )
+end
+
 function set_ft_font(ctx, font)
 
     font_face = Base.@lock font.lock ccall(

--- a/CairoMakie/src/precompiles.jl
+++ b/CairoMakie/src/precompiles.jl
@@ -18,7 +18,7 @@ end
 precompile(openurl, (String,))
 precompile(draw_atomic_scatter, (Scene, Cairo.CairoContext, Tuple{typeof(identity),typeof(identity)},
                     Vector{ColorTypes.RGBA{Float32}}, Vec{2,Float32}, ColorTypes.RGBA{Float32},
-                    Float32, BezierPath, Vec{2,Float32}, Quaternionf,
+                    Float32, BezierPath, Vec{3,Float32}, Quaternionf,
                     Mat4f, Vector{Point{2,Float32}},
                     Mat4f, Makie.FreeTypeAbstraction.FTFont, Symbol,
-                    Symbol))
+                    Symbol, Vector{Plane3f}, Bool))

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -356,7 +356,7 @@ function draw_atomic_scatter(
 
         ms = to_ndim(Vec3d, to_ndim(Vec2d, markersize, markersize), 1)
         p4d = transform * to_ndim(Point4d, to_ndim(Point3d, pos, 0), 1)
-        o = p4d[Vec(1, 2, 3)] ./ p4d[4] .+ model33 * to_ndim(Point3d, marker_offset, 0)
+        o = p4d[Vec(1, 2, 3)] ./ p4d[4] .+ model33 * to_ndim(Vec3d, mo, 0)
         proj_pos, mat, jl_mat = project_marker(scene, markerspace, o,
             ms, rotation, size_model, billboard)
 

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -367,8 +367,8 @@ function draw_atomic_scatter(
         # could be projected more accurately by projecting each point individually
         # and then building the shape.
 
-        # Can also skip if the x or y scale is ≈ 0
-        any(jl_mat * Vec2f(1) .≈ 0.0) && return
+        # Enclosed area of the marker must be at least 1 pixel?
+        (abs(det(jl_mat)) < 1) && return
 
         Cairo.set_source_rgba(ctx, rgbatuple(col)...)
         Cairo.save(ctx)
@@ -420,6 +420,7 @@ function draw_marker(ctx, marker::Char, font, pos, strokecolor, strokewidth, jl_
     cairo_font_face_destroy(cairoface)
 
     set_font_matrix(ctx, old_matrix)
+    return
 end
 
 function draw_marker(ctx, ::Type{<: Circle}, pos, strokecolor, strokewidth, mat)
@@ -432,7 +433,7 @@ function draw_marker(ctx, ::Type{<: Circle}, pos, strokecolor, strokewidth, mat)
     sc = to_color(strokecolor)
     Cairo.set_source_rgba(ctx, rgbatuple(sc)...)
     Cairo.stroke(ctx)
-    nothing
+    return
 end
 
 function draw_marker(ctx, ::Union{Makie.FastPixel,<:Type{<:Rect}}, pos, strokecolor, strokewidth, mat)
@@ -445,6 +446,7 @@ function draw_marker(ctx, ::Union{Makie.FastPixel,<:Type{<:Rect}}, pos, strokeco
     sc = to_color(strokecolor)
     Cairo.set_source_rgba(ctx, rgbatuple(sc)...)
     Cairo.stroke(ctx)
+    return
 end
 
 function draw_marker(ctx, beziermarker::BezierPath, pos, strokecolor, strokewidth, mat)
@@ -460,6 +462,7 @@ function draw_marker(ctx, beziermarker::BezierPath, pos, strokecolor, strokewidt
     Cairo.set_line_width(ctx, Float64(strokewidth))
     Cairo.stroke(ctx)
     Cairo.restore(ctx)
+    return
 end
 
 function draw_path(ctx, bp::BezierPath)
@@ -512,6 +515,7 @@ function draw_marker(ctx, marker::Matrix{T}, pos,
     Cairo.scale(ctx, 1.0 / w, 1.0 / h)
     Cairo.set_source_surface(ctx, marker_surf, -w/2, -h/2)
     Cairo.paint(ctx)
+    return
 end
 
 ################################################################################

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -352,6 +352,7 @@ function draw_atomic_scatter(
 
         isnan(pos) && return
         isnan(rotation) && return # matches GLMakie
+        isnan(markersize) && return
 
         ms = to_ndim(Vec3d, to_ndim(Vec2d, markersize, markersize), 1)
         p4d = transform * to_ndim(Point4d, to_ndim(Point3d, pos, 0), 1)
@@ -359,31 +360,22 @@ function draw_atomic_scatter(
         proj_pos, mat, jl_mat = project_marker(scene, markerspace, o,
             ms, rotation, size_model, billboard)
 
-        # TODO: fix the rest
-        scale = project_scale(scene, markerspace, markersize, size_model)
-        offset = project_scale(scene, markerspace, mo, size_model)
+        # mat and jl_mat are the same matrix, once as a CairoMatrix, once as a Mat2f
+        # They both describe an approximate basis transformation matrix from
+        # marker space to pixel space with scaling appropriate to markersize.
+        # Markers that can be drawn from points/vertices of shape (e.g. Rect)
+        # could be projected more accurately by projecting each point individually
+        # and then building the shape.
 
-        # TODO: not here
-        if m isa Char
-            charextent = Makie.FreeTypeAbstraction.get_extent(font, marker)
-            inkbb = Makie.FreeTypeAbstraction.inkboundingbox(charextent)
-
-            centering_offset = (Makie.origin(inkbb) .+ 0.5f0 .* widths(inkbb))
-            off = (jl_mat * ((1, -1) .* centering_offset))
-        end
+        # Can also skip if the x or y scale is ≈ 0
+        any(jl_mat * Vec2f(1) .≈ 0.0) && return
 
         Cairo.set_source_rgba(ctx, rgbatuple(col)...)
-
         Cairo.save(ctx)
-        # Setting a markersize of 0.0 somehow seems to break Cairos global state?
-        # At least it stops drawing any marker afterwards
-        # TODO, maybe there's something wrong somewhere else?
-        if !(isnan(scale) || norm(scale) ≈ 0.0)
-            if m isa Char
-                draw_marker(ctx, m, best_font(m, font), proj_pos, strokecolor, strokewidth, off, mat)
-            else
-                draw_marker(ctx, m, proj_pos, scale, strokecolor, strokewidth, offset, rotation)
-            end
+        if m isa Char
+            draw_marker(ctx, m, best_font(m, font), proj_pos, strokecolor, strokewidth, jl_mat, mat)
+        else
+            draw_marker(ctx, m, proj_pos, strokecolor, strokewidth, mat)
         end
         Cairo.restore(ctx)
     end
@@ -391,33 +383,30 @@ function draw_atomic_scatter(
     return
 end
 
-function draw_marker(ctx, marker::Char, font, pos, strokecolor, strokewidth, marker_offset, mat)
+function draw_marker(ctx, marker::Char, font, pos, strokecolor, strokewidth, jl_mat, mat)
     cairoface = set_ft_font(ctx, font)
 
+    # The given pos includes the user position which corresponds to the center
+    # of the marker and the user marker_offset which may shift the position.
+    # At this point we still need to center the character we draw. For that we
+    # get the character boundingbox where (0,0) is the anchor point:
     charextent = Makie.FreeTypeAbstraction.get_extent(font, marker)
     inkbb = Makie.FreeTypeAbstraction.inkboundingbox(charextent)
 
-    # scale normalized bbox by font size
-    inkbb_scaled = Rect2f(origin(inkbb), widths(inkbb))
+    # And calculate an offset to the the center of the marker
+    centering_offset = Makie.origin(inkbb) .+ 0.5f0 .* widths(inkbb)
+    # which we then transform from marker space to screen space using the
+    # local coordinate transform derived by project_marker()
+    # (Need yflip because Cairo's y coordinates are reversed)
+    char_offset = Vec2f(jl_mat * ((1, -1) .* centering_offset))
 
-    # flip y for the centering shift of the character because in Cairo y goes down
-    centering_offset = Vec2f(1, -1) .* (-origin(inkbb_scaled) .- 0.5f0 .* widths(inkbb_scaled))
-    # this is the origin where we actually have to place the glyph so it can be centered
-    charorigin = pos - Vec2f(marker_offset[1], marker_offset[2])
+    # The offset is then applied to pos and the marker placement is set
+    charorigin = pos - char_offset
+    Cairo.translate(ctx, charorigin[1], charorigin[2])
 
+    # The font matrix takes care of rotation, scaling and shearing of the marker
     old_matrix = get_font_matrix(ctx)
     set_font_matrix(ctx, mat)
-
-    # First, we translate to the point where the
-    # marker is supposed to go.
-    Cairo.translate(ctx, charorigin[1], charorigin[2])
-    # Then, we rotate the context by the
-    # appropriate amount,
-    # Cairo.rotate(ctx, to_2d_rotation(rotation))
-    # and apply a centering offset to account for
-    # the fact that text is shown from the (relative)
-    # bottom left corner.
-    # Cairo.translate(ctx, centering_offset[1], centering_offset[2])
 
     Cairo.move_to(ctx, 0, 0)
     Cairo.text_path(ctx, string(marker))
@@ -433,35 +422,24 @@ function draw_marker(ctx, marker::Char, font, pos, strokecolor, strokewidth, mar
     set_font_matrix(ctx, old_matrix)
 end
 
-function draw_marker(ctx, ::Type{<: Circle}, pos, scale, strokecolor, strokewidth, marker_offset, rotation)
-    pos += Point2f(marker_offset[1], -marker_offset[2])
-
-    if scale[1] != scale[2]
-        old_matrix = Cairo.get_matrix(ctx)
-        Cairo.scale(ctx, scale[1], scale[2])
-        Cairo.translate(ctx, pos[1]/scale[1], pos[2]/scale[2])
-        Cairo.arc(ctx, 0, 0, 0.5, 0, 2*pi)
-    else
-        Cairo.arc(ctx, pos[1], pos[2], scale[1]/2, 0, 2*pi)
-    end
-
+function draw_marker(ctx, ::Type{<: Circle}, pos, strokecolor, strokewidth, mat)
+    # There are already active transforms so we can't Cairo.set_matrix() here
+    Cairo.translate(ctx, pos[1], pos[2])
+    cairo_transform(ctx, mat)
+    Cairo.arc(ctx, 0, 0, 0.5, 0, 2*pi)
     Cairo.fill_preserve(ctx)
-
     Cairo.set_line_width(ctx, Float64(strokewidth))
-
     sc = to_color(strokecolor)
     Cairo.set_source_rgba(ctx, rgbatuple(sc)...)
     Cairo.stroke(ctx)
-    scale[1] != scale[2] && Cairo.set_matrix(ctx, old_matrix)
     nothing
 end
 
-function draw_marker(ctx, ::Union{Makie.FastPixel,<:Type{<:Rect}}, pos, scale, strokecolor, strokewidth,
-                     marker_offset, rotation)
-
-    Cairo.translate(ctx, pos[1] + marker_offset[1], pos[2] - marker_offset[2])
-    Cairo.rotate(ctx, to_2d_rotation(rotation))
-    Cairo.rectangle(ctx, -0.5scale[1], -0.5scale[2], scale...)
+function draw_marker(ctx, ::Union{Makie.FastPixel,<:Type{<:Rect}}, pos, strokecolor, strokewidth, mat)
+    # There are already active transforms so we can't Cairo.set_matrix() here
+    Cairo.translate(ctx, pos[1], pos[2])
+    cairo_transform(ctx, mat)
+    Cairo.rectangle(ctx, -0.5, -0.5, 1, 1)
     Cairo.fill_preserve(ctx)
     Cairo.set_line_width(ctx, Float64(strokewidth))
     sc = to_color(strokecolor)
@@ -469,11 +447,12 @@ function draw_marker(ctx, ::Union{Makie.FastPixel,<:Type{<:Rect}}, pos, scale, s
     Cairo.stroke(ctx)
 end
 
-function draw_marker(ctx, beziermarker::BezierPath, pos, scale, strokecolor, strokewidth, marker_offset, rotation)
+function draw_marker(ctx, beziermarker::BezierPath, pos, strokecolor, strokewidth, mat)
     Cairo.save(ctx)
-    Cairo.translate(ctx, pos[1] + marker_offset[1], pos[2] - marker_offset[2])
-    Cairo.rotate(ctx, to_2d_rotation(rotation))
-    Cairo.scale(ctx, scale[1], -scale[2]) # flip y for cairo
+    # There are already active transforms so we can't Cairo.set_matrix() here
+    Cairo.translate(ctx, pos[1], pos[2])
+    cairo_transform(ctx, mat)
+    Cairo.scale(ctx, 1, -1) # maybe to transition BezierPath y to Cairo y?
     draw_path(ctx, beziermarker)
     Cairo.fill_preserve(ctx)
     sc = to_color(strokecolor)
@@ -517,9 +496,9 @@ function path_command(ctx, c::EllipticalArc)
 end
 
 
-function draw_marker(ctx, marker::Matrix{T}, pos, scale,
-        strokecolor #= unused =#, strokewidth #= unused =#,
-        marker_offset, rotation) where T<:Colorant
+function draw_marker(ctx, marker::Matrix{T}, pos,
+    strokecolor #= unused =#, strokewidth #= unused =#,
+    mat) where T<:Colorant
 
     # convert marker to Cairo compatible image data
     marker = permutedims(marker, (2,1))
@@ -527,13 +506,13 @@ function draw_marker(ctx, marker::Matrix{T}, pos, scale,
 
     w, h = size(marker)
 
-    Cairo.translate(ctx, pos[1] + marker_offset[1], pos[2] - marker_offset[2])
-    Cairo.rotate(ctx, to_2d_rotation(rotation))
-    Cairo.scale(ctx, scale[1] / w, scale[2] / h)
+    # There are already active transforms so we can't Cairo.set_matrix() here
+    Cairo.translate(ctx, pos[1], pos[2])
+    cairo_transform(ctx, mat)
+    Cairo.scale(ctx, 1.0 / w, 1.0 / h)
     Cairo.set_source_surface(ctx, marker_surf, -w/2, -h/2)
     Cairo.paint(ctx)
 end
-
 
 ################################################################################
 #                                     Text                                     #

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -354,11 +354,10 @@ function draw_atomic_scatter(
         isnan(rotation) && return # matches GLMakie
         isnan(markersize) && return
 
-        ms = to_ndim(Vec3d, to_ndim(Vec2d, markersize, markersize), 1)
         p4d = transform * to_ndim(Point4d, to_ndim(Point3d, pos, 0), 1)
         o = p4d[Vec(1, 2, 3)] ./ p4d[4] .+ model33 * to_ndim(Vec3d, mo, 0)
         proj_pos, mat, jl_mat = project_marker(scene, markerspace, o,
-            ms, rotation, size_model, billboard)
+            markersize, rotation, size_model, billboard)
 
         # mat and jl_mat are the same matrix, once as a CairoMatrix, once as a Mat2f
         # They both describe an approximate basis transformation matrix from
@@ -621,9 +620,8 @@ function draw_glyph_collection(
             return
         end
 
-        scale3 = scale isa Number ? Vec3f(scale, scale, 1) : to_ndim(Vec3f, scale, 1)
-
-        glyphpos, mat, _ = project_marker(scene, markerspace, gp3, scale3, rotation, model33, id)
+        scale2 = scale isa Number ? Vec2d(scale, scale) : scale
+        glyphpos, mat, _ = project_marker(scene, markerspace, gp3, scale2, rotation, model33, id)
 
         Cairo.save(ctx)
         set_font_matrix(ctx, mat)

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -93,19 +93,19 @@ function project_position(@nospecialize(scenelike), space, point, model, yflip::
 end
 
 function project_marker(scene, markerspace, origin, scale, rotation, model, billboard = false)
-    scale3 = to_ndim(Vec3d, scale, 1)
+    scale3 = to_ndim(Vec2d, scale, first(scale))
     model33 = model[Vec(1,2,3), Vec(1,2,3)]
     origin3 = to_ndim(Point3d, origin, 0)
     return project_marker(scene, markerspace, origin3, scale3, rotation, model33, Mat4d(I), billboard)
 end
-function project_marker(scene, markerspace, origin::Point3, scale3::Vec3, rotation, model33::Mat3, id = Mat4d(I), billboard = false)
+function project_marker(scene, markerspace, origin::Point3, scale::Vec, rotation, model33::Mat3, id = Mat4d(I), billboard = false)
     # the CairoMatrix is found by transforming the right and up vector
     # of the marker into screen space and then subtracting the projected
     # origin. The resulting vectors give the directions in which the character
     # needs to be stretched in order to match the 3D projection
 
-    xvec = rotation * (model33 * (scale3[1] * Point3d(1, 0, 0)))
-    yvec = rotation * (model33 * (scale3[2] * Point3d(0, -1, 0)))
+    xvec = rotation * (model33 * (scale[1] * Point3d(1, 0, 0)))
+    yvec = rotation * (model33 * (scale[2] * Point3d(0, -1, 0)))
 
     proj_pos = _project_position(scene, markerspace, origin, id, true)
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -110,6 +110,44 @@ function project_scale(scene::Scene, space, s, model = Mat4d(I))
     end
 end
 
+function project_marker(scene, markerspace, origin, scale, rotation, model, billboard = false)
+    scale3 = to_ndim(Vec3d, scale, 1)
+    model33 = model[Vec(1,2,3), Vec(1,2,3)]
+    origin3 = to_ndim(Point3d, origin, 0)
+    return project_marker(scene, markerspace, origin3, scale3, rotation, model33, Mat4d(I), billboard)
+end
+function project_marker(scene, markerspace, origin::Point3, scale3::Vec3, rotation, model33::Mat3, id = Mat4d(I), billboard = false)
+    # the CairoMatrix is found by transforming the right and up vector
+    # of the marker into screen space and then subtracting the projected
+    # origin. The resulting vectors give the directions in which the character
+    # needs to be stretched in order to match the 3D projection
+
+    xvec = rotation * (model33 * (scale3[1] * Point3d(1, 0, 0)))
+    yvec = rotation * (model33 * (scale3[2] * Point3d(0, -1, 0)))
+
+    proj_pos = _project_position(scene, markerspace, origin, id, true)
+
+    if billboard && Makie.is_data_space(markerspace)
+        p4d = scene.camera.view[] * to_ndim(Point4d, origin, 1)
+        xproj = _project_position(scene, :eye, p4d[Vec(1,2,3)] / p4d[4] + xvec, id, true)
+        yproj = _project_position(scene, :eye, p4d[Vec(1,2,3)] / p4d[4] + yvec, id, true)
+    else
+        xproj = _project_position(scene, markerspace, origin + xvec, id, true)
+        yproj = _project_position(scene, markerspace, origin + yvec, id, true)
+    end
+
+    xdiff = xproj - proj_pos
+    ydiff = yproj - proj_pos
+
+    mat = Cairo.CairoMatrix(
+        xdiff[1], xdiff[2],
+        ydiff[1], ydiff[2],
+        0, 0,
+    )
+
+    return proj_pos, mat, Mat2f(xdiff..., ydiff...)
+end
+
 function project_shape(@nospecialize(scenelike), space, rect::Rect, model)
     mini = project_position(scenelike, space, minimum(rect), model)
     maxi = project_position(scenelike, space, maximum(rect), model)

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -92,24 +92,6 @@ function project_position(@nospecialize(scenelike), space, point, model, yflip::
     project_position(scene, Makie.transform_func(scenelike), space, point, model, yflip)
 end
 
-function project_scale(scene::Scene, space, s::Number, model = Mat4d(I))
-    project_scale(scene, space, Vec2d(s), model)
-end
-
-function project_scale(scene::Scene, space, s, model = Mat4d(I))
-    p4d = model * to_ndim(Vec4d, s, 0)
-    if is_data_space(space)
-        @inbounds p = (scene.camera.projectionview[] * p4d)[Vec(1, 2)]
-        return p .* scene.camera.resolution[] .* 0.5
-    elseif is_pixel_space(space)
-        return p4d[Vec(1, 2)]
-    elseif is_relative_space(space)
-        return p4d[Vec(1, 2)] .* scene.camera.resolution[]
-    else # clip
-        return p4d[Vec(1, 2)] .* scene.camera.resolution[] .* 0.5f0
-    end
-end
-
 function project_marker(scene, markerspace, origin, scale, rotation, model, billboard = false)
     scale3 = to_ndim(Vec3d, scale, 1)
     model33 = model[Vec(1,2,3), Vec(1,2,3)]

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -191,9 +191,7 @@ excludes = Set([
     "Textured meshscatter", # not yet implemented
     "Voxel - texture mapping", # not yet implemented
     "Miter Joints for line rendering", # CairoMakie does not show overlap here
-    "Scatter with FastPixel", # almost works, but scatter + markerspace=:data seems broken for 3D
     "picking", # Not implemented
-    "scatter marker_offset 3D with rotation", # missing support for 3D scatter with markerspace = :data
     "MetaMesh (Sponza)", # makes little sense without per pixel depth order
 ])
 

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -225,28 +225,36 @@ end
     s
 end
 
-@reference_test "scatter Billboard and transform_marker" begin
-    r = Rect3f(Point3f(-0.5), Vec3f(1))
-    ps = coordinates(r)
-    phis = collect(range(0, 2pi, length = 8))
-    quats = Makie.to_rotation(phis)
-    fig = Figure(size = (500, 800))
-    for (k, transform_marker) in zip(0:1, [true, false])
-        for (i, space, ms) in zip(1:2, [:data, :pixel], [1, 30])
-            for (j, rot, lbl) in zip(1:3, [Billboard(phis), phis, quats], ["Billboard", "angles", "Quaternion"])
-                Label(fig[i+2k, j][1,1], "$space | $lbl | $transform_marker", tellwidth = false)
-                a, p = scatter(fig[i+2k, j][2,1], ps, marker = 'L',
-                    strokewidth = 2, strokecolor = :black, color = :yellow,
-                    markersize = ms, markerspace = space, rotation = rot,
-                    transform_marker = transform_marker)
+# Circle and Rect have different paths in CairoMakie
+for (marker, name) in zip(
+    ['L', Rect, Circle, :utriangle, Makie.FileIO.load(Makie.assetpath("cow.png"))],
+    ["Char", "Rect", "Circle", "BezierPath", "image"])
 
-                Makie.rotate!(p, Vec3f(1, 0.5, 0.1), 1.0)
-                a.scene.camera_controls.settings[:center] = false
-                Makie.update_cam!(a.scene, r)
+    @reference_test "scatter Billboard and transform_marker for $name markers" begin
+        r = Rect3f(Point3f(-0.5), Vec3f(1))
+        ps = coordinates(r)
+        phis = collect(range(0, 2pi, length = 8))
+        quats = Makie.to_rotation(phis)
+
+        fig = Figure(size = (500, 800))
+        for (k, transform_marker) in zip(0:1, [true, false])
+            for (i, space, ms) in zip(1:2, [:data, :pixel], [1, 30])
+                for (j, rot, lbl) in zip(1:3, [Billboard(phis), phis, quats], ["Billboard", "angles", "Quaternion"])
+                    Label(fig[i+2k, j][1,1], "$space | $lbl | $transform_marker", tellwidth = false)
+                    a, p = scatter(fig[i+2k, j][2,1], ps, marker = marker,
+                        strokewidth = 2, strokecolor = :black, color = :yellow,
+                        markersize = ms, markerspace = space, rotation = rot,
+                        transform_marker = transform_marker)
+
+                    Makie.rotate!(p, Vec3f(1, 0.5, 0.1), 1.0)
+                    a.scene.camera_controls.settings[:center] = false
+                    Makie.update_cam!(a.scene, r)
+                end
             end
         end
+
+        fig
     end
-    fig
 end
 
 @reference_test "scatter with stroke" begin

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -225,6 +225,30 @@ end
     s
 end
 
+@reference_test "scatter Billboard and transform_marker" begin
+    r = Rect3f(Point3f(-0.5), Vec3f(1))
+    ps = coordinates(r)
+    phis = collect(range(0, 2pi, length = 8))
+    quats = Makie.to_rotation(phis)
+    fig = Figure(size = (500, 800))
+    for (k, transform_marker) in zip(0:1, [true, false])
+        for (i, space, ms) in zip(1:2, [:data, :pixel], [1, 30])
+            for (j, rot, lbl) in zip(1:3, [Billboard(phis), phis, quats], ["Billboard", "angles", "Quaternion"])
+                Label(fig[i+2k, j][1,1], "$space | $lbl | $transform_marker", tellwidth = false)
+                a, p = scatter(fig[i+2k, j][2,1], ps, marker = 'L',
+                    strokewidth = 2, strokecolor = :black, color = :yellow,
+                    markersize = ms, markerspace = space, rotation = rot,
+                    transform_marker = transform_marker)
+
+                Makie.rotate!(p, Vec3f(1, 0.5, 0.1), 1.0)
+                a.scene.camera_controls.settings[:center] = false
+                Makie.update_cam!(a.scene, r)
+            end
+        end
+    end
+    fig
+end
+
 @reference_test "scatter with stroke" begin
     s = Scene(size = (350, 700), camera = campixel!)
 

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -416,6 +416,8 @@ end
 function space_to_clip(cam::Camera, space::Symbol, projectionview::Bool=true)
     if is_data_space(space)
         return projectionview ? cam.projectionview[] : cam.projection[]
+    elseif space == :eye
+        return cam.projection[]
     elseif is_pixel_space(space)
         return cam.pixel_space[]
     elseif is_relative_space(space)
@@ -429,6 +431,8 @@ end
 
 function clip_to_space(cam::Camera, space::Symbol)
     if is_data_space(space)
+        return inv(cam.projectionview[])
+    elseif space == :eye
         return inv(cam.projectionview[])
     elseif is_pixel_space(space)
         w, h = cam.resolution[]


### PR DESCRIPTION
# Description

Adds tests for the different rotation types in different markerspaces with different transform_marker settings.

Also fixes `markerspace = :data`  not working correctly in CairoMakie and fixes a bunch of issues with CairoMakie not using rotation and transform_marker correctly.

Fixes #2291, fixes #4609

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) & test extension

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
