### PR TITLE
Fix function signatures in docstrings

### DIFF
--- a/src/event-recorder.jl
+++ b/src/event-recorder.jl
@@ -1,6 +1,6 @@
 
 """
-record_events(f, scene::Scene, path::String)
+    record_events(f, scene::Scene, path::String)
 
 Records all window events that happen while executing function `f`
 for `scene` and serializes them to `path`.
@@ -24,8 +24,8 @@ function record_events(f, scene::Scene, path::String)
 end
 
 """
-replay_events(f, scene::Scene, path::String)
-replay_events(scene::Scene, path::String)
+    replay_events(f, scene::Scene, path::String)
+    replay_events(scene::Scene, path::String)
 
 Replays the serialized events recorded with `record_events` in `path` in `scene`.
 """


### PR DESCRIPTION
# Description

Fix docstrings for record_event and replay_event in event-recorder.jl

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added or changed relevant sections in the documentation