### PR TITLE
Add syntax highlight tags to fenced code blocks

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -288,18 +288,18 @@ Those attributes will not be forwarded to the backend, but only used during the
 conversion pipeline.
 Usage:
 ```julia
-    struct MyType end
-    used_attributes(::MyType) = (:attribute,)
-    function convert_arguments(x::MyType; attribute = 1)
-        ...
-    end
-    # attribute will get passed to convert_arguments
-    # without keyword_verload, this wouldn't happen
-    plot(MyType, attribute = 2)
-    #You can also use the convenience macro, to overload convert_arguments in one step:
-    @keywords convert_arguments(x::MyType; attribute = 1)
-        ...
-    end
+struct MyType end
+used_attributes(::MyType) = (:attribute,)
+function convert_arguments(x::MyType; attribute = 1)
+    ...
+end
+# attribute will get passed to convert_arguments
+# without keyword_verload, this wouldn't happen
+plot(MyType, attribute = 2)
+#You can also use the convenience macro, to overload convert_arguments in one step:
+@keywords convert_arguments(x::MyType; attribute = 1)
+    ...
+end
 ```
 """
 used_attributes(::Type{<:Plot}, args...) = used_attributes(args...)

--- a/src/makielayout/helpers.jl
+++ b/src/makielayout/helpers.jl
@@ -107,7 +107,7 @@ Sets the autolimit margins to zero on all given sides.
 
 Example:
 
-```
+```julia
 tightlimits!(laxis, Bottom())
 ```
 """
@@ -313,7 +313,7 @@ All other keywords are forwarded to the `GridLayout`.
 
 Example:
 
-```
+```julia
 ls = labelslider!(scene, "Voltage:", 0:10; format = x -> "\$(x)V")
 layout[1, 1] = ls.layout
 ```
@@ -372,7 +372,7 @@ All other keywords are forwarded to the `GridLayout`.
 
 Example:
 
-```
+```julia
 ls = labelslidergrid!(scene, ["Voltage", "Ampere"], Ref(0:0.1:100); format = x -> "\$(x)V")
 layout[1, 1] = ls.layout
 ```

--- a/src/makielayout/mousestatemachine.jl
+++ b/src/makielayout/mousestatemachine.jl
@@ -112,7 +112,7 @@ To react to mouse events, use the onmouse... handlers.
 
 Example:
 
-```
+```julia
 mouseevents = addmouseevents!(scene, scatterplot)
 
 onmouseleftclick(mouseevents) do event

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -63,7 +63,7 @@ Like LinearTicks but for multiples of `multiple`.
 Example where approximately 5 numbers should be found
 that are multiples of pi, printed like "1π", "2π", etc.:
 
-```
+```julia
 MultiplesTicks(5, pi, "π")
 ```
 

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -264,13 +264,13 @@ Nested attributes are either also updated incrementally, or replaced if they are
 # Example
 To change the default colormap to `:greys`, you can pass that attribute as
 a keyword argument to `update_theme!` as demonstrated below.
-```
+```julia
 update_theme!(colormap=:greys)
 ```
 
 This can also be achieved by passing an object of types `Attributes` or `Theme`
 as the first and only positional argument:
-```
+```julia
 update_theme!(Attributes(colormap=:greys))
 update_theme!(Theme(colormap=:greys))
 ```

--- a/src/types.jl
+++ b/src/types.jl
@@ -65,7 +65,7 @@ not trigger other observer functions. The order in which functions are executed
 can be controlled via the `priority` keyword (default 0) in `on`.
 
 Example:
-```
+```julia
 on(events(scene).mousebutton, priority = 20) do event
     if is_correct_event(event)
         do_something()


### PR DESCRIPTION
# Description

Add syntax highlight tags to fenced code block examples in docstrings

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
