### PR TITLE
Respect panbutton selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed issue with UInt8 voxel data not updating correctly when Observable input is updated [#4914](https://github.com/MakieOrg/Makie.jl/pull/4914)
+- Fixed `Axis.panbutton` not working [#4932](https://github.com/MakieOrg/Makie.jl/pull/4932)
 
 ## [0.22.4] - 2025-04-11
 

--- a/src/makielayout/interactions.jl
+++ b/src/makielayout/interactions.jl
@@ -296,7 +296,7 @@ end
 
 function process_interaction(dp::DragPan, event::MouseEvent, ax)
 
-    if event.type !== MouseEventTypes.rightdrag
+    if event.type !== to_drag_event(ax.panbutton[])
         return Consume(false)
     end
 

--- a/test/interactivity/Axis.jl
+++ b/test/interactivity/Axis.jl
@@ -187,6 +187,7 @@
     @testset "Axis Translation (pan)" begin
         ax, axbox, lim, e = cleanaxes()
 
+        # Test default
         e.mouseposition[] = Tuple(axbox.origin + axbox.widths/2)
         e.scroll[] = (0.0, 1.0)
         newlim = ax.finallimits[]
@@ -195,6 +196,32 @@
         e.mousebutton[] = MouseButtonEvent(ax.panbutton[], Mouse.press)
         e.mouseposition[] = Tuple(axbox.origin + axbox.widths/10)
         e.mousebutton[] = MouseButtonEvent(ax.panbutton[], Mouse.release)
+
+        panlim = ax.finallimits[]
+        @test ax.panbutton[] == Mouse.right
+        @test panlim.widths == newlim.widths
+        @test (5/4)*panlim.origin ≈ -newlim.origin atol = 1e-6
+
+        # Test new button disables old button
+        ax, axbox, lim, e = cleanaxes()
+
+        ax.panbutton[] = Mouse.middle
+        e.mouseposition[] = Tuple(axbox.origin + axbox.widths/2)
+        e.scroll[] = (0.0, 1.0)
+        newlim = ax.finallimits[]
+
+        e.mouseposition[] = Tuple(axbox.origin)
+        e.mousebutton[] = MouseButtonEvent(Mouse.right, Mouse.press)
+        e.mouseposition[] = Tuple(axbox.origin + axbox.widths/10)
+        e.mousebutton[] = MouseButtonEvent(Mouse.right, Mouse.release)
+
+        @test ax.finallimits[] == newlim
+
+        # ... and enables new button
+        e.mouseposition[] = Tuple(axbox.origin)
+        e.mousebutton[] = MouseButtonEvent(Mouse.middle, Mouse.press)
+        e.mouseposition[] = Tuple(axbox.origin + axbox.widths/10)
+        e.mousebutton[] = MouseButtonEvent(Mouse.middle, Mouse.release)
 
         panlim = ax.finallimits[]
         @test panlim.widths == newlim.widths


### PR DESCRIPTION
# Description

I was customizing a figure window and having trouble understanding the behavior of the [`panbutton` option for an Axis](https://docs.makie.org/dev/reference/blocks/axis#panbutton). As it turns out, I came to believe the option is being ignored (at least for windows created via `plot()` and `image()`). This PR changes the behavior of the following to what I expect:

```julia
plot([1, 2, 3, 4, 5], axis=(panbutton=Makie.Mouse.middle, ))
```

Now, this works as expected and allows me to use the middle mouse button to pan around.

I did not know how to add a test for this, but happy to.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
