### PR TITLE
Broaden draw_marker to AbstractMatrix

### DIFF
--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -498,7 +498,7 @@ function path_command(ctx, c::EllipticalArc)
 end
 
 
-function draw_marker(ctx, marker::Matrix{T}, pos,
+function draw_marker(ctx, marker::AbstractMatrix{T}, pos,
     strokecolor #= unused =#, strokewidth #= unused =#,
     mat) where T<:Colorant
 


### PR DESCRIPTION
Allows drawing to Cairo with other `AbstractMatrix` types, such as `PermutedDimsArray`, not just `Matrix`.