### PR TITLE
Alpha in legends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fixed indexing error edge case in violin median code [#4682](https://github.com/MakieOrg/Makie.jl/pull/4682)
 - Fixed incomplete plot cleanup when cleanup is triggered by an event. [#4710](https://github.com/MakieOrg/Makie.jl/pull/4710)
 - Automatically plot Enums as categorical [#4717](https://github.com/MakieOrg/Makie.jl/pull/4717).
+- Fix `alpha` use in legends and some CairoMakie cases [#4721](https://github.com/MakieOrg/Makie.jl/pull/4721).
 
 ## [0.21.18] - 2024-12-12
 

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -524,7 +524,7 @@ function to_cairo_color(color::Makie.AbstractPattern, plot_object)
 end
 
 function to_cairo_color(color, plot_object)
-    return to_color(color)
+    return to_color((color, to_value(plot_object.alpha)))
 end
 
 function set_source(ctx::Cairo.CairoContext, pattern::Cairo.CairoPattern)

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -512,7 +512,7 @@ end
 #        Common color utilities        #
 ########################################
 
-function to_cairo_color(colors::Union{AbstractVector{<: Number},Number}, plot_object)
+function to_cairo_color(colors::Union{AbstractVector,Number}, plot_object)
     cmap = Makie.assemble_colors(colors, Observable(colors), plot_object)
     return to_color(to_value(cmap))
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -166,6 +166,25 @@ end
     f
 end
 
+@reference_test "Legend with scalar colors and alpha" begin
+    f = Figure()
+    ax = Axis(f[1, 1])
+    for i in 1:3
+        lines!(ax, (1:3) .+ i, color = i, colorrange = (0, 4), colormap = :Blues, label = "Line $i", linewidth = 3, alpha = 0.5)
+    end
+    for i in 1:3
+        scatter!(ax, (1:3) .+ i .+ 3, color = i, colorrange = (0, 4), colormap = :plasma, label = "Scatter $i", markersize = 15, alpha = 0.5)
+    end
+    for i in 1:3
+        barplot!(ax, (1:3) .+ i .+ 8, fillto = (1:3) .+ i .+ 7.5, color = i, colorrange = (0, 4), colormap = :tab10, label = "Barplot $i", alpha = 0.5)
+    end
+    for i in 1:3
+        poly!(ax, [Rect2f((j, i .+ 12 + j), (0.5, 0.5)) for j in 1:3], color = i, colorrange = (0, 4), colormap = :heat, label = "Poly $i", alpha = 0.5)
+    end
+    Legend(f[1, 2], ax)
+    f
+end
+
 @reference_test "Legend overrides" begin
     f = Figure()
     ax = Axis(f[1, 1])
@@ -189,8 +208,8 @@ end
     Legend(
         f[1, 3],
         [
-            sc => (; markersize = 30),
-            [li => (; color = :red), sc => (; color = :cyan)],
+            sc => (; markersize = 30, alpha = 0.3),
+            [li => (; color = :red, alpha = 0.3, linewidth = 4), sc => (; color = :cyan)],
             [li, sc] => Dict(:color => :cyan),
         ],
         ["Scatter", "Line and Scatter", "Another"],

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -284,6 +284,7 @@ function legendelement_plots!(scene, element::MarkerElement, bbox::Observable{Re
         strokecolor = attrs.markerstrokecolor, inspectable = false,
         colormap = attrs.markercolormap,
         colorrange = attrs.markercolorrange,
+        alpha = attrs.alpha,
     )
 
     return [scat]
@@ -297,7 +298,7 @@ function legendelement_plots!(scene, element::LineElement, bbox::Observable{Rect
     points = lift((bb, fp) -> fractionpoint.(Ref(bb), fp), scene, bbox, fracpoints)
     lin = lines!(scene, points, linewidth = attrs.linewidth, color = attrs.linecolor,
         colormap = attrs.linecolormap, colorrange = attrs.linecolorrange,
-        linestyle = attrs.linestyle, inspectable = false)
+        linestyle = attrs.linestyle, inspectable = false, alpha = attrs.alpha)
 
     return [lin]
 end
@@ -310,7 +311,7 @@ function legendelement_plots!(scene, element::PolyElement, bbox::Observable{Rect
     pol = poly!(scene, points, strokewidth = attrs.polystrokewidth, color = attrs.polycolor,
         strokecolor = attrs.polystrokecolor, inspectable = false,
         colormap = attrs.polycolormap, colorrange = attrs.polycolorrange,
-        linestyle = attrs.linestyle)
+        linestyle = attrs.linestyle, alpha = attrs.alpha)
 
     return [pol]
 end
@@ -350,7 +351,7 @@ end
 
 function apply_legend_override!(le::MarkerElement, override::LegendOverride)
     renamed_attrs = _rename_attributes!(MarkerElement, copy(override.overrides))
-    for sym in (:markerpoints, :markersize, :markercolor, :markerstrokewidth, :markerstrokecolor, :markercolormap, :markercolorrange)
+    for sym in (:markerpoints, :markersize, :markercolor, :markerstrokewidth, :markerstrokecolor, :markercolormap, :markercolorrange, :alpha)
         if haskey(renamed_attrs, sym)
             le.attributes[sym] = renamed_attrs[sym]
         end
@@ -359,7 +360,7 @@ end
 
 function apply_legend_override!(le::LineElement, override::LegendOverride)
     renamed_attrs = _rename_attributes!(LineElement, copy(override.overrides))
-    for sym in (:linepoints, :linewidth, :linecolor, :linecolormap, :linecolorrange, :linestyle)
+    for sym in (:linepoints, :linewidth, :linecolor, :linecolormap, :linecolorrange, :linestyle, :alpha)
         if haskey(renamed_attrs, sym)
             le.attributes[sym] = renamed_attrs[sym]
         end
@@ -368,7 +369,7 @@ end
 
 function apply_legend_override!(le::PolyElement, override::LegendOverride)
     renamed_attrs = _rename_attributes!(PolyElement, copy(override.overrides))
-    for sym in (:polypoints, :polycolor, :polystrokewidth, :polystrokecolor, :polycolormap, :polycolorrange, :polystrokestyle)
+    for sym in (:polypoints, :polycolor, :polystrokewidth, :polystrokecolor, :polycolormap, :polycolorrange, :polystrokestyle, :alpha)
         if haskey(renamed_attrs, sym)
             le.attributes[sym] = renamed_attrs[sym]
         end
@@ -479,6 +480,7 @@ function legendelements(plot::Union{Lines, LineSegments}, legend)
         linewidth = choose_scalar(plot.linewidth, legend[:linewidth]),
         colormap = plot.colormap,
         colorrange = plot.colorrange,
+        alpha = plot.alpha,
     )]
 end
 
@@ -491,6 +493,7 @@ function legendelements(plot::Scatter, legend)
         strokecolor = choose_scalar(plot.strokecolor, legend[:markerstrokecolor]),
         colormap = plot.colormap,
         colorrange = plot.colorrange,
+        alpha = plot.alpha,
     )]
 end
 
@@ -502,6 +505,7 @@ function legendelements(plot::Union{Violin, BoxPlot, CrossBar}, legend)
         strokewidth = choose_scalar(plot.strokewidth, legend[:polystrokewidth]),
         colormap = plot.colormap,
         colorrange = plot.colorrange,
+        alpha = plot.alpha,
     )]
 end
 
@@ -516,6 +520,7 @@ function legendelements(plot::Band, legend)
         polystrokewidth = 0,
         polycolormap = plot.colormap,
         polycolorrange = plot.colorrange,
+        alpha = plot.alpha,
     )]
 end
 
