### PR TITLE
Fix poly Circle & Rect stroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added `transform_marker` attribute to meshscatter and changed the default behavior to not transform marker/mesh vertices [#4606](https://github.com/MakieOrg/Makie.jl/pull/4606)
 - Fixed some issues with meshscatter not correctly transforming with transform functions and float32 rescaling [#4606](https://github.com/MakieOrg/Makie.jl/pull/4606)
 - Fixed `poly` pipeline for 3D and/or Float64 polygons that begin from an empty vector [#4615](https://github.com/MakieOrg/Makie.jl/pull/4615).
+- Fixed gaps in corners of `poly(Rect2(...))` stroke [#4664](https://github.com/MakieOrg/Makie.jl/pull/4664)
 
 ## [0.21.18] - 2024-12-12
 

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -17,21 +17,21 @@ end
 
     # Shaders for scatter + linesegments + poly etc (axis)
     display(screen, scatter(1:4))
-    @test length(cache.shader_cache) == 16
-    @test length(cache.template_cache) == 16
-    @test length(cache.program_cache) == 10
+    @test length(cache.shader_cache) == 18
+    @test length(cache.template_cache) == 18
+    @test length(cache.program_cache) == 11
 
     # No new shaders should be added:
     display(screen, scatter(1:4))
-    @test length(cache.shader_cache) == 16
-    @test length(cache.template_cache) == 16
-    @test length(cache.program_cache) == 10
+    @test length(cache.shader_cache) == 18
+    @test length(cache.template_cache) == 18
+    @test length(cache.program_cache) == 11
 
     # Same for linesegments
     display(screen, linesegments(1:4))
-    @test length(cache.shader_cache) == 16
-    @test length(cache.template_cache) == 16
-    @test length(cache.program_cache) == 10
+    @test length(cache.shader_cache) == 18
+    @test length(cache.template_cache) == 18
+    @test length(cache.program_cache) == 11
 
     # Lines hasn't been compiled so one new program should be added
     display(screen, lines(1:4))

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -9,7 +9,7 @@ end
 @testset "shader cache" begin
     GLMakie.closeall()
     screen = display(GLMakie.Screen(visible = false), Figure())
-    cache = screen.shader_cache
+    cache = screen.shader_cache;
     # Postprocessing shaders
     @test length(cache.shader_cache) == 5
     @test length(cache.template_cache) == 5
@@ -33,17 +33,17 @@ end
     @test length(cache.template_cache) == 18
     @test length(cache.program_cache) == 11
 
-    # Lines hasn't been compiled so one new program should be added
-    display(screen, lines(1:4))
-    @test length(cache.shader_cache) == 18
-    @test length(cache.template_cache) == 18
-    @test length(cache.program_cache) == 11
+    # heatmap hasn't been compiled so one new program should be added
+    display(screen, heatmap([1,2,2.5,3], [1,2,2.5,3], rand(4,4)))
+    @test length(cache.shader_cache) == 20
+    @test length(cache.template_cache) == 20
+    @test length(cache.program_cache) == 12
 
     # For second time no new shaders should be added
-    display(screen, lines(1:4))
-    @test length(cache.shader_cache) == 18
-    @test length(cache.template_cache) == 18
-    @test length(cache.program_cache) == 11
+    display(screen, heatmap([1,2,2.5,3], [1,2,2.5,3], rand(4,4)))
+    @test length(cache.shader_cache) == 20
+    @test length(cache.template_cache) == 20
+    @test length(cache.program_cache) == 12
 end
 
 @testset "unit tests" begin

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -151,6 +151,12 @@ end
     linesegments!(ax,
         [Point2f(50 + i, 50 + i) => Point2f(i + 70, i + 70) for i = 1:100:400], linewidth=8, color=:purple
     )
+    poly!(ax, [Polygon(decompose(Point2f, Rect2f(150, 0, 100, 100))), Polygon(decompose(Point2f, Circle(Point2f(350, 200), 50)))],
+        color=:gray, strokewidth=10, strokecolor=:red)
+    # single objects
+    poly!(ax, Circle(Point2f(50, 350), 50), color=:gray, strokewidth=10, strokecolor=:red)
+    poly!(ax, Rect2f(0, 150, 100, 100), color=:gray, strokewidth=10, strokecolor=:red)
+    poly!(ax, Polygon(decompose(Point2f, Rect2f(150, 300, 100, 100))), color=:gray, strokewidth=10, strokecolor=:red)
     fig
 end
 

--- a/src/basic_recipes/poly.jl
+++ b/src/basic_recipes/poly.jl
@@ -146,7 +146,7 @@ function to_lines(polygon::AbstractVector{<: VecTypes})
     return result
 end
 
-function plot!(plot::Poly{<: Tuple{<: Union{Polygon, MultiPolygon, AbstractVector{<: PolyElements}}}})
+function plot!(plot::Poly{<: Tuple{<: Union{Polygon, MultiPolygon, Rect2, Circle, AbstractVector{<: PolyElements}}}})
     geometries = plot[1]
     transform_func = plot.transformation.transform_func
     meshes = lift(poly_convert, plot, geometries, transform_func)


### PR DESCRIPTION
# Description

The breaking pr changed `poly(Circle(...))` to use the Circle wireframe for stroke, which this pr fixes.

It also changes (fixes?) `Rect2` stroke to be continuous, i.e. avoid corners like this:

![image](https://github.com/user-attachments/assets/3417d492-c855-46a8-9199-d9b49971e38b)

Also extends a refimg test to test these things

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
