### PR TITLE
Make cleanup of OpenGL objects explicit in GLMakie

### DIFF
--- a/GLMakie/src/GLAbstraction/GLAbstraction.jl
+++ b/GLMakie/src/GLAbstraction/GLAbstraction.jl
@@ -18,6 +18,10 @@ import FixedPointNumbers: N0f8, N0f16, N0f8, Normed
 
 import Base: merge, resize!, similar, length, getindex, setindex!
 
+# Debug tools
+require_context() = nothing # implemented in GLMakie/glwindow
+export require_context
+
 include("AbstractGPUArray.jl")
 
 #Methods which get overloaded by GLExtendedFunctions.jl:

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -21,6 +21,7 @@ When rendering a specialised list of Renderables, we can do some optimizations
 function render(list::Vector{RenderObject{Pre}}) where Pre
     isempty(list) && return nothing
     first(list).prerenderfunction()
+    require_context(first(list).context)
     vertexarray = first(list).vertexarray
     program = vertexarray.program
     glUseProgram(program.id)
@@ -50,6 +51,7 @@ function render(list::Vector{RenderObject{Pre}}) where Pre
             end
         end
         renderobject.postrenderfunction()
+        require_context(renderobject.context)
     end
     # we need to assume, that we're done here, which is why
     # we need to bind VertexArray to 0.
