### PR TITLE
Allow `Block.attri...` to autocomplete

### DIFF
--- a/src/ffmpeg-util.jl
+++ b/src/ffmpeg-util.jl
@@ -21,12 +21,12 @@
     - For `webm`, `63` is the maximum.
     - `compression` has no effect on `mkv` and `gif` outputs.
 - `profile = "high422"`: A ffmpeg compatible profile. Currently only applies to `mp4`. If
-you have issues playing a video, try `profile = "high"` or `profile = "main"`.
+  you have issues playing a video, try `profile = "high"` or `profile = "main"`.
 - `pixel_format = "yuv420p"`: A ffmpeg compatible pixel format (`-pix_fmt`). Currently only
-applies to `mp4`. Defaults to `yuv444p` for `profile = "high444"`.
+  applies to `mp4`. Defaults to `yuv444p` for `profile = "high444"`.
 - `loop = 0`: Number of times the video is repeated, for a `gif` or `html` output. Defaults to `0`, which
-means infinite looping. A value of `-1` turns off looping, and a value of `n > 0`
-means `n` repetitions (i.e. the video is played `n+1` times) when supported by backend.
+  means infinite looping. A value of `-1` turns off looping, and a value of `n > 0`
+  means `n` repetitions (i.e. the video is played `n+1` times) when supported by backend.
 
 !!! warning
     `profile` and `pixel_format` are only used when `format` is `"mp4"`; a warning will be issued if `format`

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -643,4 +643,6 @@ function REPL.fielddoc(t::Type{<:Block}, s::Symbol)
     return repl_docstring(nameof(t), s, docs, examples, default_str)
 end
 
-Base.propertynames(::Type{T}) where {T <: Block} = keys(_attribute_docs(T))
+# collect() doesn't seem to be necessary but the propertynames docstring says
+# "tuple or vector" so lets not return a KeySet
+Base.propertynames(::Type{T}) where {T <: Block} = collect(keys(_attribute_docs(T)))

--- a/src/makielayout/blocks.jl
+++ b/src/makielayout/blocks.jl
@@ -642,3 +642,5 @@ function REPL.fielddoc(t::Type{<:Block}, s::Symbol)
     default_str = Makie.attribute_default_expressions(t)[s]
     return repl_docstring(nameof(t), s, docs, examples, default_str)
 end
+
+Base.propertynames(::Type{T}) where {T <: Block} = keys(_attribute_docs(T))

--- a/test/SceneLike/makielayout.jl
+++ b/test/SceneLike/makielayout.jl
@@ -1,3 +1,5 @@
+using InteractiveUtils: subtypes
+
 # Minimal sanity checks for Makie Layout
 @testset "Blocks constructors" begin
     fig = Figure()

--- a/test/SceneLike/makielayout.jl
+++ b/test/SceneLike/makielayout.jl
@@ -18,6 +18,13 @@
     @test true
 end
 
+@testset "Generic Block functionality" begin
+    for T in subtypes(Makie.Block)
+        T === Makie.AbstractAxis && continue
+        @test propertynames(T) isa Vector{Symbol}
+    end
+end
+
 @testset "deleting from axis" begin
     f = Figure()
     ax = Axis(f[1, 1])


### PR DESCRIPTION
# Description

Fixes #3749

This adds autocompletion on Block types. I'm not sure if these should exist, because e.g. `Axis.ytickalign` doesn't exist (Axis is a type), but it is nice for querying docs `?Axis.ytickalign`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
