### PR TITLE
Allow GLMakie to change the title of a screen after its creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fixed gaps in corners of `poly(Rect2(...))` stroke [#4664](https://github.com/MakieOrg/Makie.jl/pull/4664)
 - Fixed an issue where `reinterpret`ed arrays of line points were not handled correctly in CairoMakie [#4668](https://github.com/MakieOrg/Makie.jl/pull/4668).
 - Fixed various issues with `markerspace = :data`, `transform_marker = true` and `rotation` for scatter in CairoMakie (incorrect marker transformations, ignored transformations, Cairo state corruption) [#4663](https://github.com/MakieOrg/Makie.jl/pull/4663)
+- It is now possible to change the title of a `GLFW.Window` with `GLMakie.set_screen_title!(screen::Screen, title::String)` [#4677](https://github.com/MakieOrg/Makie.jl/pull/4677).
 
 ## [0.21.18] - 2024-12-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Fixed gaps in corners of `poly(Rect2(...))` stroke [#4664](https://github.com/MakieOrg/Makie.jl/pull/4664)
 - Fixed an issue where `reinterpret`ed arrays of line points were not handled correctly in CairoMakie [#4668](https://github.com/MakieOrg/Makie.jl/pull/4668).
 - Fixed various issues with `markerspace = :data`, `transform_marker = true` and `rotation` for scatter in CairoMakie (incorrect marker transformations, ignored transformations, Cairo state corruption) [#4663](https://github.com/MakieOrg/Makie.jl/pull/4663)
-- It is now possible to change the title of a `GLFW.Window` with `GLMakie.set_screen_title!(screen::Screen, title::String)` [#4677](https://github.com/MakieOrg/Makie.jl/pull/4677).
+- It is now possible to change the title of a `GLFW.Window` with `GLMakie.set_title!(screen::Screen, title::String)` [#4677](https://github.com/MakieOrg/Makie.jl/pull/4677).
 
 ## [0.21.18] - 2024-12-12
 

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -440,16 +440,16 @@ function set_screen_visibility!(nw::GLFW.Window, visible::Bool)
     GLFW.set_visibility!(nw, visible)
 end
 
-function set_screen_title!(screen::Screen, title::String)
+function set_title!(screen::Screen, title::String)
     if !screen.owns_glscreen
         error(unimplemented_error)
     end
 
-    set_screen_title!(screen.glscreen, title)
+    set_title!(screen.glscreen, title)
     screen.config.title = title
 end
 
-function set_screen_title!(nw::GLFW.Window, title::String)
+function set_title!(nw::GLFW.Window, title::String)
     @assert nw.handle !== C_NULL
     GLFW.SetWindowTitle(nw, title)
 end

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -440,6 +440,20 @@ function set_screen_visibility!(nw::GLFW.Window, visible::Bool)
     GLFW.set_visibility!(nw, visible)
 end
 
+function set_screen_title!(screen::Screen, title::String)
+    if !screen.owns_glscreen
+        error(unimplemented_error)
+    end
+
+    set_screen_title!(screen.glscreen, title)
+    screen.config.title = title
+end
+
+function set_screen_title!(nw::GLFW.Window, title::String)
+    @assert nw.handle !== C_NULL
+    GLFW.SetWindowTitle(nw, title)
+end
+
 function display_scene!(screen::Screen, scene::Scene)
     @debug("display scene on screen")
     resize!(screen, size(scene)...)


### PR DESCRIPTION
# Description

Fixes #4665  

Previously, `GLFW.SetWindowTitle()` was needed, which required adding the GLFW package to the script. This change just wraps `GLFW.SetWindowTitle()` into `GLMakie.set_screen_title!()`, and modifies screen.config.title to store the new title.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)