### PR TITLE
Fix edge case with incomplete texture atlas cleanup

### DIFF
--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -740,6 +740,11 @@ function closeall(; empty_shader=true)
 
     if !isempty(atlas_texture_cache)
         @warn "texture atlas cleanup incomplete: $atlas_texture_cache"
+        # Manual cleanup - font render callbacks are not yet cleaned up, delete
+        # them here. Contexts should all be dead so there is no point in free(tex)
+        for ((atlas, ctx), (tex, func)) in atlas_texture_cache
+            Makie.remove_font_render_callback!(atlas, func)
+        end
         empty!(atlas_texture_cache)
     end
 


### PR DESCRIPTION
# Description

Fixes https://github.com/MakieOrg/Makie.jl/pull/4699#discussion_r1910570155 from #4699. Without this, if `destroy!(screen)` fails to clean up the texture atlas cache the font render function would remain. Since it encapsulates the texture that would also remain. So there would be a small memory leak.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)