### PR TITLE
Fix broken `voronoiplot` for clipped tessellations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix issue with `voronoiplot` for Voronoi tessellations with empty polygons
+
 ## [0.22.1] - 2025-01-17
 
 - Allow volume textures for mesh color, to e.g. implement a performant volume slice display [#2274](https://github.com/MakieOrg/Makie.jl/pull/2274).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fix issue with `voronoiplot` for Voronoi tessellations with empty polygons
+- Fix issue with `voronoiplot` for Voronoi tessellations with empty polygons [#4740](https://github.com/MakieOrg/Makie.jl/pull/4740)
 
 ## [0.22.1] - 2025-01-17
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1467,6 +1467,18 @@ end
     fig
 end
 
+@reference_test "Voronoiplot with empty polygons and automatic color generation" begin
+    points = [0.153071 0.210363 0.447987 0.765468 -0.681145 1.88393 -1.05474 -0.52126 1.102 0.675978 1.75767 1.19744;
+        -0.16884 -0.492721 -1.30937 0.573229 -2.39049 -0.249817 -1.15057 -0.480175 0.226354 1.18442 1.66382 -1.23949];
+    tri = triangulate(points)
+    xmin, xmax, ymin, ymax = -1 / 2, 1 / 2, -1.0, 1.0
+    clip_points = ((xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax))
+    clip_vertices = (1, 2, 3, 4, 1)
+    clip_polygon = (clip_points, clip_vertices)
+    clipped_vorn = voronoi(tri, clip=true, clip_polygon=clip_polygon)
+    voronoiplot(clipped_vorn)
+end
+
 function ppu_test_plot(resolution, px_per_unit, scalefactor)
     fig, ax, pl = scatter(1:4, markersize=100, color=1:4, figure=(; size=resolution), axis=(; titlesize=50, title="ppu: $px_per_unit, sf: $scalefactor"))
     DataInspector(ax)

--- a/src/basic_recipes/voronoiplot.jl
+++ b/src/basic_recipes/voronoiplot.jl
@@ -99,6 +99,7 @@ function get_voronoi_tiles!(generators, polygons, vorn, bbox)
     sizehint!(polygons, DelTri.num_polygons(vorn))
 
     for i in DelTri.each_generator(vorn)
+        !DelTri.has_polygon(vorn, i) && continue 
         polygon_coords = DelTri.get_polygon_coordinates(vorn, i, voronoi_bbox(bbox))
         polygon_coords_2f = map(polygon_coords) do coords
             return Point2f(DelTri.getxy(coords))


### PR DESCRIPTION
# Description

`voronoiplot` is currently unusable for clipped tessellations with automatic color generation. On the newest version, the following issue occurs:

```julia
points = [0.153071 0.210363 0.447987 0.765468 -0.681145 1.88393 -1.05474 -0.52126 1.102 0.675978 1.75767 1.19744;
    -0.16884 -0.492721 -1.30937 0.573229 -2.39049 -0.249817 -1.15057 -0.480175 0.226354 1.18442 1.66382 -1.23949];
tri = triangulate(points)
xmin, xmax, ymin, ymax = -1 / 2, 1 / 2, -1.0, 1.0
clip_points = ((xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax))
clip_vertices = (1, 2, 3, 4, 1)
clip_polygon = (clip_points, clip_vertices)
clipped_vorn = voronoi(tri, clip=true, clip_polygon=clip_polygon)
voronoiplot(clipped_vorn)
```

```julia
ERROR: All non scalars need same length, Found lengths for each argument: (12, 6, 1, 1, 1), (Vector{GeometryBasics.Polygon{2, Float32}}, Vector{ColorTypes.RGBA{Float32}}, ColorTypes.RGBA{Float32}, Nothing, Float64)
Stacktrace:
  [1] error(s::String)
    @ Base .\error.jl:35
  [2] macro expansion
    @ C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\utilities\utilities.jl:206 [inlined]
  [3] broadcast_foreach(::CairoMakie.var"#74#76"{CairoMakie.Screen{CairoMakie.IMAGE}}, ::Vector{GeometryBasics.Polygon{2, Float32}}, ::Vector{ColorTypes.RGBA{Float32}}, ::ColorTypes.RGBA{Float32}, ::Nothing, ::Float64)
    @ Makie C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\utilities\utilities.jl:199
  [4] draw_poly(scene::Scene, screen::CairoMakie.Screen{CairoMakie.IMAGE}, poly::Poly{Tuple{Vector{GeometryBasics.Polygon{2, Float32}}}}, polygons::Vector{GeometryBasics.Polygon{2, Float32}})
    @ CairoMakie C:\Users\djv23\.julia\packages\CairoMakie\5Mh09\src\overrides.jl:181
  [5] draw_plot(scene::Scene, screen::CairoMakie.Screen{CairoMakie.IMAGE}, poly::Poly{Tuple{Vector{GeometryBasics.Polygon{2, Float32}}}})
    @ CairoMakie C:\Users\djv23\.julia\packages\CairoMakie\5Mh09\src\overrides.jl:17
  [6] cairo_draw(screen::CairoMakie.Screen{CairoMakie.IMAGE}, scene::Scene)
    @ CairoMakie C:\Users\djv23\.julia\packages\CairoMakie\5Mh09\src\infrastructure.jl:49
  [7] backend_show
    @ C:\Users\djv23\.julia\packages\CairoMakie\5Mh09\src\display.jl:106 [inlined]
  [8] backend_show(screen::CairoMakie.Screen{CairoMakie.IMAGE}, io::IOBuffer, ::MIME{Symbol("juliavscode/html")}, scene::Scene)
    @ Makie C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\display.jl:499
  [9] show(io::IOBuffer, m::MIME{Symbol("juliavscode/html")}, figlike::Makie.FigureAxisPlot; backend::Module, update::Bool)
    @ Makie C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\display.jl:258
 [10] show
    @ C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\display.jl:247 [inlined]
 [11] __binrepr(m::MIME{Symbol("juliavscode/html")}, x::Makie.FigureAxisPlot, context::Nothing)
    @ Base.Multimedia .\multimedia.jl:171
 [12] _textrepr
    @ .\multimedia.jl:163 [inlined]
 [13] repr(m::MIME{Symbol("juliavscode/html")}, x::Makie.FigureAxisPlot)
    @ Base.Multimedia .\multimedia.jl:159
 [14] display(d::VSCodeServer.InlineDisplay, m::MIME{Symbol("juliavscode/html")}, x::Any)
    @ VSCodeServer c:\Users\djv23\.vscode\extensions\julialang.language-julia-1.127.2\scripts\packages\VSCodeServer\src\display.jl:68
 [15] display(d::VSCodeServer.InlineDisplay, mime::String, x::Any)
    @ Base.Multimedia .\multimedia.jl:228
 [16] display(d::VSCodeServer.InlineDisplay, x::Any)
    @ VSCodeServer c:\Users\djv23\.vscode\extensions\julialang.language-julia-1.127.2\scripts\packages\VSCodeServer\src\display.jl:207
 [17] display(x::Any)
    @ Base.Multimedia .\multimedia.jl:340
 [18] display(figlike::Makie.FigureAxisPlot; backend::Module, inline::MakieCore.Automatic, update::Bool, screen_config::@Kwargs{})
    @ Makie C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\display.jl:150
 [19] display(figlike::Makie.FigureAxisPlot)
    @ Makie C:\Users\djv23\.julia\packages\Makie\Q6F2P\src\display.jl:130
ripts\packages\VSCodeServer\src\repl.jl:38
 [26] #67
    @ c:\Users\djv23\.vscode\extensions\julialang.language-julia-1.127.2\scripts\packages\VSCodeServer\src\eval.jl:150 [inlined]
 [27] with_logstate(f::VSCodeServer.var"#67#72"{Bool, Bool, Bool, Module, String, Int64, Int64, String, VSCodeServer.ReplRunCodeRequestParams}, logstate::Base.CoreLogging.LogState)
    @ Base.CoreLogging .\logging\logging.jl:522
 [28] with_logger
    @ .\logging\logging.jl:632 [inlined]
 [29] (::VSCodeServer.var"#66#71"{VSCodeServer.ReplRunCodeRequestParams})()
    @ VSCodeServer c:\Users\djv23\.vscode\extensions\julialang.language-julia-1.127.2\scripts\packages\VSCodeServer\src\eval.jl:263
 [30] #invokelatest#2
    @ .\essentials.jl:1055 [inlined]
 [31] invokelatest(::Any)
    @ Base .\essentials.jl:1052
 [32] (::VSCodeServer.var"#64#65")()
    @ VSCodeServer c:\Users\djv23\.vscode\extensions\julialang.language-julia-1.127.2\scripts\packages\VSCodeServer\src\eval.jl:34
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
