### PR TITLE
Add option to turn off clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed issue with `WGLMakie.voxels` not rendering on linux with firefox [#4756](https://github.com/MakieOrg/Makie.jl/pull/4756)
 - Cleaned up surface handling in GLMakie: Surface cells are now discarded when there is a nan in x, y or z. Fixed incorrect normal if x or y is nan [#4735](https://github.com/MakieOrg/Makie.jl/pull/4735)
 - Cleaned up `volume` plots: Added `:indexedabsorption` and `:additive` to WGLMakie, generalized `:mip` to include negative values, fixed missing conversions for rgba algorithms (`:additive`, `:absorptionrgba`), fixed missing conversion for `absorption` attribute & extended it to `:indexedabsorption` and `absorptionrgba`, added tests and improved docs. [#4726](https://github.com/MakieOrg/Makie.jl/pull/4726)
+- Added `Axis3.clip` attribute to allow turning off clipping [#4791](https://github.com/MakieOrg/Makie.jl/pull/4791)
 
 ## [0.22.1] - 2025-01-17
 

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -406,13 +406,20 @@ end
     m = GeometryBasics.mesh(Point3f.(ps), _fs, normal = face_normals(ps, _fs))
 
     # Should create closed square and hexagonal cells
-    f = Figure()
+    f = Figure(size = (600, 300))
     a = Axis3(f[1, 1], aspect = :data,
         xautolimitmargin=(0,0), yautolimitmargin=(0,0), zautolimitmargin=(0,0)
     )
     lines!(a, ls, linewidth = 3, transparency = true)
     mesh!(a, m, color = (:orange, 0.2), transparency = true)
     scatter!(a, ps, markersize = 30, transparency = true)
+
+    a = Axis3(f[1, 2], aspect = :data, clip = false,
+        xautolimitmargin=(0,0), yautolimitmargin=(0,0), zautolimitmargin=(0,0)
+    )
+    lines!(a, ls, linewidth = 3, transparency = true)
+    mesh!(a, m, color = (:orange, 0.2), transparency = true)
+    meshscatter!(a, ps, markersize = 0.15, transparency = false)
     f
 end
 

--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -30,11 +30,15 @@ function initialize_block!(ax::Axis3)
     ax.scene = scene
     cam = Axis3Camera()
     cameracontrols!(scene, cam)
-    scene.theme.clip_planes = map(scene, scene.transformation.model, ax.finallimits) do model, lims
-        _planes = planes(lims)
-        _planes = apply_transform.(Ref(model), _planes)
-        nudge = 1f0 + 1f-5 # clip slightly outside to avoid float precision issues with 0 margin
-        return map(plane -> Plane3f(plane.normal, nudge * plane.distance), _planes)
+    scene.theme.clip_planes = map(scene, scene.transformation.model, ax.finallimits, ax.clip) do model, lims, clip
+        if clip
+            _planes = planes(lims)
+            _planes = apply_transform.(Ref(model), _planes)
+            nudge = 1f0 + 1f-5 # clip slightly outside to avoid float precision issues with 0 margin
+            return map(plane -> Plane3f(plane.normal, nudge * plane.distance), _planes)
+        else
+            return Plane3f[]
+        end
     end
 
     mi1 = Observable(!(pi/2 <= mod1(ax.azimuth[], 2pi) < 3pi/2))

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1679,6 +1679,8 @@ end
             a whole with `control + right drag`.
         """
         viewmode = :fitzoom # :fit :fitzoom :stretch
+        "Controls whether content is clipped at the axis frame. Note that you can also overwrite clipping per plot by setting `clip_planes = Plane3f[]`."
+        clip::Bool = true
         "The background color"
         backgroundcolor = :transparent
         "The x label"


### PR DESCRIPTION
# Description

Allows you to do this with `ax.clip[] = false` if you want

![image](https://github.com/user-attachments/assets/4ae2e589-856a-4534-8863-56e52ecd028e)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
