### PR TITLE
Fix voxels on linux firefox 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added a tutorial on creating an inset plot [#4697](https://github.com/MakieOrg/Makie.jl/pull/4697)
 - Enhanced Pattern support: Added general CairoMakie implementation, improved quality, added anchoring, added support in band, density, added tests & fixed various bugs and inconsistencies. [#4715](https://github.com/MakieOrg/Makie.jl/pull/4715)
 - Fixed issue with `voronoiplot` for Voronoi tessellations with empty polygons [#4740](https://github.com/MakieOrg/Makie.jl/pull/4740)
+- Fixed issue with `WGLMakie.voxels` not rendering on linux with firefox [#4756](https://github.com/MakieOrg/Makie.jl/pull/4756)
 
 ## [0.22.1] - 2025-01-17
 

--- a/WGLMakie/assets/voxel.vert
+++ b/WGLMakie/assets/voxel.vert
@@ -27,7 +27,9 @@ const mat2x3 orientations[3] = mat2x3[](
 );
 
 void main() {
-    get_dummy(); // otherwise this doesn't render :)
+    // Without fetching the instanced data the shader wont render. On some
+    // systems (linux + firefox for example) this even needs to be used.
+    float zero = get_dummy();
 
     /* How this works:
     To simplify lets consider a 2d grid of pixel where the voxel surface would
@@ -66,7 +68,7 @@ void main() {
     // Map instance id to dimension and index along dimension (0..N+1 or 0..2N)
     ivec3 size = textureSize(voxel_id, 0);
     int dim, id = gl_InstanceID, front = 1;
-    float gap = get_gap();
+    float gap = get_gap() + zero;
     if (gap > 0.01) {
         front = 1 - 2 * int(gl_InstanceID & 1);
         if (id < 2 * size.z) {


### PR DESCRIPTION
# Description

With firefox on linux voxels() refuses to render. (Also affects Pluto, at least when opened with firefox) This is caused by the per-instance dummy data of voxels not being used in the shader. 

I don't remember what exactly I tested before, but when I originally implemented this just fetching the per-instance data was enough. And it is in vscode and in chrome, but not in firefox. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
