### PR TITLE
Fix voxel transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Reverted change to `poly` which disallowed 3D geometries from being plotted [#4738](https://github.com/MakieOrg/Makie.jl/pull/4738)
 - Enabled autocompletion on Block types, e.g. `?Axis.xti...` [#4786](https://github.com/MakieOrg/Makie.jl/pull/4786)
 - Added `dpi` metadata to all rendered png files, where `px_per_unit = 1` means 96dpi, `px_per_unit = 2` means 192dpi, and so on. This gives frontends a chance to show plain Makie png images with the correct scaling [#4812](https://github.com/MakieOrg/Makie.jl/pull/4812).
+- Fixed issue with voxels not working correctly with `rotate!()` [#4824](https://github.com/MakieOrg/Makie.jl/pull/4824)
 
 ## [0.22.1] - 2025-01-17
 

--- a/GLMakie/assets/shader/voxel.vert
+++ b/GLMakie/assets/shader/voxel.vert
@@ -174,7 +174,8 @@ void main() {
     // the quad is associated with the "previous" or "next" slice of voxels. We
     // can derive that from the normal direction, as the normal always points
     // away from the voxel center.
-    o_uvw = (plane_vertex - 0.5 * (1.0 - gap) * o_normal) / size;
+    // requires object space normal (unit_vecs[dim])
+    o_uvw = (plane_vertex - 0.5 * (1.0 - gap) * normal_dir * unit_vecs[dim]) / size;
 
     // normal in: -x -y -z +x +y +z direction
     o_side = dim + 3 * int(0.5 + 0.5 * normal_dir);

--- a/GLMakie/src/glshaders/voxel.jl
+++ b/GLMakie/src/glshaders/voxel.jl
@@ -3,6 +3,7 @@ function draw_voxels(screen, main::VolumeTypes, data::Dict)
     geom = Rect2f(Point2f(0), Vec2f(1.0))
     to_opengl_mesh!(screen.glscreen, data, const_lift(GeometryBasics.triangle_mesh, geom))
     shading = pop!(data, :shading, FastShading)
+    debug = to_value(pop!(data, :debug, ""))
     @gen_defaults! data begin
         voxel_id = main => Texture
         gap = 0f0
@@ -26,7 +27,7 @@ function draw_voxels(screen, main::VolumeTypes, data::Dict)
                 "MAX_LIGHT_PARAMETERS" => "#define MAX_LIGHT_PARAMETERS $(screen.config.max_light_parameters)",
                 "buffers" => output_buffers(screen, to_value(transparency)),
                 "buffer_writes" => output_buffer_writes(screen, to_value(transparency)),
-                "DEBUG_FLAG_DEFINE" => to_value(get(data, :debug, ""))
+                "DEBUG_FLAG_DEFINE" => debug
             )
         )
     end

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -790,7 +790,7 @@ end
     cs = [:white, :red, :green, :blue, :black, :orange, :cyan, :magenta]
     voxels(fig[1, 1], chunk, color = cs, axis=(show_axis = false,))
     a, p = voxels(fig[1, 2], Float32.(chunk), colormap = [:red, :blue], is_air = x -> x == 0.0, axis=(show_axis = false,))
-    rotate!(p, Vec3f(1,2,3), 0.8)
+    Makie.rotate!(p, Vec3f(1,2,3), 0.8)
     fig
 end
 

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -790,6 +790,7 @@ end
     cs = [:white, :red, :green, :blue, :black, :orange, :cyan, :magenta]
     voxels(fig[1, 1], chunk, color = cs, axis=(show_axis = false,))
     a, p = voxels(fig[1, 2], Float32.(chunk), colormap = [:red, :blue], is_air = x -> x == 0.0, axis=(show_axis = false,))
+    rotate!(p, Vec3f(1,2,3), 0.8)
     fig
 end
 
@@ -805,9 +806,7 @@ end
 
 @reference_test "Voxel - gap attribute" begin
     # test direct mapping of ids to colors & upsampling of vector colormap
-    f,a,p = voxels(RNG.rand(3,3,3), gap = 0.3)
-    rotate!(p, Vec3f(1,2,3), 0.8)
-    f
+    voxels(RNG.rand(3,3,3), gap = 0.3)
 end
 
 @reference_test "Plot transform overwrite" begin

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -805,7 +805,9 @@ end
 
 @reference_test "Voxel - gap attribute" begin
     # test direct mapping of ids to colors & upsampling of vector colormap
-    voxels(RNG.rand(3,3,3), gap = 0.3)
+    f,a,p = voxels(RNG.rand(3,3,3), gap = 0.3)
+    rotate!(p, Vec3f(1,2,3), 0.8)
+    f
 end
 
 @reference_test "Plot transform overwrite" begin

--- a/WGLMakie/assets/voxel.vert
+++ b/WGLMakie/assets/voxel.vert
@@ -165,7 +165,8 @@ void main() {
     // the quad is associated with the "previous" or "next" slice of voxels. We
     // can derive that from the normal direction, as the normal always points
     // away from the voxel center.
-    o_uvw = (plane_vertex - 0.5 * (1.0 - gap) * o_normal) / vec3(size);
+    // requires object space normal (unit_vec[dim])
+    o_uvw = (plane_vertex - 0.5 * (1.0 - gap) * normal_dir * unit_vecs[dim]) / vec3(size);
 
     // normal in: -x -y -z +x +y +z direction
     o_side = dim + 3 * int(0.5 + 0.5 * normal_dir);


### PR DESCRIPTION
# Description

Fixes voxels not rotating correctly (see edge voxels gets elongated or shortened)

![image](https://github.com/user-attachments/assets/226a1961-ec04-45ed-8682-67ba67227bcf)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] ~~Added~~ Adjusted reference image tests for new plotting functions, recipes, visual options, etc.
