### PR TITLE
Fix WGLMakie tick and window_open events 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reverted change to `poly` which disallowed 3D geometries from being plotted [#4738](https://github.com/MakieOrg/Makie.jl/pull/4738)
 - Enabled autocompletion on Block types, e.g. `?Axis.xti...` [#4786](https://github.com/MakieOrg/Makie.jl/pull/4786)
 - Added `dpi` metadata to all rendered png files, where `px_per_unit = 1` means 96dpi, `px_per_unit = 2` means 192dpi, and so on. This gives frontends a chance to show plain Makie png images with the correct scaling [#4812](https://github.com/MakieOrg/Makie.jl/pull/4812).
+- Fixed issue with tick event not triggering in WGLMakie [#4818](https://github.com/MakieOrg/Makie.jl/pull/4818)
 
 ## [0.22.1] - 2025-01-17
 

--- a/GLMakie/test/runtests.jl
+++ b/GLMakie/test/runtests.jl
@@ -110,7 +110,7 @@ end
     sleep(0.1)
     GLMakie.closeall()
 
-        # Why does it start with a skipped tick?
+    # Why does it start with a skipped tick?
     i = 1
     while tick_record[i].state == Makie.SkippedRenderTick
         check_tick(tick_record[1], Makie.SkippedRenderTick, i)
@@ -133,6 +133,11 @@ end
     @test i == length(tick_record)+1
 end
 
+
+
+
+# NOTE: Keep this at the end! It also verifies that all cleanup is complete after
+#       all other tests have finished
 
 @testset "gl object deletion" begin
     GLMakie.closeall()

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -179,8 +179,11 @@ end
 Base.resize!(::WGLMakie.Screen, w, h) = nothing
 
 function Base.isopen(screen::Screen)
-    isnothing(screen.scene) && return false
-    return screen.scene.events.window_open[]
+    # This function is used as the source of truth for dynamically setting
+    # window_open[] = false (as opposed to using close()), so it can't just
+    # rely on window_open. Check the session too.
+    return !isnothing(screen.scene) && screen.scene.events.window_open[] &&
+        !isnothing(screen.session) && isopen(screen.session)
 end
 
 function mark_as_displayed!(screen::Screen, scene::Scene)

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -207,7 +207,12 @@ function Makie.backend_showable(::Type{Screen}, ::T) where {T<:MIME}
     return T in Makie.WEB_MIMES
 end
 
-Base.close(screen::Screen) = close(screen.session)
+function Base.close(screen::Screen)
+    Makie.stop!(screen.tick_clock)
+    events(screen.scene).window_open[] = false
+    close(screen.session)
+    return
+end
 
 function Base.size(screen::Screen)
     return size(screen.scene)

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -102,6 +102,7 @@ function render_with_init(screen::Screen, session::Session, scene::Scene)
         if initialized == true
             put!(screen.plot_initialized, true)
             mark_as_displayed!(screen, scene)
+            connect_post_init_events(screen, scene)
         else
             # Will be an error from WGLMakie.js
             put!(screen.plot_initialized, initialized)

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -179,8 +179,8 @@ end
 Base.resize!(::WGLMakie.Screen, w, h) = nothing
 
 function Base.isopen(screen::Screen)
-    session = get_screen_session(screen)
-    return !isnothing(session) && isopen(session)
+    isnothing(screen.scene) && return false
+    return screen.scene.events.window_open[]
 end
 
 function mark_as_displayed!(screen::Screen, scene::Scene)
@@ -210,7 +210,6 @@ end
 function Base.close(screen::Screen)
     Makie.stop!(screen.tick_clock)
     events(screen.scene).window_open[] = false
-    close(screen.session)
     return
 end
 

--- a/WGLMakie/src/display.jl
+++ b/WGLMakie/src/display.jl
@@ -207,8 +207,7 @@ function Makie.backend_showable(::Type{Screen}, ::T) where {T<:MIME}
     return T in Makie.WEB_MIMES
 end
 
-# TODO implement
-Base.close(screen::Screen) = nothing
+Base.close(screen::Screen) = close(screen.session)
 
 function Base.size(screen::Screen)
     return size(screen.scene)

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -123,7 +123,7 @@ end
 
 
 function connect_post_init_events(screen, scene)
-    @assert isopen(screen) "Window most be initialized first"
+    @assert isopen(screen) "Window must be initialized first"
 
     e = events(scene)
     tick_callback = Makie.TickCallback(e.tick)

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -123,6 +123,10 @@ end
 
 
 function connect_post_init_events(screen, scene)
+    for attempt in 1:10
+        isopen(screen) && break
+        sleep(0.1 * attempt)
+    end
     @assert isopen(screen) "Window must be initialized first"
 
     e = events(scene)

--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -118,16 +118,29 @@ function connect_scene_events!(screen::Screen, scene::Scene, comm::Observable)
         return
     end
 
+    return
+end
+
+
+function connect_post_init_events(screen, scene)
+    @assert isopen(screen) "Window most be initialized first"
+
+    e = events(scene)
     tick_callback = Makie.TickCallback(e.tick)
+
+    # key = rand(UInt16) # Is the right clock closing?
     Makie.start!(screen.tick_clock) do timer
         if isopen(screen)
             tick_callback(Makie.RegularRenderTick)
-            # @info "tick $(e.tick[].count) $(e.tick[].delta_time)"
+            # @info "$key tick $(e.tick[].count) $(e.tick[].delta_time)"
         else
+            # @info "stopping $key"
             Makie.stop!(timer)
+            e.window_open[] = false
         end
         return
     end
 
     return
 end
+

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -45,60 +45,6 @@ edisplay = Bonito.use_electron_display(devtools=true)
     #     ReferenceTests.test_comparison(scores; threshold = 0.05)
     # end
 
-    @testset "memory leaks" begin
-        Makie.CURRENT_FIGURE[] = nothing
-        app = App(nothing)
-        display(edisplay, app)
-        GC.gc(true);
-        # Somehow this may take a while to get emptied completely
-        p_key = "Object.keys(WGL.plot_cache)"
-        value = @time Bonito.wait_for(() -> (GC.gc(true); isempty(run(edisplay.window, p_key))); timeout=50)
-        @show run(edisplay.window, p_key)
-        @test value == :success
-
-        s_keys = "Object.keys(Bonito.Sessions.SESSIONS)"
-        value = @time Bonito.wait_for(() -> (GC.gc(true); length(run(edisplay.window, s_keys)) == 2); timeout=50)
-        @show run(edisplay.window, s_keys)
-        @show app.session[].id
-        @show app.session[].parent
-        # It seems, we don't free all sessions right now, which needs fixing.
-        # @test value == :success
-
-        wgl_plots = run(edisplay.window, "Object.keys(WGL.scene_cache)")
-        @test isempty(wgl_plots)
-
-        session = edisplay.browserdisplay.handler.session
-        session_size = Base.summarysize(session) / 10^6
-        texture_atlas_size = Base.summarysize(WGLMakie.TEXTURE_ATLAS) / 10^6
-
-        @test length(WGLMakie.TEXTURE_ATLAS.listeners) == 1 # Only one from permanent Retain
-        @test length(session.session_objects) == 1 # Also texture atlas because of Retain
-        @testset "Session fields empty" for field in [:on_document_load, :stylesheets, :imports, :message_queue, :deregister_callbacks, :inbox]
-            @test isempty(getfield(session, field))
-        end
-        server = session.connection.server
-        @test length(server.websocket_routes.table) == 1
-        @test server.websocket_routes.table[1][2] == session.connection
-        @test length(server.routes.table) == 2
-        @test server.routes.table[1][1] == "/browser-display"
-        @test server.routes.table[2][2] isa HTTPAssetServer
-        @show typeof.(last.(WGLMakie.TEXTURE_ATLAS.listeners))
-        @show length(WGLMakie.TEXTURE_ATLAS.listeners)
-        @show session_size texture_atlas_size
-
-        # TODO, this went up from 6 to 11mb, likely because of a session not getting freed
-        # It could be related to the error in the console:
-        # " Trying to send to a closed session"
-        # So maybe a subsession closes and doesn't get freed?
-        @test session_size < 11
-        @test texture_atlas_size < 11
-
-        js_sessions = run(edisplay.window, "Bonito.Sessions.SESSIONS")
-        js_objects = run(edisplay.window, "Bonito.Sessions.GLOBAL_OBJECT_CACHE")
-        # @test Set([app.session[].id, app.session[].parent.id]) == keys(js_sessions)
-        # we used Retain for global_obs, so it should stay as long as root session is open
-        @test keys(js_objects) == Set([WGLMakie.TEXTURE_ATLAS.id])
-    end
 
     @testset "window open/closed" begin
         f, a, p = scatter(rand(10));
@@ -204,4 +150,60 @@ edisplay = Bonito.use_electron_display(devtools=true)
             @test 28 <= length(tick_record) <= 33
         end
     end
+
+    @testset "memory leaks" begin
+        Makie.CURRENT_FIGURE[] = nothing
+        app = App(nothing)
+        display(edisplay, app)
+        GC.gc(true);
+        # Somehow this may take a while to get emptied completely
+        p_key = "Object.keys(WGL.plot_cache)"
+        value = @time Bonito.wait_for(() -> (GC.gc(true); isempty(run(edisplay.window, p_key))); timeout=50)
+        @show run(edisplay.window, p_key)
+        @test value == :success
+
+        s_keys = "Object.keys(Bonito.Sessions.SESSIONS)"
+        value = @time Bonito.wait_for(() -> (GC.gc(true); length(run(edisplay.window, s_keys)) == 2); timeout=50)
+        @show run(edisplay.window, s_keys)
+        @show app.session[].id
+        @show app.session[].parent
+        # It seems, we don't free all sessions right now, which needs fixing.
+        # @test value == :success
+
+        wgl_plots = run(edisplay.window, "Object.keys(WGL.scene_cache)")
+        @test isempty(wgl_plots)
+
+        session = edisplay.browserdisplay.handler.session
+        session_size = Base.summarysize(session) / 10^6
+        texture_atlas_size = Base.summarysize(WGLMakie.TEXTURE_ATLAS) / 10^6
+
+        @test length(WGLMakie.TEXTURE_ATLAS.listeners) == 1 # Only one from permanent Retain
+        @test length(session.session_objects) == 1 # Also texture atlas because of Retain
+        @testset "Session fields empty" for field in [:on_document_load, :stylesheets, :imports, :message_queue, :deregister_callbacks, :inbox]
+            @test isempty(getfield(session, field))
+        end
+        server = session.connection.server
+        @test length(server.websocket_routes.table) == 1
+        @test server.websocket_routes.table[1][2] == session.connection
+        @test length(server.routes.table) == 2
+        @test server.routes.table[1][1] == "/browser-display"
+        @test server.routes.table[2][2] isa HTTPAssetServer
+        @show typeof.(last.(WGLMakie.TEXTURE_ATLAS.listeners))
+        @show length(WGLMakie.TEXTURE_ATLAS.listeners)
+        @show session_size texture_atlas_size
+
+        # TODO, this went up from 6 to 11mb, likely because of a session not getting freed
+        # It could be related to the error in the console:
+        # " Trying to send to a closed session"
+        # So maybe a subsession closes and doesn't get freed?
+        @test session_size < 11
+        @test texture_atlas_size < 11
+
+        js_sessions = run(edisplay.window, "Bonito.Sessions.SESSIONS")
+        js_objects = run(edisplay.window, "Bonito.Sessions.GLOBAL_OBJECT_CACHE")
+        # @test Set([app.session[].id, app.session[].parent.id]) == keys(js_sessions)
+        # we used Retain for global_obs, so it should stay as long as root session is open
+        @test keys(js_objects) == Set([WGLMakie.TEXTURE_ATLAS.id])
+    end
+
 end

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -58,9 +58,6 @@ edisplay = Bonito.use_electron_display(devtools=true)
 
         close(f.scene.current_screens[1])
         @test isempty(f.scene.current_screens) || !isopen(first(f.scene.current_screens))
-        # window_open checks isopen on a timer so we need to wait a little for it to update
-        # isclosed() relies on window_open, so it too needs some time
-        sleep(0.1)
         @test events(f).window_open[] == false
         @test Makie.isclosed(f.scene) == true
     end

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -100,6 +100,23 @@ edisplay = Bonito.use_electron_display(devtools=true)
         @test keys(js_objects) == Set([WGLMakie.TEXTURE_ATLAS.id])
     end
 
+    @testset "window open/closed" begin
+        f, a, p = scatter(rand(10));
+        @test events(f).window_open[] == false
+        @test Makie.isclosed(f.scene) == false
+        @test isempty(f.scene.current_screens) || !isopen(first(f.scene.current_screens))
+
+        colorbuffer(f)
+        @test events(f).window_open[] == true
+        @test Makie.isclosed(f.scene) == false
+        @test !isempty(f.scene.current_screens) && isopen(first(f.scene.current_screens))
+
+        close(f.scene.current_screens[1])
+        @test events(f).window_open[] == false
+        @test Makie.isclosed(f.scene) == true
+        @test isempty(f.scene.current_screens) || !isopen(first(f.scene.current_screens))
+    end
+
     @testset "Tick Events" begin
         function check_tick(tick, state, count)
             @test tick.state == state

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -138,16 +138,24 @@ edisplay = Bonito.use_electron_display(devtools=true)
             @test isempty(tick_record)
             # @test all(tick -> tick.state == Makie.UnknownTickState, tick_record)
 
-            colorbuffer(f)
             t0 = time()
+            colorbuffer(f)
             sleep(1)
-            dt = time() - t0
             close(f.scene.current_screens[1])
+            dt_max = time() - t0
+            sleep(1)
 
-            # Best case: (one tick at 0, probably 1 at end)
-            @test 30 <= length(tick_record) <= 31
-            # good enough?
-            @test 28 <= length(tick_record) <= 33
+            # tests don't make this easy...
+            @test 28 <= length(tick_record) <= round(Int, 30dt_max) + 2
+            t = 0.0
+            for (i, tick) in enumerate(tick_record)
+                @test tick.state == Makie.RegularRenderTick
+                @test tick.count == i
+                @test tick.time > t
+                t = tick.time
+            end
+            # first tick is arbitrary
+            @test Makie.mean([tick.delta_time for tick in tick_record[2:end]]) ≈ 0.033 atol = 0.001
         end
     end
 

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -46,7 +46,7 @@ edisplay = Bonito.use_electron_display(devtools=true)
     end
 
     @testset "window open/closed" begin
-        f, a, p = scatter(rand(10))
+        f, a, p = scatter(rand(10));
         @test events(f).window_open[] == false
         @test Makie.isclosed(f.scene) == false
         @test isempty(f.scene.current_screens) || !isopen(first(f.scene.current_screens))


### PR DESCRIPTION
# Description

Changes:
- added `close(screen)` implementation
- split tick events from other events so they can be added after screen initialization
- added window open check in tick loop
- added test for isclosed, isopen, events.window_open

TODO:
- [x] try to add tests for tick events of a running WGLMakie window

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
