### PR TITLE
fix NaN error

### DIFF
--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -9753,7 +9753,7 @@ function __(s1, e, t, n) {
 var Td = new St, wd = new As, Ad = new qr, Rd = new Ki, gh = [], _h = [], xh = new Float32Array(16), vh = new Float32Array(9), yh = new Float32Array(4);
 function as(s1, e, t) {
     let n = s1[0];
-    if (n <= 0 || n > 0) return s1;
+    if (n <= 0 || n > 0 || isNaN(n)) return s1;
     let i = e * t, r = gh[i];
     if (r === void 0 && (r = new Float32Array(i), gh[i] = r), e !== 0) {
         n.toArray(r, 0);


### PR DESCRIPTION
# Description

when recording an animation using WGLMakie i sometimes get the following error in the browser console.  this PR fixes it.  my understanding of this part of the makie codebase is as superficial as it gets.  not sure if this breaks anything but it fixes my problem.  happy to add a test if desired.  have not taken the time to devise a MWE but could if you want.

```
Uncaught TypeError: n.toArray is not a function
    at as (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:9759:11)
    at yo.k_ [as setValue] (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:9979:13)
    at qi.upload (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:10152:39)
    at Fd (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:13117:628)
    at Ro.renderBufferDirect (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:12945:72)
    at tl (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:13073:450)
    at ks (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:13069:45)
    at el (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:13041:228)
    at Ro.render (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:13010:20)
    at render_scene (454d14251abd5406c633fb77841dd6097a73cd86-wglmakie.bundled.js:22949:18)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added unit tests for new algorithms, conversion methods, etc.