@@ -528,6 +533,7 @@ function legendelements(plot::Union{Poly, Density}, legend)
         colormap = plot.colormap,
         colorrange = plot.colorrange,
         linestyle = plot.linestyle,
+        alpha = plot.alpha,
     )]
 end
 

--- a/src/makielayout/defaultattributes.jl
+++ b/src/makielayout/defaultattributes.jl
@@ -78,7 +78,7 @@ function attributenames(::Type{LegendEntry})
         :patchsize, :patchstrokecolor, :patchstrokewidth, :patchcolor,
         :linepoints, :linewidth, :linecolor, :linestyle, :linecolorrange, :linecolormap,
         :markerpoints, :markersize, :markerstrokewidth, :markercolor, :markerstrokecolor, :markercolorrange, :markercolormap,
-        :polypoints, :polystrokewidth, :polycolor, :polystrokecolor, :polycolorrange, :polycolormap)
+        :polypoints, :polystrokewidth, :polycolor, :polystrokecolor, :polycolorrange, :polycolormap, :alpha)
 end
 
 function extractattributes(attributes::Attributes, typ::Type)

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1470,6 +1470,8 @@ const EntryGroup = Tuple{Any, Vector{LegendEntry}}
         polycolormap = theme(scene, :colormap)
         "The default colorrange for PolyElements"
         polycolorrange = automatic
+        "The default alpha for legend elements"
+        alpha = 1
         "The orientation of the legend (:horizontal or :vertical)."
         orientation = :vertical
         "The gap between each group title and its group."


### PR DESCRIPTION
Forwards `alpha` into legend elements so that it's reflected there and can be overridden like other legend attributes. Also fixes that CairoMakie did not take `alpha` into account for scalar colors in some cases.

Fixes https://github.com/MakieOrg/Makie.jl/issues/3735