### PR TITLE
Fix minorgridvisible not activating minortick updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `font` attribute and fixed faulty selection in `scatter`. Scatter fonts can now be themed with `markerfont`. [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
 - Fixed categorical `cgrad` interpolating at small enough steps [#4858](https://github.com/MakieOrg/Makie.jl/pull/4858)
+- Fixed minor grid not showing in Axis when minorticks are hidden [#4896](https://github.com/MakieOrg/Makie.jl/pull/4896)
 
 ## [0.22.2] - 2025-02-26
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -685,8 +685,8 @@ end
     for (i, scale) in enumerate([log10, log2, log, sqrt, Makie.logit, identity])
         row, col = fldmod1(i, 2)
         Axis(f[row, col], yscale = scale, title = string(scale),
-            yminorticksvisible = true, yminorgridvisible = true,
-            xminorticksvisible = true, xminorgridvisible = true,
+            yminorticksvisible = i != 6, yminorgridvisible = true,
+            xminorticksvisible = i != 6, xminorgridvisible = true,
             yminortickwidth = 4.0, xminortickwidth = 4.0,
             yminorgridwidth = 6.0, xminorgridwidth = 6.0,
             yminorticks = IntervalsBetween(3))

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -687,8 +687,11 @@ end
         Axis(f[row, col], yscale = scale, title = string(scale),
             yminorticksvisible = i != 6, yminorgridvisible = true,
             xminorticksvisible = i != 6, xminorgridvisible = true,
-            yminortickwidth = 4.0, xminortickwidth = 4.0,
-            yminorgridwidth = 6.0, xminorgridwidth = 6.0,
+            yminortickwidth = 3.0, xminortickwidth = 3.0,
+            yminorticksize = 8.0, xminorticksize = 8.0,
+            yminorgridwidth = 3.0, xminorgridwidth = 3.0,
+            yminortickcolor = :red, xminortickcolor = :red,
+            yminorgridcolor = :lightgreen, xminorgridcolor = :lightgreen,
             yminorticks = IntervalsBetween(3))
 
         lines!(data, color = :blue)

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -327,6 +327,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         ticklabelsize = ax.xticklabelsize, trimspine = ax.xtrimspine, ticksize = ax.xticksize,
         reversed = ax.xreversed, tickwidth = ax.xtickwidth, tickcolor = ax.xtickcolor,
         minorticksvisible = ax.xminorticksvisible, minortickalign = ax.xminortickalign, minorticksize = ax.xminorticksize, minortickwidth = ax.xminortickwidth, minortickcolor = ax.xminortickcolor, minorticks = ax.xminorticks, scale = ax.xscale,
+        minorticksused = ax.xminorgridvisible,
         )
 
     ax.xaxis = xaxis
@@ -341,6 +342,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         trimspine = ax.ytrimspine, ticklabelsize = ax.yticklabelsize, ticksize = ax.yticksize, flip_vertical_label = ax.flip_ylabel, reversed = ax.yreversed, tickwidth = ax.ytickwidth,
             tickcolor = ax.ytickcolor,
         minorticksvisible = ax.yminorticksvisible, minortickalign = ax.yminortickalign, minorticksize = ax.yminorticksize, minortickwidth = ax.yminortickwidth, minortickcolor = ax.yminortickcolor, minorticks = ax.yminorticks, scale = ax.yscale,
+        minorticksused = ax.yminorgridvisible,
         )
 
     ax.yaxis = yaxis

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -267,9 +267,7 @@ function LineAxis(parent::Scene, attrs::Attributes)
         ticklabelsize, ticklabelsvisible, spinewidth, spinecolor, label, labelsize, labelcolor,
         labelfont, ticklabelfont, ticklabelcolor,
         labelrotation, labelvisible, spinevisible, trimspine, flip_vertical_label, reversed,
-        minorticksvisible, minortickalign, minorticksize, minortickwidth, minortickcolor, minorticks)
-
-    minorticksused = get(attrs, :minorticksused, Observable(false))
+        minorticksvisible, minorticksused, minortickalign, minorticksize, minortickwidth, minortickcolor, minorticks)
 
     pos_extents_horizontal = lift(calculate_horizontal_extends, parent, endpoints; ignore_equal_values=true)
     horizontal = lift(x -> x[3], parent, pos_extents_horizontal)

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -267,7 +267,8 @@ function LineAxis(parent::Scene, attrs::Attributes)
         ticklabelsize, ticklabelsvisible, spinewidth, spinecolor, label, labelsize, labelcolor,
         labelfont, ticklabelfont, ticklabelcolor,
         labelrotation, labelvisible, spinevisible, trimspine, flip_vertical_label, reversed,
-        minorticksvisible, minorticksused, minortickalign, minorticksize, minortickwidth, minortickcolor, minorticks)
+        minorticksvisible, minortickalign, minorticksize, minortickwidth, minortickcolor, minorticks)
+    minorticksused = get(attrs, :minorticksused, Observable(false))
 
     pos_extents_horizontal = lift(calculate_horizontal_extends, parent, endpoints; ignore_equal_values=true)
     horizontal = lift(x -> x[3], parent, pos_extents_horizontal)

--- a/src/makielayout/lineaxis.jl
+++ b/src/makielayout/lineaxis.jl
@@ -269,6 +269,8 @@ function LineAxis(parent::Scene, attrs::Attributes)
         labelrotation, labelvisible, spinevisible, trimspine, flip_vertical_label, reversed,
         minorticksvisible, minortickalign, minorticksize, minortickwidth, minortickcolor, minorticks)
 
+    minorticksused = get(attrs, :minorticksused, Observable(false))
+
     pos_extents_horizontal = lift(calculate_horizontal_extends, parent, endpoints; ignore_equal_values=true)
     horizontal = lift(x -> x[3], parent, pos_extents_horizontal)
     # Tuple constructor converts more than `convert(NTuple{2, Float32}, x)` but we still need the conversion to Float32 tuple:
@@ -439,8 +441,8 @@ function LineAxis(parent::Scene, attrs::Attributes)
     minortickvalues = Observable(Float64[]; ignore_equal_values=true)
     minortickpositions = Observable(Point2f[]; ignore_equal_values=true)
 
-    onany(parent, tickvalues, minorticks, minorticksvisible) do tickvalues, minorticks, visible
-        if visible
+    onany(parent, tickvalues, minorticks, minorticksvisible, minorticksused) do tickvalues, minorticks, visible, used
+        if visible || used
             minortickvalues[] = get_minor_tickvalues(minorticks, attrs.scale[], tickvalues, limits[]...)
         end
         return

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -844,8 +844,6 @@ Colorbar(fig_or_scene, contourf::Makie.Contourf; kwargs...)
 
         "Controls if minor ticks are visible"
         minorticksvisible = false
-        "Additional control to request minor tick calculations for when they are used from the outside."
-        minorticksused = false
         "The alignment of minor ticks on the axis spine"
         minortickalign = 0f0
         "The tick size of minor ticks"

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -844,6 +844,8 @@ Colorbar(fig_or_scene, contourf::Makie.Contourf; kwargs...)
 
         "Controls if minor ticks are visible"
         minorticksvisible = false
+        "Additional control to request minor tick calculations for when they are used from the outside."
+        minorticksused = false
         "The alignment of minor ticks on the axis spine"
         minortickalign = 0f0
         "The tick size of minor ticks"


### PR DESCRIPTION
# Description

Fixes #4892

Adds another bool to keep calculations active when needed from the outside

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
