### PR TITLE
skip empty draw calls in GLMakie

### DIFF
--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -109,8 +109,9 @@ end
 
 function render(vao::GLVertexArray{T}, mode::GLenum=GL_TRIANGLES) where T <: TOrSignal{UnitRange{Int}}
     r = to_value(vao.indices)
-    offset = first(r) - 1 # 1 based -> 0 based
     ndraw = length(r)
+    ndraw == 0 && return nothing
+    offset = first(r) - 1 # 1 based -> 0 based
     nverts = length(vao)
     if (offset < 0 || offset + ndraw > nverts)
         error("Bounds error for drawrange. Offset $(offset) and length $(ndraw) aren't a valid range for vertexarray with length $(nverts)")
@@ -121,6 +122,7 @@ end
 
 function render(vao::GLVertexArray{T}, mode::GLenum=GL_TRIANGLES) where T <: TOrSignal{Int}
     r = to_value(vao.indices)
+    r == 0 && return nothing
     glDrawArrays(mode, 0, r)
     return nothing
 end
@@ -129,20 +131,19 @@ end
 Renders a vertex array which supplies an indexbuffer
 """
 function render(vao::GLVertexArray{GLBuffer{T}}, mode::GLenum=GL_TRIANGLES) where T <: Union{Integer,AbstractFace}
-    glDrawElements(
-        mode,
-        length(vao.indices) * cardinality(vao.indices),
-        julia2glenum(T), C_NULL
-    )
-    return
+    N = length(vao.indices) * cardinality(vao.indices)
+    N == 0 && return nothing
+    glDrawElements(mode, N, julia2glenum(T), C_NULL)
+    return nothing
 end
 
 """
 Renders a normal vertex array only containing the usual buffers buffers.
 """
 function render(vao::GLVertexArray, mode::GLenum=GL_TRIANGLES)
+    length(vao) == 0 && return nothing
     glDrawArrays(mode, 0, length(vao))
-    return
+    return nothing
 end
 
 """
@@ -154,16 +155,19 @@ renderinstanced(vao::GLVertexArray, a, primitive=GL_TRIANGLES) = renderinstanced
 Renders `amount` instances of an indexed geometry
 """
 function renderinstanced(vao::GLVertexArray{GLBuffer{T}}, amount::Integer, primitive=GL_TRIANGLES) where T <: Union{Integer,AbstractFace}
-    glDrawElementsInstanced(primitive, length(vao.indices) * cardinality(vao.indices), julia2glenum(T), C_NULL, amount)
-    return
+    N_elements = length(vao)
+    N_elements * amount == 0 && return nothing
+    glDrawElementsInstanced(primitive, N_elements, julia2glenum(T), C_NULL, amount)
+    return nothing
 end
 
 """
 Renders `amount` instances of an not indexed geometry geometry
 """
 function renderinstanced(vao::GLVertexArray, amount::Integer, primitive=GL_TRIANGLES)
+    length(vao) * amount == 0 && return nothing
     glDrawElementsInstanced(primitive, length(vao), GL_UNSIGNED_INT, C_NULL, amount)
-    return
+    return nothing
 end
 # handle all uniform objects
 

--- a/GLMakie/src/GLAbstraction/GLRender.jl
+++ b/GLMakie/src/GLAbstraction/GLRender.jl
@@ -155,9 +155,9 @@ renderinstanced(vao::GLVertexArray, a, primitive=GL_TRIANGLES) = renderinstanced
 Renders `amount` instances of an indexed geometry
 """
 function renderinstanced(vao::GLVertexArray{GLBuffer{T}}, amount::Integer, primitive=GL_TRIANGLES) where T <: Union{Integer,AbstractFace}
-    N_elements = length(vao)
-    N_elements * amount == 0 && return nothing
-    glDrawElementsInstanced(primitive, N_elements, julia2glenum(T), C_NULL, amount)
+    N = length(vao.indices) * cardinality(vao.indices)
+    N * amount == 0 && return nothing
+    glDrawElementsInstanced(primitive, N, julia2glenum(T), C_NULL, amount)
     return nothing
 end
 


### PR DESCRIPTION
# Description

While debugging I noticed that GLMakie produces a bunch of 0-element draw calls. Most of them are probably the result of the linesegments in text not being set to `visible = false`, but I don't think we should rely on that anyway. This pr introduces a check for that in GLMakie instead.

## Type of change

- [x] Internal improvement