### PR TITLE
Add a MacOS test runner to GLMakie

### DIFF
--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -79,6 +79,9 @@ jobs:
           - ubuntu-20.04
         arch:
           - x64
+        include:
+          - os: macos-latest
+            version: '1'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

There are a lot of issues on Mac that we don't catch, this PR is a foot in the direction of catching those.
We may also want to set the JULIA_NUM_THREADS optionally in some runs to test if we have multithreading issues.

This is a CI change only.