### PR TITLE
Improvements for Slider updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added a tutorial on creating an inset plot [#4697](https://github.com/MakieOrg/Makie.jl/pull/4697)
 - Enhanced Pattern support: Added general CairoMakie implementation, improved quality, added anchoring, added support in band, density, added tests & fixed various bugs and inconsistencies. [#4715](https://github.com/MakieOrg/Makie.jl/pull/4715)
 - Fixed issue with `voronoiplot` for Voronoi tessellations with empty polygons [#4740](https://github.com/MakieOrg/Makie.jl/pull/4740)
+- Added option `update_while_dragging=true` to Slider [#4745](https://github.com/MakieOrg/Makie.jl/pull/4745).
 
 ## [0.22.1] - 2025-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Enhanced Pattern support: Added general CairoMakie implementation, improved quality, added anchoring, added support in band, density, added tests & fixed various bugs and inconsistencies. [#4715](https://github.com/MakieOrg/Makie.jl/pull/4715)
 - Fixed issue with `voronoiplot` for Voronoi tessellations with empty polygons [#4740](https://github.com/MakieOrg/Makie.jl/pull/4740)
 - Added option `update_while_dragging=true` to Slider [#4745](https://github.com/MakieOrg/Makie.jl/pull/4745).
+- Added option `lowres_background=true` to Resampler, and renamed `resolution` to `max_resolution` [#4745](https://github.com/MakieOrg/Makie.jl/pull/4745).
+- Added option `throttle=0.0` to `async_latest`, to allow throttling while skipping latest updates [#4745](https://github.com/MakieOrg/Makie.jl/pull/4745).
 
 ## [0.22.1] - 2025-01-17
 

--- a/docs/src/reference/blocks/slider.md
+++ b/docs/src/reference/blocks/slider.md
@@ -19,7 +19,7 @@ fig = Figure()
 
 ax = Axis(fig[1, 1])
 
-sl_x = Slider(fig[2, 1], range = 0:0.01:10, startvalue = 3)
+sl_x = Slider(fig[2, 1], range = 0:0.01:10, startvalue = 3, update_while_dragging=false)
 sl_y = Slider(fig[1, 2], range = 0:0.01:10, horizontal = false, startvalue = 6)
 
 point = lift(sl_x.value, sl_y.value) do x, y

--- a/src/basic_recipes/datashader.jl
+++ b/src/basic_recipes/datashader.jl
@@ -692,8 +692,8 @@ function Makie.plot!(p::HeatmapShader)
     cpa = MakieCore.colormap_attributes(p)
     # Create an overview image that gets shown behind, so we always see the "big picture"
     # In case updating the detailed view takes longer
-    lp = image!(p, x, y, overview_image; gpa..., cpa..., interpolate=p.interpolate, colorrange=colorrange)
-    translate!(lp, 0, 0, -1)
+    # lp = image!(p, x, y, overview_image; gpa..., cpa..., interpolate=p.interpolate, colorrange=colorrange)
+    # translate!(lp, 0, 0, -1)
 
     first_downsample = resample_image(x[], y[], image[], max_resolution[], limits[])
     # We hide the image when outside of the limits, but we also want to correctly forward, p.visible
@@ -752,11 +752,18 @@ function Makie.plot!(p::HeatmapShader)
         # So we can skip this update
         if isempty(do_resample) && isempty(image_to_obs)
             x, y, image = x_y_image
-            visible[] = false
-            imgp[1] = x
-            imgp[2] = y
+            # visible[] = false
+            if !visible[]
+                visible[] = true
+            end
+            if imgp[1][] != x
+                imgp[1] = x
+            end
+            if imgp[2][] != y
+                imgp[2] = y
+            end
             imgp[3] = image
-            visible[] = true
+            # visible[] = true
         end
     end
     bind(image_to_obs, task)

--- a/src/interaction/observables.jl
+++ b/src/interaction/observables.jl
@@ -17,18 +17,25 @@ function safe_off(o::Observables.AbstractObservable, f)
     end
 end
 
-function on_latest(f, observable::Observable; update=false, spawn=false)
-    return on_latest(f, nothing, observable; update=update, spawn=spawn)
+function on_latest(f, observable::Observable; update=false, spawn=false, throttle=0.0)
+    return on_latest(f, nothing, observable; update=update, spawn=spawn, throttle=throttle)
 end
 
-function on_latest(f, to_track, observable::Observable; update=false, spawn=false)
+
+function on_latest(f, to_track, observable::Observable; update=false, spawn=false, throttle=0.0)
+    task_lock = Threads.ReentrantLock()
     last_task = nothing
     has_changed = Threads.Atomic{Bool}(false)
     function run_f(new_value)
+        t1 = time()
         try
             f(new_value)
+            tdiff = time() - t1
+            if throttle > 0.0 && tdiff < throttle
+                sleep(throttle - tdiff)
+            end
         catch e
-            @warn "Error in f" exception=(e, Base.catch_backtrace())
+            @warn "Error in f" exception = (e, Base.catch_backtrace())
         end
         # Since we skip updates completely while executing the above `f`
         # We need to check after finishing, if the value has changed!
@@ -43,15 +50,17 @@ function on_latest(f, to_track, observable::Observable; update=false, spawn=fals
     end
 
     function on_callback(new_value)
-        if isnothing(last_task) || istaskdone(last_task)
-            if spawn
-                last_task = Threads.@spawn run_f(new_value)
+        lock(task_lock) do
+            if isnothing(last_task) || istaskdone(last_task)
+                if spawn
+                    last_task = Threads.@spawn run_f(new_value)
+                else
+                    last_task = Threads.@async run_f(new_value)
+                end
             else
-                last_task = Threads.@async run_f(new_value)
+                has_changed[] = true
+                return nothing # Do nothing if working
             end
-        else
-            has_changed[] = true
-            return # Do nothing if working
         end
     end
 
@@ -64,19 +73,20 @@ function on_latest(f, to_track, observable::Observable; update=false, spawn=fals
     end
 end
 
-function onany_latest(f, observables...; update=false, spawn=false)
+function onany_latest(f, observables...; update=false, spawn=false, throttle=0.0)
     result = Observable{Any}(map(to_value, observables))
     onany((args...)-> (result[] = args), observables...)
-    on_latest((args)-> f(args...), result; update=update, spawn=spawn)
+    return on_latest((args) -> f(args...), result; update=update, spawn=spawn, throttle=throttle)
 end
 
-function map_latest!(f, result::Observable, observables...; update=false, spawn=false)
+function map_latest!(f, result::Observable, observables...; update=false, spawn=false, throttle=0.0)
     callback = Observables.MapCallback(f, result, observables)
-    return onany_latest(callback, observables...; update=update, spawn=spawn)
+    return onany_latest(callback, observables...; update=update, spawn=spawn, throttle=throttle)
 end
 
-function map_latest(f, observables...; spawn=false, ignore_equal_values=false)
-    result = Observable(f(map(to_value, observables)...); ignore_equal_values=ignore_equal_values)
-    map_latest!(f, result, observables...; spawn=spawn)
+function map_latest(f, observables...; spawn=false, ignore_equal_values=false, throttle=0.0)
+    first_value = f(map(to_value, observables)...)
+    result = Observable(first_value; ignore_equal_values=ignore_equal_values)
+    map_latest!(f, result, observables..., spawn=spawn, throttle=throttle)
     return result
 end

--- a/src/makielayout/blocks/slider.jl
+++ b/src/makielayout/blocks/slider.jl
@@ -59,10 +59,13 @@ function initialize_block!(sl::Slider)
         selected_index[] = closest_index(rng, sl.value[])
     end
 
-    on(topscene, selected_index) do i
-        sl.value[] = sliderrange[][i]
+    onany(topscene, selected_index, dragging) do i, dragging
+        new_val = get(sliderrange[], i, nothing)
+        if !isnothing(new_val) && !dragging[] && sl.value[] != new_val
+            sl.value[] = new_val
+        end
     end
-
+    sl.value[] = sliderrange[][selected_index[]]
     # initialize slider value with closest from range
     selected_index[] = closest_index(sliderrange[], sl.startvalue[])
 

--- a/src/makielayout/blocks/slider.jl
+++ b/src/makielayout/blocks/slider.jl
@@ -61,7 +61,10 @@ function initialize_block!(sl::Slider)
 
     onany(topscene, selected_index, dragging) do i, dragging
         new_val = get(sliderrange[], i, nothing)
-        if !isnothing(new_val) && !dragging[] && sl.value[] != new_val
+        has_value = !isnothing(new_val)
+        has_changed = sl.value[] != new_val
+        drag_updates = sl.update_while_dragging[] || !dragging[]
+        if has_value && has_changed && drag_updates
             sl.value[] = new_val
         end
     end

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -964,6 +964,8 @@ end
         horizontal::Bool = true
         "The align mode of the slider in its parent GridLayout."
         alignmode = Inside()
+        "If false, slider only updates value once dragging stops"
+        update_while_dragging = true
         "Controls if the button snaps to valid positions or moves freely"
         snap::Bool = true
     end
@@ -1810,7 +1812,7 @@ end
         "The color of y spine 3 opposite of the ticks"
         yspinecolor_3 = :black
         "The color of z spine 3 opposite of the ticks"
-        zspinecolor_3 = :black       
+        zspinecolor_3 = :black
         "Controls if the 4. Spines are created to close the outline box"
         front_spines = false
         "The color of x spine 4"


### PR DESCRIPTION
- Added option `update_while_dragging=true` to Slider
- Added option `lowres_background=true` to Resampler, and renamed `resolution` to `max_resolution`
- Added option `throttle=0.0` to `async_latest`, to allow throttling while skipping latest updates. This helps when the julia side is faster than the overall operation, so the latest values aren't getting skipped. This is the case e.g. when updating a large heatmap in WGLMakie, which takes quite a bit of time on the JS side, which `async_latest` doesn't know about, making it drop to few updates.