### PR TITLE
Use the raw export string from Showoff.showoff to manipulate axis labels.

### DIFF
--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -654,7 +654,27 @@ end
 
 Gets tick labels by applying `showoff_minus` to `values`.
 """
-get_ticklabels(::Automatic, values) = showoff_minus(values)
+function get_ticklabels(::Automatic, values)
+    rawstrings = Showoff.showoff(values, export_raw = true)
+    converted = Vector{Union{String, Makie.RichText}}(undef, length(rawstrings))
+    converted[:] = rawstrings[:] 
+    sci_notation_index = findfirst.("e", rawstrings)
+    plain_notation = isnothing.(sci_notation_index)
+    sci_notation_indices = findall(.!(plain_notation))
+    converted[plain_notation] = replace.(converted[plain_notation], r"-(?=\d)" => MINUS_SIGN)
+    for (i, idx) in enumerate(sci_notation_indices)
+        str = rawstrings[idx]
+        base_number, power = split(str, "e")
+        upperscript_str = string(parse(Int32, power))
+        converted[idx] = rich(
+            string(base_number) * "×10",
+            superscript(replace(upperscript_str, r"-(?=\d)" => MINUS_SIGN)),
+            offset = Vec2f(0.1f0, 0f0)
+        )
+    end
+
+    return converted
+end
 
 """
     get_ticklabels(formatfunction::Function, values)


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #2467 

Also introduced in my previous PR #4424 . However the previous solution was not elegant. So I submitted a PR for `Showoff.jl` to add an option exporting the raw strings for `RichText`. 

Ping @jkrumbiegel if you are satisfied with is PR. Please let me know if you have any suggestion for improvement.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
