### PR TITLE
Add test for scatter rotation/billboarding edge case

### DIFF
--- a/ReferenceTests/src/tests/attributes.jl
+++ b/ReferenceTests/src/tests/attributes.jl
@@ -17,8 +17,10 @@ end
 
     # Edge case: Quaternionf(0,0,0,1) should not default billboard to true
     scene3 = Scene(parent, viewport = Rect2f(150, 0, 150, 300), camera = cam3d!)
-    scatter!(scene3, [-0.5, 0.5], [0.5, 0.5], [0, 0], marker = Rect,
-        rotation = [Quaternionf(0,0,0,1), Quaternionf(0.01,0,0,1)], markersize = 0.5, markerspace = :data)
+    scatter!(scene3, (0.5, 0.5, 0), marker = Rect,
+        rotation = Quaternionf(0.01,0,0,1), markersize = 0.5, markerspace = :data)
+    scatter!(scene3, (-0.5, 0.5, 0), marker = Rect,
+        rotation = Quaternionf(0,0,0,1), markersize = 0.5, markerspace = :data)
     scatter!(scene3, [-0.5, 0.5], [-0.5, -0.5], [0, 0], marker = Rect, markersize = 0.5, markerspace = :data)
 
     parent

--- a/ReferenceTests/src/tests/attributes.jl
+++ b/ReferenceTests/src/tests/attributes.jl
@@ -6,12 +6,20 @@
     fig
 end
 
-@reference_test "(mesh)scatter with NaN rotation and markersize" begin
-    scene = Scene(size = (150, 300))
+@reference_test "(mesh)scatter with NaN rotation and markersize, edge cases" begin
+    parent = Scene(size = (300, 300))
+    scene = Scene(parent, viewport = Rect2f(0,0, 150, 300))
     xs = [-0.6, 0.0, 0.6]
     scatter!(scene,     xs, fill( 0.75, 3), marker = :ltriangle, rotation = [0.5, NaN, -0.5], markersize = 50)
     scatter!(scene,     xs, fill( 0.25, 3), marker = :ltriangle, markersize = [50, NaN, 50])
     meshscatter!(scene, xs, fill(-0.25, 3), marker = Rect2f(-0.5,-0.5,1,1), rotation = [0.5, NaN, -0.5], markersize = 0.2)
     meshscatter!(scene, xs, fill(-0.75, 3), marker = Rect2f(-0.5,-0.5,1,1), markersize = [0.2, NaN, 0.2])
-    scene
+
+    # Edge case: Quaternionf(0,0,0,1) should not default billboard to true
+    scene3 = Scene(parent, viewport = Rect2f(150, 0, 150, 300), camera = cam3d!)
+    scatter!(scene3, [-0.5, 0.5], [0.5, 0.5], [0, 0], marker = Rect,
+        rotation = [Quaternionf(0,0,0,1), Quaternionf(0.01,0,0,1)], markersize = 0.5, markerspace = :data)
+    scatter!(scene3, [-0.5, 0.5], [-0.5, -0.5], [0, 0], marker = Rect, markersize = 0.5, markerspace = :data)
+
+    parent
 end


### PR DESCRIPTION
# Description

I noticed that #4630 currently uses a fallback in GLMakie that sets `billboard = rotation == Quaternionf(0,0,0,1)`. Since `Billboard` was introduced many years ago this should not be hit. This pr tweaks a refimg to make sure of that.

## Type of change

- testing
