### PR TITLE
Use sources attribute in docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -28,3 +28,11 @@ RPRMakie = "22d9f318-5e34-4b44-b769-6e3734a732a6"
 RadeonProRender = "27029320-176d-4a42-b57d-56729d2ad457"
 Typst_jll = "eb4b1da6-20f6-5c66-9826-fdb8ad410d0e"
 WGLMakie = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
+
+[sources]
+Makie = { path = ".." }
+MakieCore = { path = "../MakieCore" }
+CairoMakie = { path = "../CairoMakie" }
+GLMakie = { path = "../GLMakie" }
+WGLMakie = { path = "../WGLMakie" }
+RPRMakie = { path = "../RPRMakie" }

--- a/docs/makedocs.jl
+++ b/docs/makedocs.jl
@@ -1,7 +1,7 @@
 using Pkg
 cd(@__DIR__)
 Pkg.activate(".")
-pkg"dev .. ../MakieCore ../CairoMakie ../GLMakie ../WGLMakie ../RPRMakie"
+Pkg.instantiate()
 Pkg.precompile()
 
 using CairoMakie


### PR DESCRIPTION
# Description

This takes advantage of the `sources.<pkgname>.path` attributes in the docs/Project.toml file. Since this repo hosts multiple packages, this moves dependency management into the Project.toml file for the docs rather than making a script do it separately. This can also help with reproducing the docs environment more easily.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

