### PR TITLE
update voxels if underlying chunk array changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed issue with UInt8 voxel data not updating correctly when Observable input is updated [#4914](https://github.com/MakieOrg/Makie.jl/pull/4914)
+
 ## [0.22.3] - 2025-04-08
 
 - Added `alpha` attribute to `tricontourf.jl` to control the transparency of filled contours [#4800](https://github.com/MakieOrg/Makie.jl/pull/4800)

--- a/src/basic_recipes/voxels.jl
+++ b/src/basic_recipes/voxels.jl
@@ -147,17 +147,17 @@ function plot!(plot::Voxels)
     # Internal attribute for communicating updates to the backend.
     plot.attributes[:_local_update] = Observable((0:0, 0:0, 0:0))
 
-    # Disconnect automatic mapping
-    # I want to avoid recalculating limits every time the input is updated.
-    # Maybe this can be done with conversion kwargs...?
-    off(plot.args[end], plot.args[end].listeners[1][2])
-
     # If a UInt8 Array is passed we don't do any mapping between plot.args and
     # plot.converted. Instead we just set plot.converted = plot.args in
     # convert_arguments
     if eltype(plot.args[end][]) == UInt8
         plot._limits[] = (1, 255)
         return
+    else
+        # Disconnect automatic mapping
+        # I want to avoid recalculating limits every time the input is updated.
+        # Maybe this can be done with conversion kwargs...?
+        off(plot.args[end], plot.args[end].listeners[1][2])
     end
 
 

--- a/test/plots/primitives.jl
+++ b/test/plots/primitives.jl
@@ -56,6 +56,17 @@ end
     ps = [Point3f(x - 2.5, y - 2.0, z - 1.5) for z in 0:3 for y in 0:4 for x in 0:5]
     @test Makie.voxel_positions(p) ≈ ps
     @test Makie.voxel_colors(p) == cc.colormap[][p.converted[end][][:]]
+
+    # raw UInt8 input updates, issue #4912
+    data = Observable(zeros(UInt8, 4,5,6))
+    f, a, p = voxels(data)
+    @test p.converted[1][] == Vec2f(-2, 2)
+    @test p.converted[2][] == Vec2f(-2.5, 2.5)
+    @test p.converted[3][] == Vec2f(-3, 3)
+    @test p.converted[4][] == p.args[end][]
+    data[] = ones(UInt8, 4,5,6)
+    @test p.args[end][] == data[]
+    @test p.converted[end][] == data[]
 end
 
 # TODO, test all primitives and argument conversions


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #4912

Don't disconnect the listener if data is passed as raw UInt8 chunk. Works locally for me, but didn't figure out how to write a test for this.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
