### PR TITLE
fix hexbin using logscales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed hexbin using log-scales [#4898](https://github.com/MakieOrg/Makie.jl/pull/4898)
 - Added `font` attribute and fixed faulty selection in `scatter`. Scatter fonts can now be themed with `markerfont`. [#4832](https://github.com/MakieOrg/Makie.jl/pull/4832)
 - Fixed categorical `cgrad` interpolating at small enough steps [#4858](https://github.com/MakieOrg/Makie.jl/pull/4858)
 

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1056,7 +1056,7 @@ end
     )
 end
 
-@testset "hexbin logscale" begin
+@eference_test "hexbin logscale" begin
     # https://github.com/MakieOrg/Makie.jl/issues/4895
     x = RNG.randn(100_000)
     y = RNG.randn(100_000) .|> exp

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1056,7 +1056,7 @@ end
     )
 end
 
-@eference_test "hexbin logscale" begin
+@reference_test "hexbin logscale" begin
     # https://github.com/MakieOrg/Makie.jl/issues/4895
     x = RNG.randn(100_000)
     y = RNG.randn(100_000) .|> exp

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1045,7 +1045,7 @@ end
     x = RNG.randn(100_000)
     y = RNG.randn(100_000)
 
-    f, ax, pl = hexbin(x, y,
+    hexbin(x, y,
         bins = 40,
         axis = (aspect = DataAspect(),),
         colorrange = (10, 300),

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1018,8 +1018,8 @@ end
 @reference_test "hexbin threshold" begin
     f = Figure(size = (800, 800))
 
-    x = RNG.randn(100000)
-    y = RNG.randn(100000)
+    x = RNG.randn(100_000)
+    y = RNG.randn(100_000)
 
     for (i, threshold) in enumerate([1, 10, 100, 500])
         ax = Axis(f[fldmod1(i, 2)...], title = "threshold = $threshold", aspect = DataAspect())
@@ -1029,8 +1029,8 @@ end
 end
 
 @reference_test "hexbin scale" begin
-    x = RNG.randn(100000)
-    y = RNG.randn(100000)
+    x = RNG.randn(100_000)
+    y = RNG.randn(100_000)
 
     f = Figure()
     hexbin(f[1, 1], x, y, bins = 40,
@@ -1042,8 +1042,8 @@ end
 
 # Scatter needs working highclip/lowclip first
 @reference_test "hexbin colorrange highclip lowclip" begin
-    x = RNG.randn(100000)
-    y = RNG.randn(100000)
+    x = RNG.randn(100_000)
+    y = RNG.randn(100_000)
 
     f, ax, pl = hexbin(x, y,
         bins = 40,
@@ -1054,6 +1054,13 @@ end
         strokewidth = 1,
         strokecolor = :gray30
     )
+end
+
+@testset "hexbin logscale" begin
+    # https://github.com/MakieOrg/Makie.jl/issues/4895
+    x = RNG.randn(100_000)
+    y = RNG.randn(100_000) .|> exp
+    hexbin(x, y; axis = (; yscale=log10))
 end
 
 @reference_test "bracket scalar" begin

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -1060,6 +1060,7 @@ end
     # https://github.com/MakieOrg/Makie.jl/issues/4895
     x = RNG.randn(100_000)
     y = RNG.randn(100_000) .|> exp
+
     hexbin(x, y; axis = (; yscale=log10))
 end
 

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -337,6 +337,9 @@ apply_transform(f::NTuple{3, typeof(identity)}, x::VecTypes) = x
 apply_transform(f::NTuple{3, typeof(identity)}, x::Number) = x
 apply_transform(f::NTuple{3, typeof(identity)}, x::ClosedInterval) = x
 
+can_handle_negative_domain(f::Tuple, dim::Int) = !(f[dim] isa LogFunctions)
+can_handle_negative_domain(f, dim::Int) = can_handle_negative_domain(ntuple(_ -> f, Val(dim)), dim)
+
 struct PointTrans{N, F}
     f::F
     function PointTrans{N}(f::F) where {N, F}

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -244,8 +244,11 @@ function apply_transform_and_model(plot::AbstractPlot, data, output_type = Point
     )
 end
 function apply_transform_and_model(model::Mat4, f, data, space = :data, output_type = Point3d)
-    promoted = promote_geom(output_type, data)
-    transformed = apply_transform(f, promoted, space)
+    transformed = promoted = promote_geom(output_type, data)
+    try
+        transformed = apply_transform(f, promoted, space)
+    catch
+    end
     world = apply_model(model, transformed, space)
     return promote_geom(output_type, world)
 end
@@ -370,10 +373,18 @@ function apply_transform(f, data::AbstractArray)
 end
 
 function apply_transform(f::Tuple{Any, Any}, point::VecTypes{2, T}) where T
-    Point2{T}(
-        f[1](point[1]),
-        f[2](point[2]),
-    )
+    p1, p2 = point
+    try
+        p1 = f[1](p1)
+    catch err
+        @warn err
+    end
+    try
+        p2 = f[2](p2)
+    catch err
+        @warn err
+    end
+    Point2{T}(p1, p2)
 end
 # ambiguity fix
 apply_transform(f::NTuple{2, typeof(identity)}, point::VecTypes{2}) = point
@@ -386,11 +397,23 @@ end
 apply_transform(f::NTuple{2, typeof(identity)}, point::VecTypes{3}) = point
 
 function apply_transform(f::Tuple{Any, Any, Any}, point::VecTypes{3, T}) where T
-    Point3{T}(
-        f[1](point[1]),
-        f[2](point[2]),
-        f[3](point[3]),
-    )
+    p1, p2, p3 = point
+    try
+        p1 = f[1](p1)
+    catch err
+        @warn err
+    end
+    try
+        p2 = f[2](p2)
+    catch err
+        @warn err
+    end
+    try
+        p3 = f[3](p3)
+    catch err
+        @warn err
+    end
+    Point3{T}(p1, p2, p3)
 end
 # ambiguity fix
 apply_transform(f::NTuple{3, typeof(identity)}, point::VecTypes{3}) = point

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -373,18 +373,10 @@ function apply_transform(f, data::AbstractArray)
 end
 
 function apply_transform(f::Tuple{Any, Any}, point::VecTypes{2, T}) where T
-    p1, p2 = point
-    try
-        p1 = f[1](p1)
-    catch err
-        @warn err
-    end
-    try
-        p2 = f[2](p2)
-    catch err
-        @warn err
-    end
-    Point2{T}(p1, p2)
+    Point2{T}(
+        f[1](point[1]),
+        f[2](point[2]),
+    )
 end
 # ambiguity fix
 apply_transform(f::NTuple{2, typeof(identity)}, point::VecTypes{2}) = point
@@ -397,23 +389,11 @@ end
 apply_transform(f::NTuple{2, typeof(identity)}, point::VecTypes{3}) = point
 
 function apply_transform(f::Tuple{Any, Any, Any}, point::VecTypes{3, T}) where T
-    p1, p2, p3 = point
-    try
-        p1 = f[1](p1)
-    catch err
-        @warn err
-    end
-    try
-        p2 = f[2](p2)
-    catch err
-        @warn err
-    end
-    try
-        p3 = f[3](p3)
-    catch err
-        @warn err
-    end
-    Point3{T}(p1, p2, p3)
+    Point3{T}(
+        f[1](point[1]),
+        f[2](point[2]),
+        f[3](point[3]),
+    )
 end
 # ambiguity fix
 apply_transform(f::NTuple{3, typeof(identity)}, point::VecTypes{3}) = point

--- a/src/layouting/transformation.jl
+++ b/src/layouting/transformation.jl
@@ -244,11 +244,8 @@ function apply_transform_and_model(plot::AbstractPlot, data, output_type = Point
     )
 end
 function apply_transform_and_model(model::Mat4, f, data, space = :data, output_type = Point3d)
-    transformed = promoted = promote_geom(output_type, data)
-    try
-        transformed = apply_transform(f, promoted, space)
-    catch
-    end
+    promoted = promote_geom(output_type, data)
+    transformed = apply_transform(f, promoted, space)
     world = apply_model(model, transformed, space)
     return promote_geom(output_type, world)
 end

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -26,6 +26,10 @@ function spacings_offsets_nbins(bins::Tuple{Int,Int}, cellsize::Nothing, xmi, xm
     return xspacing, yspacing, xmi, ymi, bins...
 end
 
+# hardcoded scale factors
+xfact() = 2
+yfact() = 4 / 3
+
 function spacings_offsets_nbins(bins, cellsize::Real, xmi, xma, ymi, yma)
     return spacings_offsets_nbins(bins, (cellsize, cellsize * 2 / sqrt(3)), xmi, xma, ymi, yma)
 end
@@ -36,8 +40,8 @@ end
 function spacings_offsets_nbins(bins, cellsizes::Tuple{<:Real,<:Real}, xmi, xma, ymi, yma)
     x_diff = xma - xmi
     y_diff = yma - ymi
-    xspacing = cellsizes[1] / 2
-    yspacing = cellsizes[2] * 3 / 4
+    xspacing = cellsizes[1] / xfact()
+    yspacing = cellsizes[2] / yfact()
     (nx, restx), (ny, resty) = fldmod.((x_diff, y_diff), (xspacing, yspacing))
     return xspacing, yspacing, xmi - (restx > 0 ? (xspacing - restx) / 2 : 0),
            ymi - (resty > 0 ? (yspacing - resty) / 2 : 0), Int(nx) + (restx > 0), Int(ny) + (resty > 0)
@@ -111,11 +115,11 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
         xspacing, yspacing, xoff, yoff, nbinsx, nbinsy =
             spacings_offsets_nbins(bins, cellsize, xmi, xma, ymi, yma)
 
-        ysize = yspacing / 3 * 4
-        ry = ysize / 2
-
-        xsize = xspacing * 2
+        xsize = xspacing * xfact()
         rx = xsize / sqrt3
+
+        ysize = yspacing * yfact()
+        ry = ysize / 2
 
         bin_map = Dict{Tuple{Int,Int}, Float64}()
 

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -90,11 +90,11 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
         isempty(xy) && return
 
         # enclose data in limits
-        xmi, xma = let (lo, hi) = extrema(p[1] for p in xy)
+        xmi, xma = let (lo, hi) = extrema(p -> p[1], xy)
             tfx(prevfloat(lo)), tfx(nextfloat(hi))
         end
 
-        ymi, yma = let (lo, hi) = extrema(p[2] for p in xy)
+        ymi, yma = let (lo, hi) = extrema(p -> p[2], xy)
             tfy(prevfloat(lo)), tfy(nextfloat(hi))
         end
 

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -117,7 +117,7 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
         xsize = xspacing * 2
         rx = xsize / sqrt3
 
-        d = Dict{Tuple{Int,Int}, Float64}()
+        bin_map = Dict{Tuple{Int,Int}, Float64}()
 
         # for the distance measurement, the y dimension must be weighted relative to the x
         # dimension according to the different sizes in each, otherwise the attribution to hexagonal
@@ -145,7 +145,7 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
                 )
             end
 
-            d[id] = get(d, id, 0.0) + get_weight(weights, i)
+            bin_map[id] = get(bin_map, id, 0.0) + get_weight(weights, i)
             i += 1
         end
 
@@ -155,12 +155,12 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
             for iy in 0:nbinsy-1
                 _nx = isodd(iy) ? fld(nbinsx, 2) : cld(nbinsx, 2)
                 for ix in 0:_nx-1
-                    add_hex_point(ix, iy, off_sp, get(d, (ix, iy), 0.0))
+                    add_hex_point(ix, iy, off_sp, get(bin_map, (ix, iy), 0.0))
                 end
             end
         else
             # if we don't plot zero cells, we only have to iterate the sparse entries in the dict
-            for ((ix, iy), value) in d
+            for ((ix, iy), value) in bin_map
                 value ≥ threshold && add_hex_point(ix, iy, off_sp, value)
             end
         end

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -83,6 +83,13 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
     markersize = Observable(Vec2f(1, 1))
     sqrt3 = sqrt(3)
 
+    function add_hex_point(ix, iy, (xoff, yoff, xspacing, yspacing), count)
+        x = itfx(xoff + 2ix * xspacing + isodd(iy) * xspacing)
+        y = itfy(yoff + iy * yspacing)
+        push!(points[], Point2f(x, y))
+        push!(count_hex[], count)
+    end
+
     function calculate_grid(xy, weights, bins, cellsize, threshold)
         empty!(points[])
         empty!(count_hex[])
@@ -142,24 +149,19 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
             i += 1
         end
 
-        function add_hex_point(ix, iy, count)
-            x = itfx(xoff + 2ix * xspacing + isodd(iy) * xspacing)
-            y = itfy(yoff + iy * yspacing)
-            push!(points[], Point2f(x, y))
-            push!(count_hex[], count)
-        end
+        off_sp = (xoff, yoff, xspacing, yspacing)
 
         if threshold == 0
             for iy in 0:nbinsy-1
                 _nx = isodd(iy) ? fld(nbinsx, 2) : cld(nbinsx, 2)
                 for ix in 0:_nx-1
-                    add_hex_point(ix, iy, get(d, (ix, iy), 0.0))
+                    add_hex_point(ix, iy, off_sp, get(d, (ix, iy), 0.0))
                 end
             end
         else
             # if we don't plot zero cells, we only have to iterate the sparse entries in the dict
             for ((ix, iy), value) in d
-                value ≥ threshold && add_hex_point(ix, iy, value)
+                value ≥ threshold && add_hex_point(ix, iy, off_sp, value)
             end
         end
 

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -90,13 +90,13 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
         isempty(xy) && return
 
         # enclose data in limits
-        _expand((lo, hi)) = prevfloat(lo), nextfloat(hi)
+        xmi, xma = let (lo, hi) = extrema(p[1] for p in xy)
+            tfx(prevfloat(lo)), tfx(nextfloat(hi))
+        end
 
-        xmi, xma = extrema(p[1] for p in xy) |> _expand
-        ymi, yma = extrema(p[2] for p in xy) |> _expand
-
-        xmi, xma = tfx(xmi), tfx(xma)
-        ymi, yma = tfy(ymi), tfy(yma)
+        ymi, yma = let (lo, hi) = extrema(p[2] for p in xy)
+            tfy(prevfloat(lo)), tfy(nextfloat(hi))
+        end
 
         x_diff = xma - xmi
         y_diff = yma - ymi
@@ -125,11 +125,8 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
 
             d1 = (tx - nx)^2 + (yweight * (ty - ny))^2
             d2 = (tx - nxs)^2 + (yweight * (ty - nys))^2
-            is_grid1 = d1 < d2
 
-            # _xy = is_grid1 ? (nx, ny) : (nxs, nys)
-
-            id = if is_grid1
+            id = if (is_grid1 = d1 < d2)
                 (
                     cld(dvx, 2),
                     iseven(dvy) ? dvy : dvy+1
@@ -218,7 +215,7 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
 end
 
 function center_value(dv, spacing, offset, is_grid1)
-    offset + spacing * (dv + is_grid1 ? isodd(dv) : iseven(dv))
+    return offset + spacing * (dv + is_grid1 ? isodd(dv) : iseven(dv))
 end
 
 function nearest_center(val, spacing, offset)

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -145,7 +145,7 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
                 )
             end
 
-            d[id] = get(d, id, 0) + get_weight(weights, i)
+            d[id] = get(d, id, 0.0) + get_weight(weights, i)
             i += 1
         end
 

--- a/src/stats/hexbin.jl
+++ b/src/stats/hexbin.jl
@@ -75,8 +75,8 @@ get_weight(::Nothing, i) = 1e0
 
 function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
     xy = hb[1]
-    tfx, tfy = transform_func(hb)
-    itfx, itfy = inverse_transform(tfx), inverse_transform(tfy)
+    tfx, tfy = tf = transform_func(hb)
+    itfx, itfy = inverse_transform(tf)
 
     points = Observable(Point2f[])
     count_hex = Observable(Float64[])
@@ -181,11 +181,7 @@ function plot!(hb::Hexbin{<:Tuple{<:AbstractVector{<:Point2}}})
             # and every cell has only 1 entry, then we set the minimum to 0 so we do not get
             # a singular colorrange error down the line.
             if mi == ma
-                if ma == 0
-                    (0, 1)
-                else
-                    (0, ma)
-                end
+                (0, ma == 0 ? 1 : ma)
             else
                 (mi, ma)
             end

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -215,3 +215,10 @@ end
     sc = scatter!(ax, Point(0, 0), marker=triangle, markerspace=:data)
     data_limits(sc) # doesn't stackoverflow
 end
+
+@testset "issue 4895" begin
+    n = 10_000
+    xs = randn(n)
+    ys = randn(n) .|> exp
+    hexbin(xs, ys; axis = (; yscale=log10))
+end

--- a/test/boundingboxes.jl
+++ b/test/boundingboxes.jl
@@ -215,10 +215,3 @@ end
     sc = scatter!(ax, Point(0, 0), marker=triangle, markerspace=:data)
     data_limits(sc) # doesn't stackoverflow
 end
-
-@testset "issue 4895" begin
-    n = 10_000
-    xs = randn(n)
-    ys = randn(n) .|> exp
-    hexbin(xs, ys; axis = (; yscale=log10))
-end


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #4895.

Fix hexbin using logscales (`data_limits` would extend limits, which can be invalid when using logscales).

```julia
using CairoMakie
using Random

begin
  Random.seed!(0)
  xs = randn(10_000)
  ys = randn(10_000) .|> exp
  log_ys = log10.(ys)
  yticks = floor(Int, minimum(log_ys)) : ceil(Int, maximum(log_ys))

  fap = hexbin(
    xs,
    log_ys;
    axis=(;
      yticks=(yticks, [rich("10", y |> string |> superscript) for y ∈ yticks]),
    ),
  )
  display(fap)
  save("hb-workaround.png", fap)

  println("==  "^20)
  fap = hexbin(
    xs,
    ys;
    axis=(; yscale=log10),
  )
  display(fap)
  save("hb-fix.png", fap)
end
```
**workaround**
![hb-workaround](https://github.com/user-attachments/assets/79849278-0363-4db1-8279-bd45ec69c78f)

**fix**
![hb-fix](https://github.com/user-attachments/assets/b3d9f22c-1d8b-4aec-86cd-10f1cb1e7dda)

Note that for the fix, the y limits are **not** extended, as they would produce a `DomainError` on log scale.

Added reference image:
![hexbin logscale](https://github.com/user-attachments/assets/5c0a6198-6580-41f6-9d32-66ede13480d8)

Becnhmark test failure seems unrelated.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
