### PR TITLE
Fix markdown list in docstring

### DIFF
--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -21,12 +21,12 @@
     - For `webm`, `63` is the maximum.
     - `compression` has no effect on `mkv` and `gif` outputs.
 - `profile = "high422"`: A ffmpeg compatible profile. Currently only applies to `mp4`. If
-you have issues playing a video, try `profile = "high"` or `profile = "main"`.
+  you have issues playing a video, try `profile = "high"` or `profile = "main"`.
 - `pixel_format = "yuv420p"`: A ffmpeg compatible pixel format (`-pix_fmt`). Currently only
-applies to `mp4`. Defaults to `yuv444p` for `profile = "high444"`.
+  applies to `mp4`. Defaults to `yuv444p` for `profile = "high444"`.
 - `loop = 0`: Number of times the video is repeated, for a `gif` or `html` output. Defaults to `0`, which
-means infinite looping. A value of `-1` turns off looping, and a value of `n > 0`
-means `n` repetitions (i.e. the video is played `n+1` times) when supported by backend.
+  means infinite looping. A value of `-1` turns off looping, and a value of `n > 0`
+  means `n` repetitions (i.e. the video is played `n+1` times) when supported by backend.
 
 !!! warning
     `profile` and `pixel_format` are only used when `format` is `"mp4"`; a warning will be issued if `format`


### PR DESCRIPTION


# Description

Fixes markdown list in the docstring of VideoStreamOptions in  ffmpeg-util.jl.

Indenting makes sure each list item is kept whole.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added or changed relevant sections in the documentation
