### PR TITLE
fix Colorbar for categorical colormaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `font` attribute and fixed faulty selection in `scatter`. Scatter fonts can now be themed with `markerfont`. [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
 - Fixed categorical `cgrad` interpolating at small enough steps [#4858](https://github.com/MakieOrg/Makie.jl/pull/4858)
+- Fixed an error with legends for categorical colormaps, where they displayed values out of colorrange and NaN.
 
 ## [0.22.2] - 2025-02-26
 

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -470,6 +470,14 @@ end
     fig
 end
 
+@reference_test "Categorical Colorbar with nan_color" begin
+    arr = [0 0 NaN; 1 1 NaN; 3 3 NaN]
+    fig = Figure(size = (300, 200))
+    a, hm = heatmap(fig[1,1], arr; colormap=Makie.Categorical(:Paired_8), colorrange=(1,3), lowclip=:black)
+    Colorbar(fig[1,2], hm)
+    fig
+end
+
 @reference_test "datashader" begin
     airports = Point2f.(eachrow(readdlm(assetpath("airportlocations.csv"))))
     # Dont use the full dataset, since WGLMakie seems to time out if it's too big

--- a/src/makielayout/blocks/colorbar.jl
+++ b/src/makielayout/blocks/colorbar.jl
@@ -159,7 +159,12 @@ function initialize_block!(cb::Colorbar)
             if mapping_type === Makie.banded
                 error("Banded without a mapping is invalid. Please use colormap=cgrad(...; categorical=true)")
             elseif mapping_type === Makie.categorical
-                return convert(Vector{Float64}, sort!(unique(values)))
+                # First we find all unique values,
+                # then we throw out NaNs that are rendered independently anyway
+                # then we clamp the remaining values to the limits,
+                # remove remaining duplicates and sort
+                vals = sort(unique(clamp.(filter(!isnan, unique(values)), limits...)))
+                return convert(Vector{Float64}, vals)
             else
                 return convert(Vector{Float64}, LinRange(limits..., n))
             end


### PR DESCRIPTION
# Description
This fixes the display of categorical colorbars. They now properly obey their limits and don't include NaN values anymore. Sorry for not providing pics, but the latest CairoMakie version fails to precompile and I need sleep.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
