### PR TITLE
Test that categorical colors are not interpolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed categorical `cgrad` interpolating at small enough steps [#4858](https://github.com/MakieOrg/Makie.jl/pull/4858)
 
 ## [0.22.2] - 2025-02-26
 

--- a/ReferenceTests/src/tests/attributes.jl
+++ b/ReferenceTests/src/tests/attributes.jl
@@ -25,3 +25,16 @@ end
 
     parent
 end
+
+@reference_test "Categorical color interpolation" begin
+    cg = cgrad(:viridis, 5, categorical = true, scale = log10);
+    kwargs = (colorrange = (0, 1000), colormap = cg, marker = Rect, markersize = 30, strokewidth = 0)
+    scene = Scene(size = (500, 200))
+    image!(scene, -1..1, -1..1, reshape(cg.colors.colors, (1, 5)), interpolate = false)
+    for i in 2:5
+        edge = cg.values[i]
+        y = range(-1, 1, length=6)[i]
+        p = scatter!(scene, -1..1, fill(y, 11), color = (1000 .+ (-3:7)) * edge; kwargs...)
+    end
+    scene
+end

--- a/ReferenceTests/src/tests/attributes.jl
+++ b/ReferenceTests/src/tests/attributes.jl
@@ -27,16 +27,39 @@ end
 end
 
 @reference_test "Categorical color interpolation" begin
+    parent = Scene(size = (500, 500))
+
+    # test with cgrad
+    # - optimally switch near horizontal center (colormap gets upscaled to colorrange)
+    # - no interpolation (match image behind marker/line (slightly above or below))
+    scene = Scene(parent, viewport = Rect2f(0, 0, 500, 190))
     cg = cgrad(:viridis, 5, categorical = true, scale = log10);
-    scatter_kwargs = (colorrange = (0, 1000), colormap = cg, marker = Rect, markersize = 25, strokewidth = 0)
+    scatter_kwargs = (colorrange = (0, 1000), colormap = cg, marker = Rect, markersize = 25)
     line_kwargs = (colorrange = (0, 1000), colormap = cg, linewidth = 10)
-    scene = Scene(size = (500, 200))
     image!(scene, -1..1, -1..1, reshape(cg.colors.colors, (1, 5)), interpolate = false)
     for i in 2:5
         edge = cg.values[i]
         y = range(-1, 1, length=6)[i]
-        scatter!(scene, -1..1, fill(y, 15), color = (1000 .+ (-5:9)) * edge; scatter_kwargs...)
-        lines!(scene, -1..1, fill(y, 15), color = (1000 .+ (-5:9)) * edge; line_kwargs...)
+        scatter!(scene, -1..1, fill(y, 15), color = round(Int, 1000 * edge) .+ (-5:9); scatter_kwargs...)
+        lines!(scene, -1..1, fill(y, 15),   color = round(Int, 1000 * edge) .+ (-5:9); line_kwargs...)
     end
-    scene
+
+    # test with categorical
+    # - optimally alternate between black and white (no downscaling of colormap)
+    # - no interpolation (match image behind marker/line (slightly above or below))
+    scene = Scene(parent, viewport = Rect2f(0, 200, 500, 300))
+    cg = Categorical([RGBf(i%2, i%2, i%2) for i in 0:1000]);
+    scatter_kwargs = (colorrange = (0, 1000), colormap = cg, marker = Rect, markersize = 20, alpha = 1)
+    line_kwargs = (colorrange = (0, 1000), colormap = cg, linewidth = 8, alpha = 1)
+    cm = to_colormap(cg)
+    image!(scene, -1..1, -1..1, reshape(cm[1:6], (1, 6)), interpolate = false)
+    p = nothing
+    for i in 1:5
+        edge = 100 * i
+        y = range(-1, 1, length=7)[i+1]
+        p = scatter!(scene, -1..1, fill(y, 15), color = edge .+ (-7:7); scatter_kwargs...)
+        lines!(scene, -1..1, fill(y, 15), color = edge .+ (-7:7); line_kwargs...)
+    end
+
+    parent
 end

--- a/ReferenceTests/src/tests/attributes.jl
+++ b/ReferenceTests/src/tests/attributes.jl
@@ -28,13 +28,15 @@ end
 
 @reference_test "Categorical color interpolation" begin
     cg = cgrad(:viridis, 5, categorical = true, scale = log10);
-    kwargs = (colorrange = (0, 1000), colormap = cg, marker = Rect, markersize = 30, strokewidth = 0)
+    scatter_kwargs = (colorrange = (0, 1000), colormap = cg, marker = Rect, markersize = 25, strokewidth = 0)
+    line_kwargs = (colorrange = (0, 1000), colormap = cg, linewidth = 10)
     scene = Scene(size = (500, 200))
     image!(scene, -1..1, -1..1, reshape(cg.colors.colors, (1, 5)), interpolate = false)
     for i in 2:5
         edge = cg.values[i]
         y = range(-1, 1, length=6)[i]
-        p = scatter!(scene, -1..1, fill(y, 11), color = (1000 .+ (-3:7)) * edge; kwargs...)
+        scatter!(scene, -1..1, fill(y, 15), color = (1000 .+ (-5:9)) * edge; scatter_kwargs...)
+        lines!(scene, -1..1, fill(y, 15), color = (1000 .+ (-5:9)) * edge; line_kwargs...)
     end
     scene
 end

--- a/WGLMakie/src/lines.jl
+++ b/WGLMakie/src/lines.jl
@@ -25,7 +25,8 @@ function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
 
     color = plot.calculated_colors
     if color[] isa Makie.ColorMapping
-        uniforms[:colormap] = Sampler(color[].colormap)
+        cm_minfilter = color[].color_mapping_type[] === Makie.continuous ? :linear : :nearest
+        uniforms[:colormap] = Sampler(color[].colormap, minfilter = cm_minfilter)
         uniforms[:colorrange] = color[].colorrange_scaled
         uniforms[:highclip] = Makie.highclip(color[])
         uniforms[:lowclip] = Makie.lowclip(color[])

--- a/WGLMakie/src/meshes.jl
+++ b/WGLMakie/src/meshes.jl
@@ -53,7 +53,8 @@ function handle_color!(plot, uniforms, buffers, uniform_color_name = :uniform_co
             color_scaled = convert_texture(color[].color_scaled)
             uniforms[uniform_color_name] = Sampler(color_scaled; minfilter=minfilter)
         end
-        uniforms[:colormap] = Sampler(color[].colormap)
+        cm_minfilter = color[].color_mapping_type[] === Makie.continuous ? :linear : :nearest
+        uniforms[:colormap] = Sampler(color[].colormap, minfilter = cm_minfilter)
         uniforms[:colorrange] = color[].colorrange_scaled
         uniforms[:highclip] = Makie.highclip(color[])
         uniforms[:lowclip] = Makie.lowclip(color[])

--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -394,7 +394,7 @@ function assemble_colors(::Number, color, plot)
     cm = assemble_colors([color[]], lift(x -> [x], color), plot)
     return lift(
             cm.color_scaled, cm.colormap, identity, cm.colorrange_scaled,
-            cm.lowclip, cm.highclip, cm.nan_color, c.color_mapping_type
+            cm.lowclip, cm.highclip, cm.nan_color, cm.color_mapping_type
         ) do vals, cm, cs, cr, lw, hc, nc, ct
         return numbers_to_colors(vals, cm, cs, cr, lw, hc, nc, ct == continuous)[1]
     end

--- a/src/colorsampler.jl
+++ b/src/colorsampler.jl
@@ -54,7 +54,14 @@ function interpolated_getindex(cmap::AbstractArray{T}, i01::AbstractFloat) where
     return convert(T, downc * (one(interp_val) - interp_val) + upc * interp_val)
 end
 
-function nearest_getindex(cmap::AbstractArray, value::AbstractFloat)
+function nearest_getindex(cmap::AbstractArray, value::Real, norm::VecTypes)
+    cmin, cmax = norm
+    cmin == cmax && error("Can't interpolate in a range where cmin == cmax. This can happen, for example, if a colorrange is set automatically but there's only one unique value present.")
+    i01 = clamp((value - cmin) / (cmax - cmin), zero(value), one(value))
+    return nearest_getindex(cmap, i01)
+end
+
+function nearest_getindex(cmap::AbstractArray, i01::Real)
     idx = round(Int, i01 * (length(cmap) - 1)) + 1
     return cmap[idx]
 end
@@ -148,14 +155,16 @@ function numbers_to_colors(numbers::Union{AbstractArray{<:Number},Number}, primi
     highclip = get_attribute(primitive, :highclip)::RGBAf
     nan_color = get_attribute(primitive, :nan_color, RGBAf(0,0,0,0))::RGBAf
 
-    return numbers_to_colors(numbers, colormap, colorscale, colorrange, lowclip, highclip, nan_color)
+    return numbers_to_colors(numbers, colormap, colorscale, colorrange, lowclip, highclip, nan_color, true)
 end
 
-function numbers_to_colors(numbers::Union{AbstractArray{<:Number, N},Number},
-                           colormap, colorscale, colorrange::Vec2,
-                           lowclip::Union{Automatic,RGBAf},
-                           highclip::Union{Automatic,RGBAf},
-                           nan_color::RGBAf)::Union{Array{RGBAf, N},RGBAf} where {N}
+function numbers_to_colors(
+        numbers::Union{AbstractArray{<:Number, N},Number},
+        colormap, colorscale, colorrange::Vec2,
+        lowclip::Union{Automatic,RGBAf}, highclip::Union{Automatic,RGBAf},
+        nan_color::RGBAf, interpolate
+    )::Union{Array{RGBAf, N},RGBAf} where {N}
+
     cmin, cmax = colorrange
     scaled_cmin = apply_scale(colorscale, cmin)
     scaled_cmax = apply_scale(colorscale, cmax)
@@ -169,10 +178,11 @@ function numbers_to_colors(numbers::Union{AbstractArray{<:Number, N},Number},
         elseif highclip !== automatic && scaled_number > scaled_cmax
             return highclip
         end
-        return interpolated_getindex(
-            colormap,
-            scaled_number,
-            (scaled_cmin, scaled_cmax))
+        if interpolate
+            return interpolated_getindex(colormap, scaled_number, (scaled_cmin, scaled_cmax))
+        else
+            return nearest_getindex(colormap, scaled_number, (scaled_cmin, scaled_cmax))
+        end
     end
 end
 
@@ -358,12 +368,15 @@ function assemble_colors(c::AbstractArray{<:Number}, @nospecialize(color), @nosp
 end
 
 function to_color(c::ColorMapping)
-    return numbers_to_colors(c.color_scaled[], c.colormap[], identity, c.colorrange_scaled[], lowclip(c)[], highclip(c)[], c.nan_color[])
+    return numbers_to_colors(
+        c.color_scaled[], c.colormap[], identity, c.colorrange_scaled[],
+        lowclip(c)[], highclip(c)[], c.nan_color[], c.color_mapping_type[] == continuous)
 end
 
 function Base.get(c::ColorMapping, value::Number)
-    return numbers_to_colors([value], c.colormap[], c.scale[], c.colorrange_scaled[], lowclip(c)[],
-                             highclip(c)[], c.nan_color[])[1]
+    return numbers_to_colors(
+        [value], c.colormap[], c.scale[], c.colorrange_scaled[],
+        lowclip(c)[], highclip(c)[], c.nan_color[], c.color_mapping_type[] == continuous)[1]
 end
 
 function assemble_colors(colortype, color, plot)
@@ -379,8 +392,12 @@ end
 function assemble_colors(::Number, color, plot)
     plot.colorrange[] isa Automatic && error("Cannot determine a colorrange automatically for single number color value. Pass an explicit colorrange.")
     cm = assemble_colors([color[]], lift(x -> [x], color), plot)
-    return lift((args...)-> numbers_to_colors(args...)[1], cm.color_scaled, cm.colormap, identity, cm.colorrange_scaled, cm.lowclip, cm.highclip,
-                      cm.nan_color)
+    return lift(
+            cm.color_scaled, cm.colormap, identity, cm.colorrange_scaled,
+            cm.lowclip, cm.highclip, cm.nan_color, c.color_mapping_type
+        ) do vals, cm, cs, cr, lw, hc, nc, ct
+        return numbers_to_colors(vals, cm, cs, cr, lw, hc, nc, ct == continuous)[1]
+    end
 end
 
 highclip(cmap::ColorMapping) = lift((cm, hc) -> hc isa Automatic ? last(cm) : hc, cmap.colormap, cmap.highclip)


### PR DESCRIPTION
# Description

Another test inspired by #4630 - tests that a categorical `cgrad` uses nearest interpolation and doesn't just look like it because the resolution of 
https://github.com/MakieOrg/Makie.jl/blob/d77c537884e139eb476cb552a8129ef270586e6b/src/conversions.jl#L1603-L1609
is high enough. 

Also test that `Categorical` can handle a larger number of categories (1000)

Fixes cgrad interpolation in CairoMakie and WGLMakie.

Does not fix fixed sample density with `cgrad` (don't think we can improve this without controlling the colorscale function) and interpolation in CairoMakie lines (Can you do nearest interpolation on Cairo lines?)

## Type of change

- [x] Bug fix, test improvements

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.