### PR TITLE
Fix px_per_unit scaling while rendering in GLMakie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix `px_per_unit != 1` not getting fit to the interactive window size in GLMakie [#4687](https://github.com/MakieOrg/Makie.jl/pull/4687)
+
 ## [0.22.0] - 2024-12-12
 
 - Updated to GeometryBasics 0.5: [GeometryBasics#173](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/173), [GeometryBasics#219](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/219) [#4319](https://github.com/MakieOrg/Makie.jl/pull/4319)

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -285,15 +285,12 @@ function to_screen_postprocessor(framebuffer, shader_cache, screen_fb_id = nothi
     pass = RenderObject(data, shader, PostprocessPrerender(), nothing)
     pass.postrenderfunction = () -> draw_fullscreen(pass.vertexarray.id)
 
-    full_render = screen -> begin
+    full_render = (screen, size) -> begin
         # transfer everything to the screen
         default_id = isnothing(screen_fb_id) ? 0 : screen_fb_id[]
         # GLFW uses 0, Gtk uses a value that we have to probe at the beginning of rendering
         glBindFramebuffer(GL_FRAMEBUFFER, default_id)
-        # This includes px_per_unit scaling. The final output does not, so it
-        # needs to be removed (also true for size(screen), size(framebuffer), ...)
-        w, h = framebuffer_size(screen) ./ screen.px_per_unit[]
-        glViewport(0, 0, w, h)
+        glViewport(0, 0, size...)
         glClear(GL_COLOR_BUFFER_BIT)
         GLAbstraction.render(pass) # copy postprocess
     end

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -290,7 +290,10 @@ function to_screen_postprocessor(framebuffer, shader_cache, screen_fb_id = nothi
         default_id = isnothing(screen_fb_id) ? 0 : screen_fb_id[]
         # GLFW uses 0, Gtk uses a value that we have to probe at the beginning of rendering
         glBindFramebuffer(GL_FRAMEBUFFER, default_id)
-        glViewport(0, 0, framebuffer_size(screen)...)
+        # This includes px_per_unit scaling. The final output does not, so it
+        # needs to be removed (also true for size(screen), size(framebuffer), ...)
+        w, h = framebuffer_size(screen) ./ screen.px_per_unit[]
+        glViewport(0, 0, w, h)
         glClear(GL_COLOR_BUFFER_BIT)
         GLAbstraction.render(pass) # copy postprocess
     end

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -285,12 +285,12 @@ function to_screen_postprocessor(framebuffer, shader_cache, screen_fb_id = nothi
     pass = RenderObject(data, shader, PostprocessPrerender(), nothing)
     pass.postrenderfunction = () -> draw_fullscreen(pass.vertexarray.id)
 
-    full_render = (screen, size) -> begin
+    full_render = (screen) -> begin
         # transfer everything to the screen
         default_id = isnothing(screen_fb_id) ? 0 : screen_fb_id[]
         # GLFW uses 0, Gtk uses a value that we have to probe at the beginning of rendering
         glBindFramebuffer(GL_FRAMEBUFFER, default_id)
-        glViewport(0, 0, size...)
+        glViewport(0, 0, screen.size...)
         glClear(GL_COLOR_BUFFER_BIT)
         GLAbstraction.render(pass) # copy postprocess
     end

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -48,10 +48,9 @@ function render_frame(screen::Screen; resize_buffers=true)
     # render order here may introduce artifacts because of that.
 
     fb = screen.framebuffer
-    screen_size = size(screen.scene::Scene)
     if resize_buffers
         ppu = screen.px_per_unit[]
-        resize!(fb, round.(Int, ppu .* screen_size)...)
+        resize!(fb, round.(Int, ppu .* size(screen.scene::Scene))...)
     end
 
     # prepare stencil (for sub-scenes)
@@ -102,7 +101,7 @@ function render_frame(screen::Screen; resize_buffers=true)
     screen.postprocessors[3].render(screen)
 
     # transfer everything to the screen
-    screen.postprocessors[4].render(screen, screen_size)
+    screen.postprocessors[4].render(screen)
 
     return
 end

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -27,6 +27,8 @@ end
 Renders a single frame of a `window`
 """
 function render_frame(screen::Screen; resize_buffers=true)
+    isnothing(screen.scene) && return
+
     nw = to_native(screen)
     ShaderAbstractions.switch_context!(nw)
 
@@ -46,9 +48,10 @@ function render_frame(screen::Screen; resize_buffers=true)
     # render order here may introduce artifacts because of that.
 
     fb = screen.framebuffer
-    if resize_buffers && !isnothing(screen.scene)
+    screen_size = size(screen.scene::Scene)
+    if resize_buffers
         ppu = screen.px_per_unit[]
-        resize!(fb, round.(Int, ppu .* size(screen.scene))...)
+        resize!(fb, round.(Int, ppu .* screen_size)...)
     end
 
     # prepare stencil (for sub-scenes)
@@ -99,7 +102,7 @@ function render_frame(screen::Screen; resize_buffers=true)
     screen.postprocessors[3].render(screen)
 
     # transfer everything to the screen
-    screen.postprocessors[4].render(screen)
+    screen.postprocessors[4].render(screen, screen_size)
 
     return
 end


### PR DESCRIPTION
# Description

The `framebuffer_size` optimization from #4485 broke rendering with `px_per_unit != 1` for me. For example
```julia
f,a,p = scatter(rand(10))
# img = Makie.save("px_per_unit.png", f)
screen = display(f, px_per_unit = 0.5)
```
results in:

| render | saved | render with fix |
| --- | --- | --- |
|  ![Screenshot 2024-12-22 192731](https://github.com/user-attachments/assets/a1e35da1-5641-4843-833e-5214fc013022) | ![px_per_unit](https://github.com/user-attachments/assets/ac517796-8894-40d6-8905-6739a7531dba) | ![Screenshot 2024-12-22 192744](https://github.com/user-attachments/assets/e96c6385-0dbf-4a94-be37-9dd2d22870d9) |

The current version sets the viewport of the final output to the size of the framebuffer color attachment, which is scaled by px_per_unit. The final output is however sized based on real pixels, so we only draw to half of them like this.

This is not caught by tests because they rely on `colorbuffer()` which reads the framebuffer color attachment, which the copy-to-screen task does not affect.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
