### PR TITLE
Fix CairoMakie not being able to plot exotic point arrays in lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Added `transform_marker` attribute to meshscatter and changed the default behavior to not transform marker/mesh vertices [#4606](https://github.com/MakieOrg/Makie.jl/pull/4606)
 - Fixed some issues with meshscatter not correctly transforming with transform functions and float32 rescaling [#4606](https://github.com/MakieOrg/Makie.jl/pull/4606)
 - Fixed `poly` pipeline for 3D and/or Float64 polygons that begin from an empty vector [#4615](https://github.com/MakieOrg/Makie.jl/pull/4615).
-- Fixed an issue where `reinterpret`ed arrays of points were not handled correctly in CairoMakie [#4668](https://github.com/MakieOrg/Makie.jl/pull/4668).
+- Fixed an issue where `reinterpret`ed arrays of line points were not handled correctly in CairoMakie [#4668](https://github.com/MakieOrg/Makie.jl/pull/4668).
 
 ## [0.21.18] - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Added `transform_marker` attribute to meshscatter and changed the default behavior to not transform marker/mesh vertices [#4606](https://github.com/MakieOrg/Makie.jl/pull/4606)
 - Fixed some issues with meshscatter not correctly transforming with transform functions and float32 rescaling [#4606](https://github.com/MakieOrg/Makie.jl/pull/4606)
 - Fixed `poly` pipeline for 3D and/or Float64 polygons that begin from an empty vector [#4615](https://github.com/MakieOrg/Makie.jl/pull/4615).
+- Fixed an issue where `reinterpret`ed arrays of points were not handled correctly in CairoMakie [#4668](https://github.com/MakieOrg/Makie.jl/pull/4668).
 
 ## [0.21.18] - 2024-12-12
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -193,7 +193,7 @@ end
 
 
 
-function project_line_points(scene, plot::T, positions, colors, linewidths) where {T <: Union{Lines, LineSegments}}
+function project_line_points(scene, plot::T, positions::AbstractArray{<: Makie.VecTypes{N, FT}}, colors, linewidths) where {T <: Union{Lines, LineSegments}, N, FT <: Real}
     # If colors are defined per point they need to be interpolated like positions
     # at clip planes
     per_point_colors = colors isa AbstractArray
@@ -202,7 +202,7 @@ function project_line_points(scene, plot::T, positions, colors, linewidths) wher
     space = (plot.space[])::Symbol
     model = (plot.model[])::Mat4d
     # Standard transform from input space to clip space
-    points = Makie.apply_transform(transform_func(plot), positions, space)::typeof(positions)
+    points = Makie.apply_transform(transform_func(plot), positions, space)::AbstractVector{Point{N, FT}}
     f32convert = Makie.f32_convert_matrix(scene.float32convert, space)
     transform = Makie.space_to_clip(scene.camera, space) * f32convert * model
     clip_points = map(points) do point

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -197,7 +197,9 @@ function project_line_points(scene, plot::T, positions::AbstractArray{<: Makie.V
 
     # Standard transform from input space to clip space
     # Note that this is type unstable, so there is a function barrier in place.
+    space = (plot.space[])::Symbol
     points = Makie.apply_transform(transform_func(plot), positions, space)::AbstractVector{Point{N, FT}}
+
     return project_transformed_line_points(scene, plot, points, colors, linewidths)
 end
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -194,6 +194,15 @@ end
 
 
 function project_line_points(scene, plot::T, positions::AbstractArray{<: Makie.VecTypes{N, FT}}, colors, linewidths) where {T <: Union{Lines, LineSegments}, N, FT <: Real}
+
+    # Standard transform from input space to clip space
+    # Note that this is type unstable, so there is a function barrier in place.
+    points = Makie.apply_transform(transform_func(plot), positions, space)::AbstractVector{Point{N, FT}}
+    return project_transformed_line_points(scene, plot, points, colors, linewidths)
+end
+
+function project_transformed_line_points(scene, plot::T, points::AbstractArray{<: Makie.VecTypes{N, FT}}, colors, linewidths) where {T <: Union{Lines, LineSegments}, N, FT <: Real}
+    # Note that here, `points` has already had `transform_func` applied.
     # If colors are defined per point they need to be interpolated like positions
     # at clip planes
     per_point_colors = colors isa AbstractArray
@@ -201,8 +210,6 @@ function project_line_points(scene, plot::T, positions::AbstractArray{<: Makie.V
 
     space = (plot.space[])::Symbol
     model = (plot.model[])::Mat4d
-    # Standard transform from input space to clip space
-    points = Makie.apply_transform(transform_func(plot), positions, space)::AbstractVector{Point{N, FT}}
     f32convert = Makie.f32_convert_matrix(scene.float32convert, space)
     transform = Makie.space_to_clip(scene.camera, space) * f32convert * model
     clip_points = map(points) do point

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -198,7 +198,7 @@ function project_line_points(scene, plot::T, positions::AbstractArray{<: Makie.V
     # Standard transform from input space to clip space
     # Note that this is type unstable, so there is a function barrier in place.
     space = (plot.space[])::Symbol
-    points = Makie.apply_transform(transform_func(plot), positions, space)::AbstractVector{Point{N, FT}}
+    points = Makie.apply_transform(transform_func(plot), positions, space)
 
     return project_transformed_line_points(scene, plot, points, colors, linewidths)
 end

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -304,4 +304,15 @@ end
     ps, _, _ = CairoMakie.project_line_points(a.scene, ls, ls_points, nothing, nothing)
     @test length(ps) >= 6 # at least 6 points: [2,3,3,4,4,5]
     @test all(ref -> findfirst(p -> isapprox(p, ref, atol = 1e-4), ps) !== nothing, necessary_points)
+
+    # Check that `reinterpret`ed arrays of points are handled correctly
+    # ref. https://github.com/MakieOrg/Makie.jl/issues/4661
+
+    data = reinterpret(Point2f, rand(Point2f, 10) .=> rand(Point2f, 10))
+
+    f, a, p = lines(data)
+    Makie.update_state_before_display!(f)
+    ps, _, _ = @test_nowarn CairoMakie.project_line_points(a.scene, p, data, nothing, nothing)
+    @test length(ps) == length(data) # this should never clip!
+
 end


### PR DESCRIPTION
# Description

Fixes #4661

Splits out the CairoMakie `project_line_points` into a main entry point that applies `transform_func`, and a second internal function.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
