### PR TITLE
Fix CI for ModernGL 1.1.8

### DIFF
--- a/GLMakie/test/runtests.jl
+++ b/GLMakie/test/runtests.jl
@@ -9,7 +9,10 @@ using ReferenceTests
 # verify OpenGL object cleanup
 GLMakie.GLAbstraction.GLMAKIE_DEBUG[] = true
 
-if !GLMakie.ModernGL.enable_opengl_debugging
+deref(x) = x
+deref(x::Base.RefValue) = x[]
+
+if !deref(GLMakie.ModernGL.enable_opengl_debugging)
     # can't error, since we can't enable debugging for users
     @warn("TESTING WITHOUT OPENGL DEBUGGING")
 end


### PR DESCRIPTION
ModernGL changed a global bool we read in CI to a ref
