### PR TITLE
Fix GLMakie embedding support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed GLMakie embedding support [#4848](https://github.com/MakieOrg/Makie.jl/pull/4848).
 
 ## [0.22.2] - 2025-02-26
 

--- a/docs/src/explanations/backends/glmakie.md
+++ b/docs/src/explanations/backends/glmakie.md
@@ -80,6 +80,8 @@ do:
    - `ShaderAbstractions.native_context_alive(::MyWindow)` (check if the window
      OpenGL context is still valid)
    - `GLMakie.framebuffer_size(::MyWindow)` (get the size of the windows framebuffer)
+   - `GLMakie.destroy!(::MyWindow)` ('destroy' the window, this should be a no-op
+     unless you want GLMakie to really close the window)
    - `GLMakie.connect_screen(::Scene, Screen{MyWindow})` (connect input signals
      for e.g. the keyboard and mouse; you may want to implement the individual
      connection methods instead).


### PR DESCRIPTION
# Description

An exit handler was added to GLMakie in https://github.com/MakieOrg/Makie.jl/pull/4782 to ensure that all OpenGL resources are cleaned up, which will eventually call `close(::Screen)` and `destroy!(::Screen)`, which previously assumed that GLMakie owned `screen.glscreen` and would try calling GLFW functions on it. Now they will only do GLFW things if GLMakie owns the screen window. Also documented that embedders will need to implement `destroy!(::MyWindow)`.

Relevant prior PR: https://github.com/MakieOrg/Makie.jl/pull/4073

I don't have the bandwidth for it right now, but in the future I'd like to try writing some unit tests for embedding support.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
