### PR TITLE
Fix faulty font selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added `font` attribute and fixed faulty defaulting in `scatter` [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
+- Added `font` and `fonts` attributes to scatter and fixed faulty font defaulting [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
 
 ## [0.22.2] - 2025-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added `font` attribute and fixed faulty defaulting in `scatter` [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
 
 ## [0.22.2] - 2025-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Added `font` and `fonts` attributes to scatter and fixed faulty font defaulting [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
+- Added `font` attribute and fixed faulty defaulting in `scatter` [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
 
 ## [0.22.2] - 2025-02-26
 

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -320,7 +320,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Scat
     isempty(positions) && return
     size_model = transform_marker ? model : Mat4d(I)
 
-    font = to_font(to_value(get(primitive, :font, Makie.defaultfont())))
+    font = to_font(primitive.fonts, primitive.font[])
     colors = to_color(primitive.calculated_colors[])
     markerspace = primitive.markerspace[]
     space = primitive.space[]

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -320,7 +320,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Scat
     isempty(positions) && return
     size_model = transform_marker ? model : Mat4d(I)
 
-    font = to_font(primitive.fonts, primitive.font[])
+    font = to_font(to_value(get(primitive, :font, Makie.defaultfont())))
     colors = to_color(primitive.calculated_colors[])
     markerspace = primitive.markerspace[]
     space = primitive.space[]

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -451,7 +451,7 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::Union{Sca
                         return nothing
                     end
                 end
-                font = get(gl_attributes, :font, Observable(Makie.defaultfont()))
+                font = map(to_font, pop!(gl_attributes, :font))
                 gl_attributes[:uv_offset_width][] == Vec4f(0) && delete!(gl_attributes, :uv_offset_width)
                 get!(gl_attributes, :uv_offset_width) do
                     return Makie.primitive_uv_offset_width(atlas, marker, font)

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -222,7 +222,7 @@ function get_space(x)
 end
 
 const EXCLUDE_KEYS = Set([:transformation, :tickranges, :ticklabels, :raw, :SSAO,
-                        :lightposition, :material, :axis_cycler, :fonts, :font,
+                        :lightposition, :material, :axis_cycler,
                         :inspector_label, :inspector_hover, :inspector_clear, :inspectable,
                         :colorrange, :colormap, :colorscale, :highclip, :lowclip, :nan_color,
                         :calculated_colors, :space, :markerspace, :model, :dim_conversions, :material])
@@ -451,7 +451,7 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::Union{Sca
                         return nothing
                     end
                 end
-                font = map(f -> to_font(plot[:fonts], f), plot[:font])
+                font = map(to_font, pop!(gl_attributes, :font))
                 gl_attributes[:uv_offset_width][] == Vec4f(0) && delete!(gl_attributes, :uv_offset_width)
                 get!(gl_attributes, :uv_offset_width) do
                     return Makie.primitive_uv_offset_width(atlas, marker, font)

--- a/GLMakie/src/drawing_primitives.jl
+++ b/GLMakie/src/drawing_primitives.jl
@@ -222,7 +222,7 @@ function get_space(x)
 end
 
 const EXCLUDE_KEYS = Set([:transformation, :tickranges, :ticklabels, :raw, :SSAO,
-                        :lightposition, :material, :axis_cycler,
+                        :lightposition, :material, :axis_cycler, :fonts, :font,
                         :inspector_label, :inspector_hover, :inspector_clear, :inspectable,
                         :colorrange, :colormap, :colorscale, :highclip, :lowclip, :nan_color,
                         :calculated_colors, :space, :markerspace, :model, :dim_conversions, :material])
@@ -451,7 +451,7 @@ function draw_atomic(screen::Screen, scene::Scene, @nospecialize(plot::Union{Sca
                         return nothing
                     end
                 end
-                font = map(to_font, pop!(gl_attributes, :font))
+                font = map(f -> to_font(plot[:fonts], f), plot[:font])
                 gl_attributes[:uv_offset_width][] == Vec4f(0) && delete!(gl_attributes, :uv_offset_width)
                 get!(gl_attributes, :uv_offset_width) do
                     return Makie.primitive_uv_offset_width(atlas, marker, font)

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -484,10 +484,8 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
     marker_offset = Vec3f(0)
     "Controls whether the model matrix (without translation) applies to the marker itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the marker."
     transform_marker = false
-    "Sets the font used for character marker. Can be a `Symbol` which will be looked up in the `fonts` dictionary or a `String` specifying the (partial) name of a font or the file path of a font file"
-    font = @inherit font
-    "Used as a dictionary to look up fonts specified by `Symbol`, for example `:regular`, `:bold` or `:italic`."
-    fonts = @inherit fonts
+    "Sets the font used for character markers."
+    font = automatic
     "Optional distancefield used for e.g. font and bezier path rendering. Will get set automatically."
     distancefield = nothing
     uv_offset_width = (0.0, 0.0, 0.0, 0.0)

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -484,8 +484,10 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
     marker_offset = Vec3f(0)
     "Controls whether the model matrix (without translation) applies to the marker itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the marker."
     transform_marker = false
-    "Sets the font used for character markers."
-    font = automatic
+    "Sets the font used for character marker. Can be a `Symbol` which will be looked up in the `fonts` dictionary or a `String` specifying the (partial) name of a font or the file path of a font file"
+    font = @inherit font
+    "Used as a dictionary to look up fonts specified by `Symbol`, for example `:regular`, `:bold` or `:italic`."
+    fonts = @inherit fonts
     "Optional distancefield used for e.g. font and bezier path rendering. Will get set automatically."
     distancefield = nothing
     uv_offset_width = (0.0, 0.0, 0.0, 0.0)

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -484,6 +484,8 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
     marker_offset = Vec3f(0)
     "Controls whether the model matrix (without translation) applies to the marker itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the marker."
     transform_marker = false
+    "Sets the font used for character markers."
+    font = automatic
     "Optional distancefield used for e.g. font and bezier path rendering. Will get set automatically."
     distancefield = nothing
     uv_offset_width = (0.0, 0.0, 0.0, 0.0)

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -484,8 +484,8 @@ Plots a marker for each element in `(x, y, z)`, `(x, y)`, or `positions`.
     marker_offset = Vec3f(0)
     "Controls whether the model matrix (without translation) applies to the marker itself, rather than just the positions. (If this is true, `scale!` and `rotate!` will affect the marker."
     transform_marker = false
-    "Sets the font used for character markers."
-    font = automatic
+    "Sets the font used for character markers. Can be a `String` specifying the (partial) name of a font or the file path of a font file"
+    font = @inherit markerfont
     "Optional distancefield used for e.g. font and bezier path rendering. Will get set automatically."
     distancefield = nothing
     uv_offset_width = (0.0, 0.0, 0.0, 0.0)

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -1162,7 +1162,7 @@ end
     fig
 end
 
-@testset "Scatter fonts" begin
+@reference_test "Scatter fonts" begin
     scene = Scene(size = (150, 150), camera = campixel!)
 
     # Just needs to not be Fira Mona here, but good to test the default too

--- a/ReferenceTests/src/tests/primitives.jl
+++ b/ReferenceTests/src/tests/primitives.jl
@@ -1161,3 +1161,22 @@ end
 
     fig
 end
+
+@testset "Scatter fonts" begin
+    scene = Scene(size = (150, 150), camera = campixel!)
+
+    # Just needs to not be Fira Mona here, but good to test the default too
+    @test Makie.to_font(Makie.automatic) == Makie.to_font("TeX Gyre Heros Makie")
+
+    scatter!(scene, (40,  40), marker=Rect, markersize=45, color = :black, strokecolor = :red, strokewidth = 1)
+    scatter!(scene, (40,  40), marker='◇', markersize=45, color = :white)
+    scatter!(scene, (110, 40), marker=Rect, markersize=45, color = :green, strokecolor = :red, strokewidth = 1)
+    text!(scene,    (110, 40), text = "◇", fontsize = 45, align = (:center, :center), color = :white)
+
+    scatter!(scene, (40,  110), marker=Rect, font = "Fira Mono", markersize=45, color = :black, strokecolor = :red, strokewidth = 1)
+    scatter!(scene, (40,  110), marker='◇',  font = "Fira Mono", markersize=45, color = :white)
+    scatter!(scene, (110, 110), marker=Rect, font = "Fira Mono", markersize=45, color = :green, strokecolor = :red, strokewidth = 1)
+    text!(scene,    (110, 110), text = "◇",  font = "Fira Mono", fontsize = 45, align = (:center, :center), color = :white)
+
+    scene
+end

--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -174,7 +174,7 @@ function scatter_shader(scene::Scene, attributes, plot)
     marker = nothing
     atlas = wgl_texture_atlas()
     if haskey(attributes, :marker)
-        font = map(Makie.to_font, pop!(attributes, :fonts), pop!(attributes, :font))
+        font = map(Makie.to_font, pop!(attributes, :font))
         marker = lift(plot, attributes[:marker]) do marker
             marker isa Makie.FastPixel && return Rect # FastPixel not supported, but same as Rect just slower
             marker isa AbstractMatrix{<:Colorant} && return to_color(marker)

--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -174,7 +174,7 @@ function scatter_shader(scene::Scene, attributes, plot)
     marker = nothing
     atlas = wgl_texture_atlas()
     if haskey(attributes, :marker)
-        font = map(Makie.to_font, pop!(attributes, :font))
+        font = map(Makie.to_font, pop!(attributes, :fonts), pop!(attributes, :font))
         marker = lift(plot, attributes[:marker]) do marker
             marker isa Makie.FastPixel && return Rect # FastPixel not supported, but same as Rect just slower
             marker isa AbstractMatrix{<:Colorant} && return to_color(marker)

--- a/WGLMakie/src/particles.jl
+++ b/WGLMakie/src/particles.jl
@@ -174,7 +174,7 @@ function scatter_shader(scene::Scene, attributes, plot)
     marker = nothing
     atlas = wgl_texture_atlas()
     if haskey(attributes, :marker)
-        font = get(attributes, :font, Observable(Makie.defaultfont()))
+        font = map(Makie.to_font, pop!(attributes, :font))
         marker = lift(plot, attributes[:marker]) do marker
             marker isa Makie.FastPixel && return Rect # FastPixel not supported, but same as Rect just slower
             marker isa AbstractMatrix{<:Colorant} && return to_color(marker)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1442,6 +1442,8 @@ end
 
 to_font(fonts::Attributes, x) = to_font(x)
 
+to_font(::Automatic) = defaultfont()
+
 
 """
     rotation accepts:

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -89,7 +89,7 @@ function data_limits(plot::Scatter)
             get_texture_atlas(),
             plot.marker[],
             plot.markersize[],
-            get(plot.attributes, :font, Observable(Makie.defaultfont())),
+            to_font(plot.font[]),
             plot
         )
         rotations = convert_attribute(to_value(get(plot, :rotation, 0)), key"rotation"())

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -89,7 +89,7 @@ function data_limits(plot::Scatter)
             get_texture_atlas(),
             plot.marker[],
             plot.markersize[],
-            to_font(plot.font[]),
+            to_font(plot.fonts, plot.font[]),
             plot
         )
         rotations = convert_attribute(to_value(get(plot, :rotation, 0)), key"rotation"())

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -89,7 +89,7 @@ function data_limits(plot::Scatter)
             get_texture_atlas(),
             plot.marker[],
             plot.markersize[],
-            to_font(plot.fonts, plot.font[]),
+            to_font(plot.font[]),
             plot
         )
         rotations = convert_attribute(to_value(get(plot, :rotation, 0)), key"rotation"())

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -45,6 +45,7 @@ const MAKIE_DEFAULT_THEME = Attributes(
     markercolor = :black,
     markerstrokecolor = :black,
     markerstrokewidth = 0,
+    markerfont = "TeX Gyre Heros Makie",
     linecolor = :black,
     linewidth = 1.5,
     linestyle = nothing,

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -266,14 +266,7 @@ function find_font_for_char(glyph, font::NativeFont)
 end
 
 function glyph_index!(atlas::TextureAtlas, glyph, font::NativeFont)
-    if FreeTypeAbstraction.glyph_index(font, glyph) == 0
-        for afont in alternativefonts()
-            if FreeTypeAbstraction.glyph_index(afont, glyph) != 0
-                font = afont
-            end
-        end
-    end
-    return insert_glyph!(atlas, glyph, font)
+    return insert_glyph!(atlas, glyph, find_font_for_char(glyph, font))
 end
 
 function glyph_index!(atlas::TextureAtlas, b::BezierPath)

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -256,7 +256,7 @@ function find_font_for_char(glyph, font::NativeFont)
     FreeTypeAbstraction.glyph_index(font, glyph) != 0 && return font
     # it seems that linebreaks are not found which messes up font metrics
     # if another font is selected just for those chars
-    glyph in ('\n', '\r', '\t') && return font
+    glyph in ('\n', '\r', '\t', UInt32(0)) && return font
     for afont in alternativefonts()
         if FreeTypeAbstraction.glyph_index(afont, glyph) != 0
             return afont


### PR DESCRIPTION
# Description

Probably fixes #4830
Closes #620

The code from the first commit always picked the last font alternative because it was missing a `break`. CairoMakie picks the first working alternative, as it should. `find_font_for_char` does too, so this should equalize GLMakie and CairoMakie. (Both char markers from #4830 run into this issue.)

TODO:
- [x] add `font` to scatter (because CairoMakie, GLMakie and WGLMakie all suggest it should be there)
- [x] add tests
- [x] Figure out what to do with theme inheritance


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