@@ -68,6 +70,7 @@ a lot of objects.
 """
 function render(renderobject::RenderObject, vertexarray=renderobject.vertexarray)
     if renderobject.visible
+        require_context(renderobject.context)
         renderobject.prerenderfunction()
         setup_clip_planes(to_value(get(renderobject.uniforms, :num_clip_planes, 0)))
         program = vertexarray.program
@@ -91,6 +94,7 @@ function render(renderobject::RenderObject, vertexarray=renderobject.vertexarray
         bind(vertexarray)
         renderobject.postrenderfunction()
         glBindVertexArray(0)
+        require_context(renderobject.context)
     end
     return
 end

--- a/GLMakie/src/GLAbstraction/GLShader.jl
+++ b/GLMakie/src/GLAbstraction/GLShader.jl
@@ -103,6 +103,20 @@ function ShaderCache(context)
     )
 end
 
+function unsafe_free(cache::ShaderCache)
+    require_context(cache.context)
+    for (k, v) in cache.shader_cache
+        for (k2, shader) in v
+            unsafe_free(shader)
+        end
+    end
+    for program in values(cache.program_cache)
+        unsafe_free(program)
+    end
+    require_context(cache.context)
+    return
+end
+
 abstract type AbstractLazyShader end
 
 struct LazyShader <: AbstractLazyShader

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -523,3 +523,7 @@ end
 function free(x::GLVertexArray)
     @assert x.id == 0 "Must be freed explicitly"
 end
+
+function free(x::Texture)
+    @assert x.id == 0 "Must be freed explicitly"
+end

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -497,10 +497,10 @@ function unsafe_free(x::GLVertexArray)
     GLAbstraction.context_alive(x.context) || return
     GLAbstraction.switch_context!(x.context)
     for (key, buffer) in x.buffers
-        free(buffer)
+        unsafe_free(buffer)
     end
     if x.indices isa GPUArray
-        free(x.indices)
+        unsafe_free(x.indices)
     end
     id = Ref(x.id)
     glDeleteVertexArrays(1, id)
@@ -513,5 +513,13 @@ function free(x::Shader)
 end
 
 function free(x::GLProgram)
+    @assert x.id == 0 "Must be freed explicitly"
+end
+
+function free(x::GLBuffer)
+    @assert x.id == 0 "Must be freed explicitly"
+end
+
+function free(x::GLVertexArray)
     @assert x.id == 0 "Must be freed explicitly"
 end

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -455,6 +455,7 @@ function unsafe_free(x::GLProgram)
     GLAbstraction.context_alive(x.context) || return
     GLAbstraction.switch_context!(x.context)
     glDeleteProgram(x.id)
+    x.id = 0
     return
 end
 
@@ -463,6 +464,7 @@ function unsafe_free(x::Shader)
     GLAbstraction.context_alive(x.context) || return
     GLAbstraction.switch_context!(x.context)
     glDeleteShader(x.id)
+    x.id = 0
     return
 end
 
@@ -504,4 +506,12 @@ function unsafe_free(x::GLVertexArray)
     glDeleteVertexArrays(1, id)
     x.id = 0
     return
+end
+
+function free(x::Shader)
+    @assert x.id == 0 "Must be freed explicitly"
+end
+
+function free(x::GLProgram)
+    @assert x.id == 0 "Must be freed explicitly"
 end

--- a/GLMakie/src/GLAbstraction/GLTypes.jl
+++ b/GLMakie/src/GLAbstraction/GLTypes.jl
@@ -27,9 +27,10 @@ struct Shader
     typ::GLenum
     id::GLuint
     context::GLContext
-    function Shader(name, source, typ, id)
-        new(Symbol(name), source, typ, id, current_context())
-    end
+end
+
+function Shader(name, source, typ, id)
+    new(Symbol(name), source, typ, id, current_context())
 end
 
 function Shader(name, source::Vector{UInt8}, typ)

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -431,7 +431,7 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::Union{Sca
                 gl_attributes[:shape] = shape
                 get!(gl_attributes, :distancefield) do
                     if shape[] === Cint(DISTANCEFIELD)
-                        return get_texture!(atlas)
+                        return get_texture!(screen.glscreen, atlas)
                     else
                         return nothing
                     end
@@ -642,7 +642,7 @@ function draw_atomic(screen::Screen, scene::Scene,
         gl_attributes[:quad_offset] = quad_offset
         gl_attributes[:marker_offset] = char_offset
         gl_attributes[:uv_offset_width] = uv_offset_width
-        gl_attributes[:distancefield] = get_texture!(atlas)
+        gl_attributes[:distancefield] = get_texture!(screen.glscreen, atlas)
         gl_attributes[:visible] = plot.visible
         gl_attributes[:fxaa] = get(plot, :fxaa, Observable(false))
         gl_attributes[:depthsorting] = get(plot, :depthsorting, false)
@@ -740,7 +740,7 @@ function mesh_inner(screen::Screen, mesh, transfunc, gl_attributes, plot, space=
     color = pop!(gl_attributes, :color)
     interp = to_value(pop!(gl_attributes, :interpolate, true))
     interp = interp ? :linear : :nearest
-    
+
     if to_value(color) isa Colorant
         gl_attributes[:vertex_color] = color
         delete!(gl_attributes, :color_map)
@@ -760,7 +760,7 @@ function mesh_inner(screen::Screen, mesh, transfunc, gl_attributes, plot, space=
     elseif to_value(color) isa ShaderAbstractions.Sampler
         gl_attributes[:image] = Texture(lift(el32convert, plot, color))
         delete!(gl_attributes, :color_map)
-        delete!(gl_attributes, :color_norm)    
+        delete!(gl_attributes, :color_norm)
     elseif to_value(color) isa AbstractMatrix{<:Colorant}
         gl_attributes[:image] = Texture(lift(el32convert, plot, color), minfilter = interp)
         delete!(gl_attributes, :color_map)

--- a/GLMakie/src/gl_backend.jl
+++ b/GLMakie/src/gl_backend.jl
@@ -22,7 +22,7 @@ function cleanup_texture_atlas!(context)
     for (atlas, ctx) in to_delete
         tex, func = pop!(atlas_texture_cache, (atlas, ctx))
         Makie.remove_font_render_callback!(atlas, func)
-        GLAbstraction.free(tex)
+        GLAbstraction.unsafe_free(tex)
     end
     return
 end

--- a/GLMakie/src/glshaders/visualize_interface.jl
+++ b/GLMakie/src/glshaders/visualize_interface.jl
@@ -105,7 +105,7 @@ function assemble_shader(data)
         GLAbstraction.StandardPrerender(transp, overdraw)
     end
 
-    robj = RenderObject(data, shader, pre, shader.screen.glscreen)
+    robj = RenderObject(data, shader, pre, nothing, shader.screen.glscreen)
 
     post = if haskey(data, :instances)
         GLAbstraction.StandardPostrenderInstanced(pop!(data, :instances), robj.vertexarray, primitive)

--- a/GLMakie/src/glwindow.jl
+++ b/GLMakie/src/glwindow.jl
@@ -157,6 +157,16 @@ Makie.@noconstprop function GLFramebuffer(context, fb_size::NTuple{2, Int})
     )::GLFramebuffer
 end
 
+function destroy!(fb::GLFramebuffer)
+    for tex in values(fb.buffers)
+        GLAbstraction.unsafe_free(tex)
+    end
+    id = [fb.id]
+    glDeleteFramebuffers(1, id)
+    fb.id = 0
+    return
+end
+
 function Base.resize!(fb::GLFramebuffer, w::Int, h::Int)
     (w > 0 && h > 0 && (w, h) != size(fb)) || return
     for (name, buffer) in fb.buffers

--- a/GLMakie/src/glwindow.jl
+++ b/GLMakie/src/glwindow.jl
@@ -148,6 +148,8 @@ Makie.@noconstprop function GLFramebuffer(context, fb_size::NTuple{2, Int})
         :stencil => depth_buffer
     )
 
+    require_context(context)
+
     return GLFramebuffer(
         fb_size_node, frambuffer_id,
         buffer_ids, buffers,
@@ -204,6 +206,13 @@ end
 
 function ShaderAbstractions.native_context_alive(x::GLFW.Window)
     GLFW.is_initialized() && !was_destroyed(x)
+end
+
+# require_context(ctx, current = nothing) = nothing
+function GLAbstraction.require_context(ctx, current = ShaderAbstractions.current_context())
+    @assert GLFW.is_initialized() "Context $ctx must be initialized, but is not."
+    @assert !was_destroyed(ctx) "Context $ctx must not be destroyed."
+    @assert ctx.handle == current.handle "Context $ctx must be current, but $current is."
 end
 
 function destroy!(nw::GLFW.Window)

--- a/GLMakie/src/glwindow.jl
+++ b/GLMakie/src/glwindow.jl
@@ -86,7 +86,9 @@ function check_framebuffer()
     return enum_to_error(status)
 end
 
-Makie.@noconstprop function GLFramebuffer(fb_size::NTuple{2, Int})
+Makie.@noconstprop function GLFramebuffer(context, fb_size::NTuple{2, Int})
+    ShaderAbstractions.switch_context!(context)
+
     # Create framebuffer
     frambuffer_id = glGenFramebuffers()
     glBindFramebuffer(GL_FRAMEBUFFER, frambuffer_id)

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -177,7 +177,7 @@ function ssao_postprocessor(framebuffer, shader_cache)
             a = viewport(scene)[]
             glScissor(ppu(minimum(a))..., ppu(widths(a))...)
             # update uniforms
-            data1[:projection] = scene.camera.projection[]
+            data1[:projection] = Mat4f(scene.camera.projection[])
             data1[:bias] = scene.ssao.bias[]
             data1[:radius] = scene.ssao.radius[]
             GLAbstraction.render(pass1)

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -102,6 +102,8 @@ function ssao_postprocessor(framebuffer, shader_cache)
         push!(framebuffer.render_buffer_ids, normal_occ_id)
     end
 
+    require_context(shader_cache.context)
+
     # SSAO setup
     N_samples = 64
     lerp_min = 0.1f0
@@ -195,6 +197,8 @@ function ssao_postprocessor(framebuffer, shader_cache)
         glDisable(GL_SCISSOR_TEST)
     end
 
+    require_context(shader_cache.context)
+
     PostProcessor(RenderObject[pass1, pass2], full_render, ssao_postprocessor)
 end
 
@@ -218,6 +222,8 @@ function fxaa_postprocessor(framebuffer, shader_cache)
             luma_id = framebuffer[:HDR_color][1]
         end
     end
+
+    require_context(shader_cache.context)
 
     # calculate luma for FXAA
     shader1 = LazyShader(
@@ -262,6 +268,8 @@ function fxaa_postprocessor(framebuffer, shader_cache)
         glDrawBuffer(color_id)  # color buffer
         GLAbstraction.render(pass2)
     end
+
+    require_context(shader_cache.context)
 
     PostProcessor(RenderObject[pass1, pass2], full_render, fxaa_postprocessor)
 end

--- a/GLMakie/src/postprocessing.jl
+++ b/GLMakie/src/postprocessing.jl
@@ -310,8 +310,6 @@ function to_screen_postprocessor(framebuffer, shader_cache, screen_fb_id = nothi
 end
 
 function destroy!(pp::PostProcessor)
-    while !isempty(pp.robjs)
-        destroy!(pop!(pp.robjs))
-    end
+    foreach(destroy!, pp.robjs)
     return
 end

--- a/GLMakie/src/precompiles.jl
+++ b/GLMakie/src/precompiles.jl
@@ -49,7 +49,6 @@ let
             screen = Screen(Scene(), config; visible=false, start_renderloop=false)
             close(screen)
 
-            empty!(atlas_texture_cache)
             closeall(; empty_shader=false)
             @assert isempty(SCREEN_REUSE_POOL)
             @assert isempty(ALL_SCREENS)

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -117,7 +117,7 @@ end
 function GLAbstraction.render(filter_elem_func, screen::Screen)
     # Somehow errors in here get ignored silently!?
     try
-        GLAbstraction.require_context(nw)
+        GLAbstraction.require_context(screen.glscreen)
         for (zindex, screenid, elem) in screen.renderlist
             filter_elem_func(elem)::Bool || continue
 
@@ -129,7 +129,7 @@ function GLAbstraction.render(filter_elem_func, screen::Screen)
             glViewport(round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
             render(elem)
         end
-        GLAbstraction.require_context(nw)
+        GLAbstraction.require_context(screen.glscreen)
     catch e
         @error "Error while rendering!" exception = e
         rethrow(e)

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -101,6 +101,8 @@ function render_frame(screen::Screen; resize_buffers=true)
     # transfer everything to the screen
     screen.postprocessors[4].render(screen)
 
+    GLAbstraction.require_context(nw)
+
     return
 end
 
@@ -115,6 +117,7 @@ end
 function GLAbstraction.render(filter_elem_func, screen::Screen)
     # Somehow errors in here get ignored silently!?
     try
+        GLAbstraction.require_context(nw)
         for (zindex, screenid, elem) in screen.renderlist
             filter_elem_func(elem)::Bool || continue
 
@@ -126,6 +129,7 @@ function GLAbstraction.render(filter_elem_func, screen::Screen)
             glViewport(round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
             render(elem)
         end
+        GLAbstraction.require_context(nw)
     catch e
         @error "Error while rendering!" exception = e
         rethrow(e)

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -580,13 +580,13 @@ function destroy!(rob::RenderObject)
             # TODO, refcounting, or leaving freeing to GC...
             # GC is a bit tricky with active contexts, so immediate free is preferred.
             # I guess as long as we make it hard for users to share buffers directly, this should be fine!
-            GLAbstraction.free(v)
+            GLAbstraction.unsafe_free(v)
         end
     end
     for obs in rob.observables
         Observables.clear(obs)
     end
-    GLAbstraction.free(rob.vertexarray)
+    GLAbstraction.unsafe_free(rob.vertexarray)
 end
 
 function Base.delete!(screen::Screen, scene::Scene, plot::AbstractPlot)
@@ -647,6 +647,7 @@ function destroy!(screen::Screen)
     GLFW.SetWindowRefreshCallback(window, nothing)
     GLFW.SetWindowContentScaleCallback(window, nothing)
     cleanup_texture_atlas!(window)
+    GLAbstraction.unsafe_free(screen.shader_cache)
     destroy!(window)
     # Since those are sets, we can just delete them from there, even if they weren't in there (e.g. reuse=false)
     delete!(SCREEN_REUSE_POOL, screen)

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -646,6 +646,7 @@ function destroy!(screen::Screen)
     window = screen.glscreen
     GLFW.SetWindowRefreshCallback(window, nothing)
     GLFW.SetWindowContentScaleCallback(window, nothing)
+    foreach(destroy!, screen.postprocessors) # before texture atlas, otherwise it regenerates
     cleanup_texture_atlas!(window)
     GLAbstraction.unsafe_free(screen.shader_cache)
     destroy!(window)

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -647,6 +647,7 @@ function destroy!(screen::Screen)
     GLFW.SetWindowRefreshCallback(window, nothing)
     GLFW.SetWindowContentScaleCallback(window, nothing)
     foreach(destroy!, screen.postprocessors) # before texture atlas, otherwise it regenerates
+    destroy!(screen.framebuffer)
     cleanup_texture_atlas!(window)
     GLAbstraction.unsafe_free(screen.shader_cache)
     destroy!(window)

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -569,7 +569,7 @@ function destroy!(rob::RenderObject)
     # These need explicit clean up because (some of) the source observables
     # remain when the plot is deleted.
     GLAbstraction.switch_context!(rob.context)
-    tex = get_texture!(gl_texture_atlas())
+    tex = get_texture!(rob.context, gl_texture_atlas())
     for (k, v) in rob.uniforms
         if v isa Observable
             Observables.clear(v)
@@ -646,6 +646,7 @@ function destroy!(screen::Screen)
     window = screen.glscreen
     GLFW.SetWindowRefreshCallback(window, nothing)
     GLFW.SetWindowContentScaleCallback(window, nothing)
+    cleanup_texture_atlas!(window)
     destroy!(window)
     # Since those are sets, we can just delete them from there, even if they weren't in there (e.g. reuse=false)
     delete!(SCREEN_REUSE_POOL, screen)

--- a/GLMakie/test/unit_tests.jl
+++ b/GLMakie/test/unit_tests.jl
@@ -486,3 +486,81 @@ end
     @test robj.uniforms[:resolution][]     == screen.px_per_unit[] * cam.resolution[]
     @test robj.uniforms[:projectionview][] == cam.projectionview[]
 end
+
+@testset "gl Object deletion" begin
+    # image so we have a user generated texture in the mix
+    # texture atlas is triggered by text
+    # include SSAO to make sure its cleanup works too
+    f,a,p = image(rand(4,4))
+    screen = display(f, ssao = true, visible = false)
+    colorbuffer(screen)
+
+    # verify that SSAO is active
+    @test screen.postprocessors[1] != GLMakie.empty_postprocessor()
+
+    framebuffer = screen.framebuffer
+    framebuffer_textures = copy(screen.framebuffer.buffers)
+    atlas_textures = first.(values(GLMakie.atlas_texture_cache))
+    shaders = vcat([[shader for shader in values(shaders)] for shaders in values(screen.shader_cache.shader_cache)]...)
+    programs = [program for program in values(screen.shader_cache.program_cache)]
+    postprocessors = copy(screen.postprocessors)
+    robjs = last.(screen.renderlist)
+
+    GLMakie.destroy!(screen)
+
+    @testset "Texture Atlas" begin
+        for tex in atlas_textures
+            @test tex.id == 0
+        end
+    end
+
+    @testset "Framebuffer" begin
+        @test framebuffer.id == 0
+        for (k, tex) in framebuffer_textures
+            @test tex.id == 0
+        end
+    end
+
+    @testset "ShaderCache" begin
+        for shader in shaders
+            @test shader.id == 0
+        end
+        for program in programs
+            @test program.id == 0
+        end
+    end
+
+    function validate_robj(robj)
+        for uniform in robj.uniforms
+            if to_value(uniform) isa GLMakie.GLAbstraction.GPUArray
+                @test to_value(uniform).id == 0
+            end
+        end
+        @test robj.vertexarray.id == 0
+        if robj.vertexarray.indices isa GLMakie.GLAbstraction.GPUArray
+            @test robj.vertexarray.indices.id == 0
+        end
+        for buffer in values(robj.vertexarray.buffers)
+            @test buffer.id == 0
+        end
+        @test robj.vertexarray.program.id == 0
+        for shader in robj.vertexarray.program.shader
+            @test shader.id == 0
+        end
+    end
+
+    @testset "PostProcessors" begin
+        @test map(pp -> length(pp.robjs), postprocessors) == [2,1,2,1]
+        for pp in postprocessors
+            for robj in pp.robjs
+                validate_robj(robj)
+            end
+        end
+    end
+
+    @testset "RenderObjects" begin
+        for robj in robjs
+            validate_robj(robj)
+        end
+    end
+end


### PR DESCRIPTION
# Description

After some help from Simon we figured out that GC / `free()` was the cause of issues in #4689. Specifically because free() includes a context switch and GC can trigger it whenever via finalizers, context switches can occur randomly. To fix this I'm making all cleanup of OpenGL objects explicit here, i.e. remove the need for finalizers.

The current version should segfault if a finalizer deletes OpenGL objects. I'll let CI run with this so I can see if I missed anything

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
