### PR TITLE
skip minorticks calculations when they are not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Changed minorticks to skip computation when they are not visible [#4681](https://github.com/MakieOrg/Makie.jl/pull/4681)
+
 ## [0.22.0] - 2024-12-12
 
 - Updated to GeometryBasics 0.5: [GeometryBasics#173](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/173), [GeometryBasics#219](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/219) [#4319](https://github.com/MakieOrg/Makie.jl/pull/4319)

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -439,8 +439,10 @@ function LineAxis(parent::Scene, attrs::Attributes)
     minortickvalues = Observable(Float64[]; ignore_equal_values=true)
     minortickpositions = Observable(Point2f[]; ignore_equal_values=true)
 
-    onany(parent, tickvalues, minorticks) do tickvalues, minorticks
-        minortickvalues[] = get_minor_tickvalues(minorticks, attrs.scale[], tickvalues, limits[]...)
+    onany(parent, tickvalues, minorticks, minorticksvisible) do tickvalues, minorticks, visible
+        if visible
+            minortickvalues[] = get_minor_tickvalues(minorticks, attrs.scale[], tickvalues, limits[]...)
+        end
         return
     end
 

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -212,6 +212,23 @@ end
     end
 end
 
+@testset "Minor tick skip" begin
+    # Verify that minor ticks aren't calculated if they are not needed
+    f,a,p = scatter(1:10);
+    a.xminortickcolor[] = :red
+    Makie.update_state_before_display!(f)
+    plots = filter(p -> p.color[] == :red, a.blockscene.plots)
+    for p in plots
+        @test isempty(p.args[1][])
+        @test !p.visible[]
+    end
+    a.xminorticksvisible[] = true
+    for p in plots
+        @test !isempty(p.args[1][])
+        @test p.visible[]
+    end
+end
+
 @testset "MultiplesTicks strip_zero" begin
     default = MultiplesTicks(5, pi, "π")
     strip = MultiplesTicks(5, pi, "π"; strip_zero=true)

--- a/test/makielayout.jl
+++ b/test/makielayout.jl
@@ -214,7 +214,7 @@ end
 
 @testset "Minor tick skip" begin
     # Verify that minor ticks aren't calculated if they are not needed
-    f,a,p = scatter(1:10);
+    f,a,_ = scatter(1:10, axis = (xticksmirrored = true,));
     a.xminortickcolor[] = :red
     Makie.update_state_before_display!(f)
     plots = filter(p -> p.color[] == :red, a.blockscene.plots)


### PR DESCRIPTION
# Description

Fixes #4608

Skips minortick generation when they are not shown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
