### PR TITLE
resize wgl content using ResizeObserver

### DIFF
--- a/WGLMakie/src/wglmakie.bundled.js
+++ b/WGLMakie/src/wglmakie.bundled.js
@@ -24361,8 +24361,9 @@ function add_canvas_events(screen, comm, resize_to) {
     }
     if (resize_to) {
         const resize_callback_throttled = Bonito.throttle_function(resize_callback, 100);
-        window.addEventListener("resize", (event)=>resize_callback_throttled());
-        setTimeout(resize_callback, 50);
+        const resizeObserver = new ResizeObserver(resize_callback_throttled);
+        resizeObserver.observe(canvas.parentElement);
+        resize_callback();
     }
 }
 function threejs_module(canvas) {

--- a/WGLMakie/src/wglmakie.js
+++ b/WGLMakie/src/wglmakie.js
@@ -353,13 +353,14 @@ function add_canvas_events(screen, comm, resize_to) {
             resize_callback,
             100
         );
-        window.addEventListener("resize", (event) =>
-            resize_callback_throttled()
-        );
+
+        // use resize observer to watch parent size changes
+        const resizeObserver = new ResizeObserver(resize_callback_throttled);
+        resizeObserver.observe(canvas.parentElement);
+
         // Fire the resize event once at the start to auto-size our window
-        // Without setTimeout, the parent doesn't have the right size yet?
-        // TODO, there should be a way to do this cleanly
-        setTimeout(resize_callback, 50);
+        // No need for setTimeout since resizeObserver should pick up on changes from now on
+        resize_callback();
     }
 }
 


### PR DESCRIPTION
# Description
Currently, each WGLMakie figure registers a `resize` event listener on the `window` to trigger `resize_to=:parent` updates. This checks for changes in viewport but not changes of the individual elements (i.e. the MWE below does not work correctly until you change the viewport size).

I propose to change this to a `ResizeObserver` on the parent itself.

I didn't add or change any tests since I don't know how something like this could be tested.
The [browser compatiblity](https://caniuse.com/resizeobserver) seems good but not great. Do we need some kind of fallback? Not sure about the WGLMakie project goals in that regard.

```julia
using Bonito, WGLMakie
WGLMakie.activate!(resize_to=:parent)

app = App() do session
    fig = scatter(rand(3))
    Card(fig; style=Styles(
        "height"=>"500px",
        "width"=>"500px",
        "resize"=>"both",
        "overflow"=>"hidden",
    ))
end;

isdefined(Main, :server) && close(server)
server = Bonito.Server(app, "127.0.0.1", 8082)
```

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
