### PR TITLE
Resolve :data space when deciding whether to connect transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed an issue with transformations not propagating to child plots when their spaces only match indirectly. [#4723](https://github.com/MakieOrg/Makie.jl/pull/4723)
+
 ## [0.22.0] - 2024-12-12
 
 - Updated to GeometryBasics 0.5: [GeometryBasics#173](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/173), [GeometryBasics#219](https://github.com/JuliaGeometry/GeometryBasics.jl/pull/219) [#4319](https://github.com/MakieOrg/Makie.jl/pull/4319)

--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/camera/camera2d.jl
+++ b/src/camera/camera2d.jl
@@ -327,7 +327,6 @@ struct UpdatePixelCam
     near::Float64
     far::Float64
 end
-get_space(::UpdatePixelCam) = :pixel
 
 function (cam::UpdatePixelCam)(window_size)
     w, h = Float64.(widths(window_size))

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -451,8 +451,14 @@ function get_space(scene::Scene)
     space === :data ? (:data,) : (:data, space)
 end
 get_space(::AbstractCamera) = :data
-# TODO: Should this be less specialized? ScenePlot? AbstractPlot?
-get_space(plot::Plot) = to_value(get(plot, :space, :data))::Symbol
+function get_space(plot::Plot)
+    space = to_value(get(plot, :space, :data))::Symbol
+    # :data should resolve based on the parent scene/camera
+    if (space == :data) && (parent_scene(plot) !== nothing)
+        return get_space(parent_scene(plot))
+    end
+    return space
+end
 
 is_space_compatible(a, b) = is_space_compatible(get_space(a), get_space(b))
 is_space_compatible(a::Symbol, b::Symbol) = a === b

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -156,8 +156,8 @@ function apply_expand_dimensions(trait, args, args_obs, deregister)
             for (obs, arg) in zip(new_obs, expanded)
                 obs.val = arg
             end
-            # It should be enough to trigger the first observable since 
-            # this will go into `map(convert_arguments, new_obs...)` 
+            # It should be enough to trigger the first observable since
+            # this will go into `map(convert_arguments, new_obs...)`
             # Without this, we'll get 3 updates for `notify(data)` in `heatmap(data)`
             notify(new_obs[1])
             return

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -646,6 +646,7 @@ end
 parent_scene(x) = parent_scene(get_scene(x))
 parent_scene(x::Plot) = parent_scene(parent(x))
 parent_scene(x::Scene) = x
+parent_scene(::Nothing) = nothing
 
 Base.isopen(x::SceneLike) = events(x).window_open[]
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -369,6 +369,17 @@ function Transformation(parent::Transformable;
     return trans
 end
 
+function Base.show(io::IO, ::MIME"text/plain", t::Transformation)
+    println(io, "Transformation()")
+    println(io, "          parent = ", isassigned(t.parent) ? "Transformation(…)" : "#undef")
+    println(io, "     translation = ", t.translation[])
+    println(io, "           scale = ", t.scale[])
+    println(io, "        rotation = ", t.rotation[])
+    println(io, "          origin = ", t.origin[])
+    println(io, "           model = ", t.model[])
+    println(io, "  transform_func = ", t.transform_func[])
+end
+
 struct ScalarOrVector{T}
     sv::Union{T, Vector{T}}
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,6 +4,7 @@ abstract type AbstractAxis <: Block end
 
 # placeholder if no camera is present
 struct EmptyCamera <: AbstractCamera end
+get_space(::EmptyCamera) = :clip
 
 @enum RaymarchAlgorithm begin
     IsoValue # 0

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -33,7 +33,7 @@
 
     @testset "#4722 Transformation passthrough" begin
         scene = Scene(camera = campixel!)
-        text!(scene, L"\frac{1}{2}")
+        p = text!(scene, L"\frac{1}{2}")
         translate!(scene, 0, 0, 10)
         @test isassigned(p.transformation.parent)
         @test isassigned(p.plots[1].transformation.parent)

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -13,14 +13,14 @@
         f, a, p = scatter(ps)
         Makie.update_state_before_display!(f)
         # sanity check: old behavior should fail
-        M = Makie.Mat4f(Makie.clip_to_space(a.scene.camera, :data)) * 
+        M = Makie.Mat4f(Makie.clip_to_space(a.scene.camera, :data)) *
             Makie.Mat4f(Makie.space_to_clip(a.scene.camera, :data))
         @test !(M ≈ I)
         # this should not
         M = Makie.clip_to_space(a.scene.camera, :data) * Makie.space_to_clip(a.scene.camera, :data)
         @test M ≈ I atol = 1e-4
     end
-    
+
     @testset "#4416 Merging attributes" begin
         # See https://github.com/MakieOrg/Makie.jl/pull/4416
         theme1 = Theme(Axis = (; titlesize = 10))
@@ -29,5 +29,21 @@
         # Test that merging themes does not modify leftmost argument
         @test !haskey(theme1.Axis, :xgridvisible)
         @test !haskey(theme2.Axis, :titlesize)  # sanity check other argument
+    end
+
+    @testset "#4722 Transformation passthrough" begin
+        scene = Scene(camera = campixel!)
+        text!(scene, L"\frac{1}{2}")
+        translate!(scene, 0, 0, 10)
+        @test isassigned(p.transformation.parent)
+        @test isassigned(p.plots[1].transformation.parent)
+        @test isassigned(p.plots[1].plots[1].transformation.parent)
+        @test isassigned(p.plots[1].plots[2].transformation.parent)
+
+        @test scene.transformation.model[][3, 4] == 10.0
+        @test p.transformation.model[][3, 4] == 10.0
+        @test p.plots[1].transformation.model[][3, 4] == 10.0
+        @test p.plots[1].plots[1].transformation.model[][3, 4] == 10.0
+        @test p.plots[1].plots[2].transformation.model[][3, 4] == 10.0
     end
 end


### PR DESCRIPTION
# Description

Fixes #4722

We have a check which stops transformations from connecting if parent.space != child.space. If the parent is a scene this check looks at the camera and treats `campixel!` as pixel space. This pr adjusts the check to trace back to the scene if `space == :data`, as that could still be pixel space.

In #4722 the text shown in legend is a text plot to a pixel space scene. The linesegments used for LaTeXStrings are hard-coded to be in pixel space. Other elements of the plot are in `space == :data`, which causes transformation to not be connected and thus translations to not propagate to the linesegments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
