### PR TITLE
Generic float conversion

### DIFF
--- a/src/dim-converts/unitful-integration.jl
+++ b/src/dim-converts/unitful-integration.jl
@@ -112,7 +112,7 @@ end
 # We always convert to preferred unit!
 function unit_convert(unit::T, value) where T <: Union{Type{<:Unitful.AbstractQuantity}, Unitful.FreeUnits, Unitful.Unit}
     conv = uconvert(to_free_unit(unit, value), value)
-    return Float64(ustrip(conv))
+    return float(ustrip(conv))
 end
 
 


### PR DESCRIPTION

# Description

Fixes #4919

Makes float conversion generic for unitful types

## Type of change

Delete options that do not apply:

- [x ] New feature (non-breaking change which adds functionality)

