### PR TITLE
Update CairoMakie primitives for compute branch

### DIFF
--- a/.github/workflows/compilation-benchmark.yaml
+++ b/.github/workflows/compilation-benchmark.yaml
@@ -6,6 +6,7 @@ on:
       - '*.md'
     branches:
       - master
+      - sd/compute-graph
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/CairoMakie/src/new_primitives.jl
+++ b/CairoMakie/src/new_primitives.jl
@@ -636,16 +636,18 @@ end
 function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.MeshScatter))
     @get_attribute(primitive, (
         model_f32c, marker, markersize, rotation, positions_transformed_f32c,
-        clip_planes, scaled_color, transform_marker))
+        clip_planes, transform_marker))
 
     # We combine vertices and positions in world space.
     # Here we do the transformation to world space of meshscatter args
     # The rest happens in draw_scattered_mesh()
     transformed_pos = Makie.apply_model(model_f32c, positions_transformed_f32c)
 
+    colors = cairo_colors(primitive)
+
     draw_scattered_mesh(
         scene, screen, primitive, marker,
-        transformed_pos, markersize, rotation, scaled_color,
+        transformed_pos, markersize, rotation, colors,
         clip_planes, transform_marker
     )
 end

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -1228,21 +1228,21 @@ end
 ################################################################################
 
 
-function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Surface))
-    # Pretend the surface plot is a mesh plot and plot that instead
-    mesh = Makie.surface2mesh(primitive[1][], primitive[2][], primitive[3][])
-    old = primitive[:color]
-    if old[] === nothing
-        primitive[:color] = primitive[3]
-    end
-    if !haskey(primitive, :faceculling)
-        primitive[:faceculling] = Observable(-10)
-    end
-    uv_transform = Makie.convert_attribute(primitive[:uv_transform][], Makie.key"uv_transform"(), Makie.key"surface"())
-    draw_mesh3D(scene, screen, primitive, mesh; uv_transform = uv_transform)
-    primitive[:color] = old
-    return nothing
-end
+# function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Surface))
+#     # Pretend the surface plot is a mesh plot and plot that instead
+#     mesh = Makie.surface2mesh(primitive[1][], primitive[2][], primitive[3][])
+#     old = primitive[:color]
+#     if old[] === nothing
+#         primitive[:color] = primitive[3]
+#     end
+#     if !haskey(primitive, :faceculling)
+#         primitive[:faceculling] = Observable(-10)
+#     end
+#     uv_transform = Makie.convert_attribute(primitive[:uv_transform][], Makie.key"uv_transform"(), Makie.key"surface"())
+#     draw_mesh3D(scene, screen, primitive, mesh; uv_transform = uv_transform)
+#     primitive[:color] = old
+#     return nothing
+# end
 
 
 ################################################################################

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -873,39 +873,39 @@ end
 ################################################################################
 
 
-function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Mesh))
-    mesh = primitive[1][]
-    if Makie.cameracontrols(scene) isa Union{Camera2D, Makie.PixelCamera, Makie.EmptyCamera}
-        draw_mesh2D(scene, screen, primitive, mesh)
-    else
-        if !haskey(primitive, :faceculling)
-            primitive[:faceculling] = Observable(-10)
-        end
-        uv_transform = Makie.convert_attribute(primitive[:uv_transform][], Makie.key"uv_transform"(), Makie.key"mesh"())
-        draw_mesh3D(scene, screen, primitive, mesh; uv_transform = uv_transform)
-    end
-    return nothing
-end
+# function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Mesh))
+#     mesh = primitive[1][]
+#     if Makie.cameracontrols(scene) isa Union{Camera2D, Makie.PixelCamera, Makie.EmptyCamera}
+#         draw_mesh2D(scene, screen, primitive, mesh)
+#     else
+#         if !haskey(primitive, :faceculling)
+#             primitive[:faceculling] = Observable(-10)
+#         end
+#         uv_transform = Makie.convert_attribute(primitive[:uv_transform][], Makie.key"uv_transform"(), Makie.key"mesh"())
+#         draw_mesh3D(scene, screen, primitive, mesh; uv_transform = uv_transform)
+#     end
+#     return nothing
+# end
 
-function draw_mesh2D(scene, screen, @nospecialize(plot::Makie.Mesh), @nospecialize(mesh::GeometryBasics.Mesh))
-    space = plot.space[]::Symbol
-    transform_func = Makie.transform_func(plot)
-    model = plot.model[]::Mat4d
-    vs = project_position(scene, transform_func, space, GeometryBasics.coordinates(mesh), model)::Vector{Point2f}
-    fs = decompose(GLTriangleFace, mesh)::Vector{GLTriangleFace}
-    uv = decompose_uv(mesh)::Union{Nothing, Vector{Vec2f}}
-    # Note: This assume the function is only called from mesh plots
-    uv_transform = Makie.convert_attribute(plot[:uv_transform][], Makie.key"uv_transform"(), Makie.key"mesh"())
-    if uv isa Vector{Vec2f} && to_value(uv_transform) !== nothing
-        uv = map(uv -> uv_transform * to_ndim(Vec3f, uv, 1), uv)
-    end
-    color = hasproperty(mesh, :color) ? to_color(mesh.color) : plot.calculated_colors[]
-    cols = per_face_colors(color, nothing, fs, nothing, uv)
-    if cols isa Cairo.CairoPattern
-        align_pattern(cols, scene, model)
-    end
-    return draw_mesh2D(screen, cols, vs, fs)
-end
+# function draw_mesh2D(scene, screen, @nospecialize(plot::Makie.Mesh), @nospecialize(mesh::GeometryBasics.Mesh))
+#     space = plot.space[]::Symbol
+#     transform_func = Makie.transform_func(plot)
+#     model = plot.model[]::Mat4d
+#     vs = project_position(scene, transform_func, space, GeometryBasics.coordinates(mesh), model)::Vector{Point2f}
+#     fs = decompose(GLTriangleFace, mesh)::Vector{GLTriangleFace}
+#     uv = decompose_uv(mesh)::Union{Nothing, Vector{Vec2f}}
+#     # Note: This assume the function is only called from mesh plots
+#     uv_transform = Makie.convert_attribute(plot[:uv_transform][], Makie.key"uv_transform"(), Makie.key"mesh"())
+#     if uv isa Vector{Vec2f} && to_value(uv_transform) !== nothing
+#         uv = map(uv -> uv_transform * to_ndim(Vec3f, uv, 1), uv)
+#     end
+#     color = hasproperty(mesh, :color) ? to_color(mesh.color) : plot.calculated_colors[]
+#     cols = per_face_colors(color, nothing, fs, nothing, uv)
+#     if cols isa Cairo.CairoPattern
+#         align_pattern(cols, scene, model)
+#     end
+#     return draw_mesh2D(screen, cols, vs, fs)
+# end
 
 function draw_mesh2D(screen, color, vs::Vector{<: Point2}, fs::Vector{GLTriangleFace})
     return draw_mesh2D(screen.context, color, vs, fs, eachindex(fs))
@@ -987,173 +987,173 @@ function strip_translation(M::Mat4{T}) where {T}
     )
 end
 
-function draw_mesh3D(
-        scene, screen, attributes, mesh; pos = Vec3d(0), scale = 1.0, rotation = Mat4d(I),
-        uv_transform = Mat{2, 3, Float32}(1,0,0,1,0,0)
-    )
-    @get_attribute(attributes, (shading, diffuse, specular, shininess, faceculling, clip_planes))
+# function draw_mesh3D(
+#         scene, screen, attributes, mesh; pos = Vec3d(0), scale = 1.0, rotation = Mat4d(I),
+#         uv_transform = Mat{2, 3, Float32}(1,0,0,1,0,0)
+#     )
+#     @get_attribute(attributes, (shading, diffuse, specular, shininess, faceculling, clip_planes))
 
-    matcap = to_value(get(attributes, :matcap, nothing))
-    transform_marker = to_value(get(attributes, :transform_marker, true))
-    meshpoints = decompose(Point3f, mesh)::Vector{Point3f}
-    meshfaces = decompose(GLTriangleFace, mesh)::Vector{GLTriangleFace}
-    meshnormals = normals(mesh)::Union{Nothing, Vector{Vec3f}} # note: can be made NaN-aware.
-    _meshuvs = texturecoordinates(mesh)
-    if (_meshuvs isa AbstractVector{<:Vec3})
-        error("Only 2D texture coordinates are supported right now. Use GLMakie for 3D textures.")
-    end
-    meshuvs::Union{Nothing,Vector{Vec2f}} = _meshuvs
+#     matcap = to_value(get(attributes, :matcap, nothing))
+#     transform_marker = to_value(get(attributes, :transform_marker, true))
+#     meshpoints = decompose(Point3f, mesh)::Vector{Point3f}
+#     meshfaces = decompose(GLTriangleFace, mesh)::Vector{GLTriangleFace}
+#     meshnormals = normals(mesh)::Union{Nothing, Vector{Vec3f}} # note: can be made NaN-aware.
+#     _meshuvs = texturecoordinates(mesh)
+#     if (_meshuvs isa AbstractVector{<:Vec3})
+#         error("Only 2D texture coordinates are supported right now. Use GLMakie for 3D textures.")
+#     end
+#     meshuvs::Union{Nothing,Vector{Vec2f}} = _meshuvs
 
-    if meshuvs isa Vector{Vec2f} && to_value(uv_transform) !== nothing
-        meshuvs = map(uv -> uv_transform * to_ndim(Vec3f, uv, 1), meshuvs)
-    end
+#     if meshuvs isa Vector{Vec2f} && to_value(uv_transform) !== nothing
+#         meshuvs = map(uv -> uv_transform * to_ndim(Vec3f, uv, 1), meshuvs)
+#     end
 
-    # Prioritize colors of the mesh if present
-    color = hasproperty(mesh, :color) ? mesh.color : to_value(attributes.calculated_colors)
-    per_face_col = per_face_colors(color, matcap, meshfaces, meshnormals, meshuvs)
+#     # Prioritize colors of the mesh if present
+#     color = hasproperty(mesh, :color) ? mesh.color : to_value(attributes.calculated_colors)
+#     per_face_col = per_face_colors(color, matcap, meshfaces, meshnormals, meshuvs)
 
-    model = attributes.model[]::Mat4d
-    space = to_value(get(attributes, :space, :data))::Symbol
+#     model = attributes.model[]::Mat4d
+#     space = to_value(get(attributes, :space, :data))::Symbol
 
-    if per_face_col isa Cairo.CairoPattern
-        align_pattern(per_face_col, scene, Makie.f32_convert_matrix(scene.float32convert, space) * model)
-    end
+#     if per_face_col isa Cairo.CairoPattern
+#         align_pattern(per_face_col, scene, Makie.f32_convert_matrix(scene.float32convert, space) * model)
+#     end
 
-    if haskey(attributes, :transform_marker)
-        # meshscatter/voxels route:
-        # - transform_func does not apply to vertices (only pos)
-        # - only scaling from float32convert applies to vertices
-        #   f32c_scale * (model) * rotation * scale * vertices  +  f32c * model * transform_func(plot[1])
-        # = f32c_model * rotation * scale * vertices  +  pos   (see draw_atomic(meshscatter))
-        transform_marker = attributes[:transform_marker][]::Bool
-        f32c_model = transform_marker ? strip_translation(model) : Mat4d(I)
-        if !isnothing(scene.float32convert) && Makie.is_data_space(space)
-            f32c_model = Makie.scalematrix(scene.float32convert.scaling[].scale::Vec3d) * f32c_model
-        end
-    else
-        # mesh/surface path
-        # - transform_func applies to vertices here
-        # - full float32convert applies to vertices
-        # f32c * model * vertices = f32c_model * vertices
-        transform_marker = true
-        meshpoints = apply_transform(Makie.transform_func(attributes), meshpoints)
-        f32c_model = Makie.f32_convert_matrix(scene.float32convert, space) * model
-    end
+#     if haskey(attributes, :transform_marker)
+#         # meshscatter/voxels route:
+#         # - transform_func does not apply to vertices (only pos)
+#         # - only scaling from float32convert applies to vertices
+#         #   f32c_scale * (model) * rotation * scale * vertices  +  f32c * model * transform_func(plot[1])
+#         # = f32c_model * rotation * scale * vertices  +  pos   (see draw_atomic(meshscatter))
+#         transform_marker = attributes[:transform_marker][]::Bool
+#         f32c_model = transform_marker ? strip_translation(model) : Mat4d(I)
+#         if !isnothing(scene.float32convert) && Makie.is_data_space(space)
+#             f32c_model = Makie.scalematrix(scene.float32convert.scaling[].scale::Vec3d) * f32c_model
+#         end
+#     else
+#         # mesh/surface path
+#         # - transform_func applies to vertices here
+#         # - full float32convert applies to vertices
+#         # f32c * model * vertices = f32c_model * vertices
+#         transform_marker = true
+#         meshpoints = apply_transform(Makie.transform_func(attributes), meshpoints)
+#         f32c_model = Makie.f32_convert_matrix(scene.float32convert, space) * model
+#     end
 
-    # TODO: assume Symbol here after this has been deprecated for a while
-    if shading isa Bool
-        @warn "`shading::Bool` is deprecated. Use `shading = NoShading` instead of false and `shading = FastShading` or `shading = MultiLightShading` instead of true."
-        shading_bool = shading
-    else
-        shading_bool = shading != NoShading
-    end
+#     # TODO: assume Symbol here after this has been deprecated for a while
+#     if shading isa Bool
+#         @warn "`shading::Bool` is deprecated. Use `shading = NoShading` instead of false and `shading = FastShading` or `shading = MultiLightShading` instead of true."
+#         shading_bool = shading
+#     else
+#         shading_bool = shading != NoShading
+#     end
 
-    if !isnothing(meshnormals) && to_value(get(attributes, :invert_normals, false))
-        meshnormals .= -meshnormals
-    end
+#     if !isnothing(meshnormals) && to_value(get(attributes, :invert_normals, false))
+#         meshnormals .= -meshnormals
+#     end
 
-    draw_mesh3D(
-        scene, screen, space, meshpoints, meshfaces, meshnormals, per_face_col,
-        pos, scale, rotation,
-        f32c_model::Mat4d, shading_bool::Bool, diffuse::Vec3f,
-        specular::Vec3f, shininess::Float32, faceculling::Int, clip_planes
-    )
-end
+#     draw_mesh3D(
+#         scene, screen, space, meshpoints, meshfaces, meshnormals, per_face_col,
+#         pos, scale, rotation,
+#         f32c_model::Mat4d, shading_bool::Bool, diffuse::Vec3f,
+#         specular::Vec3f, shininess::Float32, faceculling::Int, clip_planes
+#     )
+# end
 
-function draw_mesh3D(
-        scene, screen, space, meshpoints, meshfaces, meshnormals, per_face_col,
-        pos, scale, rotation,
-        f32c_model, shading, diffuse,
-        specular, shininess, faceculling, clip_planes
-    )
-    ctx = screen.context
-    projectionview = Makie.space_to_clip(scene.camera, space, true)
-    eyeposition = scene.camera.eyeposition[]
+# function draw_mesh3D(
+#         scene, screen, space, meshpoints, meshfaces, meshnormals, per_face_col,
+#         pos, scale, rotation,
+#         f32c_model, shading, diffuse,
+#         specular, shininess, faceculling, clip_planes
+#     )
+#     ctx = screen.context
+#     projectionview = Makie.space_to_clip(scene.camera, space, true)
+#     eyeposition = scene.camera.eyeposition[]
 
-    # local_model applies rotation and markersize from meshscatter to vertices
-    i = Vec(1, 2, 3)
-    local_model = rotation * Makie.scalematrix(Vec3d(scale))
-    normalmatrix = transpose(inv(f32c_model[i, i] * local_model[i, i])) # see issue #3702
+#     # local_model applies rotation and markersize from meshscatter to vertices
+#     i = Vec(1, 2, 3)
+#     local_model = rotation * Makie.scalematrix(Vec3d(scale))
+#     normalmatrix = transpose(inv(f32c_model[i, i] * local_model[i, i])) # see issue #3702
 
-    # mesh, surface:        apply f32convert and model to vertices
-    # meshscatter, voxels:  apply f32 scale, maybe model, rotation, markersize, positions to vertices
-    # (see previous function)
-    vs = broadcast(meshpoints) do v
-        # Should v get a nan2zero?
-        p4d = to_ndim(Vec4d, to_ndim(Vec3d, v, 0), 1)
-        p4d = f32c_model * local_model * p4d
-        return to_ndim(Vec4f, p4d .+ to_ndim(Vec4d, pos, 0), NaN32)
-    end
+#     # mesh, surface:        apply f32convert and model to vertices
+#     # meshscatter, voxels:  apply f32 scale, maybe model, rotation, markersize, positions to vertices
+#     # (see previous function)
+#     vs = broadcast(meshpoints) do v
+#         # Should v get a nan2zero?
+#         p4d = to_ndim(Vec4d, to_ndim(Vec3d, v, 0), 1)
+#         p4d = f32c_model * local_model * p4d
+#         return to_ndim(Vec4f, p4d .+ to_ndim(Vec4d, pos, 0), NaN32)
+#     end
 
-    if Makie.is_data_space(space) && !isempty(clip_planes)
-        valid = Bool[is_visible(clip_planes, p) for p in vs]
-    else
-        valid = Bool[]
-    end
+#     if Makie.is_data_space(space) && !isempty(clip_planes)
+#         valid = Bool[is_visible(clip_planes, p) for p in vs]
+#     else
+#         valid = Bool[]
+#     end
 
-    # Camera to screen space
-    transform = cairo_viewport_matrix(scene.camera.resolution[]) * projectionview
-    ts = project_position(Point3f, transform, vs, eachindex(vs))
+#     # Camera to screen space
+#     transform = cairo_viewport_matrix(scene.camera.resolution[]) * projectionview
+#     ts = project_position(Point3f, transform, vs, eachindex(vs))
 
-    # Approximate zorder
-    average_zs = map(f -> average_z(ts, f), meshfaces)
-    zorder = sortperm(average_zs)
+#     # Approximate zorder
+#     average_zs = map(f -> average_z(ts, f), meshfaces)
+#     zorder = sortperm(average_zs)
 
-    if isnothing(meshnormals)
-        ns = nothing
-    else
-        ns = map(n -> normalize(normalmatrix * n), meshnormals)
-    end
+#     if isnothing(meshnormals)
+#         ns = nothing
+#     else
+#         ns = map(n -> normalize(normalmatrix * n), meshnormals)
+#     end
 
-    # Face culling
-    if isempty(valid) && !isnothing(ns)
-        zorder = filter(i -> any(last.(ns[meshfaces[i]]) .> faceculling), zorder)
-    elseif !isempty(valid)
-        zorder = filter(i -> all(valid[meshfaces[i]]), zorder)
-    else
-        # no clipped faces, no normals to rely on for culling -> do nothing
-    end
+#     # Face culling
+#     if isempty(valid) && !isnothing(ns)
+#         zorder = filter(i -> any(last.(ns[meshfaces[i]]) .> faceculling), zorder)
+#     elseif !isempty(valid)
+#         zorder = filter(i -> all(valid[meshfaces[i]]), zorder)
+#     else
+#         # no clipped faces, no normals to rely on for culling -> do nothing
+#     end
 
-    # If per_face_col is a CairoPattern the plot is using an AbstractPattern
-    # as a color. In this case we don't do shading and fall back to mesh2D
-    # rendering
-    if per_face_col isa Cairo.CairoPattern
-        return draw_mesh2D(ctx, per_face_col, ts, meshfaces, reverse(zorder))
-    end
+#     # If per_face_col is a CairoPattern the plot is using an AbstractPattern
+#     # as a color. In this case we don't do shading and fall back to mesh2D
+#     # rendering
+#     if per_face_col isa Cairo.CairoPattern
+#         return draw_mesh2D(ctx, per_face_col, ts, meshfaces, reverse(zorder))
+#     end
 
 
-    # Light math happens in view/camera space
-    dirlight = Makie.get_directional_light(scene)
-    if !isnothing(dirlight)
-        lightdirection = if dirlight.camera_relative
-            T = inv(scene.camera.view[][Vec(1,2,3), Vec(1,2,3)])
-            normalize(T * dirlight.direction[])
-        else
-            normalize(dirlight.direction[])
-        end
-        c = dirlight.color[]
-        light_color = Vec3f(red(c), green(c), blue(c))
-    else
-        lightdirection = Vec3f(0,0,-1)
-        light_color = Vec3f(0)
-    end
+#     # Light math happens in view/camera space
+#     dirlight = Makie.get_directional_light(scene)
+#     if !isnothing(dirlight)
+#         lightdirection = if dirlight.camera_relative
+#             T = inv(scene.camera.view[][Vec(1,2,3), Vec(1,2,3)])
+#             normalize(T * dirlight.direction[])
+#         else
+#             normalize(dirlight.direction[])
+#         end
+#         c = dirlight.color[]
+#         light_color = Vec3f(red(c), green(c), blue(c))
+#     else
+#         lightdirection = Vec3f(0,0,-1)
+#         light_color = Vec3f(0)
+#     end
 
-    ambientlight = Makie.get_ambient_light(scene)
-    ambient = if !isnothing(ambientlight)
-        c = ambientlight.color[]
-        Vec3f(c.r, c.g, c.b)
-    else
-        Vec3f(0)
-    end
+#     ambientlight = Makie.get_ambient_light(scene)
+#     ambient = if !isnothing(ambientlight)
+#         c = ambientlight.color[]
+#         Vec3f(c.r, c.g, c.b)
+#     else
+#         Vec3f(0)
+#     end
 
-    # vs are used as camdir (camera to vertex) for light calculation (in world space)
-    vs = map(v -> normalize(v[i] - eyeposition), vs)
+#     # vs are used as camdir (camera to vertex) for light calculation (in world space)
+#     vs = map(v -> normalize(v[i] - eyeposition), vs)
 
-    draw_pattern(
-        ctx, zorder, shading, meshfaces, ts, per_face_col, ns, vs,
-        lightdirection, light_color, shininess, diffuse, ambient, specular)
-    return
-end
+#     draw_pattern(
+#         ctx, zorder, shading, meshfaces, ts, per_face_col, ns, vs,
+#         lightdirection, light_color, shininess, diffuse, ambient, specular)
+#     return
+# end
 
 function _calculate_shaded_vertexcolors(N, v, c, lightdir, light_color, ambient, diffuse, specular, shininess)
     L = lightdir

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -1249,7 +1249,7 @@ end
 #                                 MeshScatter                                  #
 ################################################################################
 
-
+# Still used for voxels
 function _transform_to_world(scene::Scene, @nospecialize(plot), pos)
     space = plot.space[]::Symbol
     model = plot.model[]::Mat4d
@@ -1320,44 +1320,44 @@ end
 ################################################################################
 
 
-function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Voxels))
-    pos = Makie.voxel_positions(primitive)
-    scale = Makie.voxel_size(primitive)
-    colors = Makie.voxel_colors(primitive)
-    marker = GeometryBasics.expand_faceviews(normal_mesh(Rect3f(Point3f(-0.5), Vec3f(1))))
+# function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.Voxels))
+#     pos = Makie.voxel_positions(primitive)
+#     scale = Makie.voxel_size(primitive)
+#     colors = Makie.voxel_colors(primitive)
+#     marker = GeometryBasics.expand_faceviews(normal_mesh(Rect3f(Point3f(-0.5), Vec3f(1))))
 
-    # transformation to world space
-    transformed_pos = _transform_to_world(scene, primitive, pos)
+#     # transformation to world space
+#     transformed_pos = _transform_to_world(scene, primitive, pos)
 
-    # Face culling
-    if !isempty(primitive.clip_planes[]) && Makie.is_data_space(primitive)
-        valid = [is_visible(primitive.clip_planes[], p) for p in transformed_pos]
-        transformed_pos = transformed_pos[valid]
-        colors = colors[valid]
-    end
+#     # Face culling
+#     if !isempty(primitive.clip_planes[]) && Makie.is_data_space(primitive)
+#         valid = [is_visible(primitive.clip_planes[], p) for p in transformed_pos]
+#         transformed_pos = transformed_pos[valid]
+#         colors = colors[valid]
+#     end
 
-    # For correct z-ordering we need to be in view/camera or screen space
-    view = scene.camera.view[]
-    zorder = sortperm(transformed_pos, by = p -> begin
-        p4d = to_ndim(Vec4d, p, 1)
-        cam_pos = view[Vec(3,4), Vec(1,2,3,4)] * p4d
-        cam_pos[1] / cam_pos[2]
-    end, rev=false)
+#     # For correct z-ordering we need to be in view/camera or screen space
+#     view = scene.camera.view[]
+#     zorder = sortperm(transformed_pos, by = p -> begin
+#         p4d = to_ndim(Vec4d, p, 1)
+#         cam_pos = view[Vec(3,4), Vec(1,2,3,4)] * p4d
+#         cam_pos[1] / cam_pos[2]
+#     end, rev=false)
 
-    submesh = Attributes(
-        model = primitive.model,
-        shading = primitive.shading, diffuse = primitive.diffuse,
-        specular = primitive.specular, shininess = primitive.shininess,
-        faceculling = get(primitive, :faceculling, -10),
-        transformation = Makie.transformation(primitive),
-        clip_planes = Plane3f[],
-        transform_marker = true
-    )
+#     submesh = Attributes(
+#         model = primitive.model,
+#         shading = primitive.shading, diffuse = primitive.diffuse,
+#         specular = primitive.specular, shininess = primitive.shininess,
+#         faceculling = get(primitive, :faceculling, -10),
+#         transformation = Makie.transformation(primitive),
+#         clip_planes = Plane3f[],
+#         transform_marker = true
+#     )
 
-    for i in zorder
-        submesh[:calculated_colors] = colors[i]
-        draw_mesh3D(scene, screen, submesh, marker, pos = transformed_pos[i], scale = scale)
-    end
+#     for i in zorder
+#         submesh[:calculated_colors] = colors[i]
+#         draw_mesh3D(scene, screen, submesh, marker, pos = transformed_pos[i], scale = scale)
+#     end
 
-    return nothing
-end
+#     return nothing
+# end

--- a/CairoMakie/src/primitives.jl
+++ b/CairoMakie/src/primitives.jl
@@ -1267,51 +1267,51 @@ function _transform_to_world(f32_model, tf, pos)
     end
 end
 
-function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.MeshScatter))
-    @get_attribute(primitive, (model, marker, markersize, rotation))
+# function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Makie.MeshScatter))
+#     @get_attribute(primitive, (model, marker, markersize, rotation))
 
-    # We combine vertices and positions in world space. Here we do the
-    # transformation to world space
-    transformed_pos = _transform_to_world(scene, primitive, primitive[1][])
+#     # We combine vertices and positions in world space. Here we do the
+#     # transformation to world space
+#     transformed_pos = _transform_to_world(scene, primitive, primitive[1][])
 
-    # For correct z-ordering we need to be in view/camera or screen space
-    view = scene.camera.view[]
-    zorder = sortperm(transformed_pos, by = p -> begin
-        p4d = to_ndim(Vec4d, p, 1)
-        cam_pos = view[Vec(3,4), Vec(1,2,3,4)] * p4d
-        cam_pos[1] / cam_pos[2]
-    end, rev=false)
+#     # For correct z-ordering we need to be in view/camera or screen space
+#     view = scene.camera.view[]
+#     zorder = sortperm(transformed_pos, by = p -> begin
+#         p4d = to_ndim(Vec4d, p, 1)
+#         cam_pos = view[Vec(3,4), Vec(1,2,3,4)] * p4d
+#         cam_pos[1] / cam_pos[2]
+#     end, rev=false)
 
-    color = to_color(primitive.calculated_colors[])
-    submesh = Attributes(
-        model = model,
-        calculated_colors = color,
-        shading = primitive.shading, diffuse = primitive.diffuse,
-        specular = primitive.specular, shininess = primitive.shininess,
-        faceculling = get(primitive, :faceculling, -10),
-        transformation = Makie.transformation(primitive),
-        clip_planes = primitive.clip_planes,
-        transform_marker = primitive.transform_marker
-    )
+#     color = to_color(primitive.calculated_colors[])
+#     submesh = Attributes(
+#         model = model,
+#         calculated_colors = color,
+#         shading = primitive.shading, diffuse = primitive.diffuse,
+#         specular = primitive.specular, shininess = primitive.shininess,
+#         faceculling = get(primitive, :faceculling, -10),
+#         transformation = Makie.transformation(primitive),
+#         clip_planes = primitive.clip_planes,
+#         transform_marker = primitive.transform_marker
+#     )
 
-    uv_transform = Makie.convert_attribute(primitive[:uv_transform][], Makie.key"uv_transform"(), Makie.key"meshscatter"())
-    for i in zorder
-        if color isa AbstractVector
-            submesh[:calculated_colors] = color[i]
-        end
-        scale = markersize isa Vector ? markersize[i] : markersize
-        _rotation = Makie.rotationmatrix4(to_rotation(Makie.sv_getindex(rotation, i)))
-        _uv_transform = Makie.sv_getindex(uv_transform, i)
+#     uv_transform = Makie.convert_attribute(primitive[:uv_transform][], Makie.key"uv_transform"(), Makie.key"meshscatter"())
+#     for i in zorder
+#         if color isa AbstractVector
+#             submesh[:calculated_colors] = color[i]
+#         end
+#         scale = markersize isa Vector ? markersize[i] : markersize
+#         _rotation = Makie.rotationmatrix4(to_rotation(Makie.sv_getindex(rotation, i)))
+#         _uv_transform = Makie.sv_getindex(uv_transform, i)
 
-        draw_mesh3D(
-            scene, screen, submesh, marker, pos = transformed_pos[i],
-            scale = scale isa Real ? Vec3f(scale) : to_ndim(Vec3f, scale, 1f0),
-            rotation = _rotation, uv_transform = _uv_transform
-        )
-    end
+#         draw_mesh3D(
+#             scene, screen, submesh, marker, pos = transformed_pos[i],
+#             scale = scale isa Real ? Vec3f(scale) : to_ndim(Vec3f, scale, 1f0),
+#             rotation = _rotation, uv_transform = _uv_transform
+#         )
+#     end
 
-    return nothing
-end
+#     return nothing
+# end
 
 
 

--- a/ComputePipeline/src/io.jl
+++ b/ComputePipeline/src/io.jl
@@ -91,8 +91,8 @@ function edge_callback_to_string(f, args::Tuple)
     arg_str = join(("::$T" for T in args), ", ")
     arg_str = replace(arg_str, "Base.RefValue" => "Ref")
     func = edge_callback_name(f, "($arg_str)")
-    file, line = Base.functionloc(f, args)
-    return "$func", "@ $file:$line"
+    loc = edge_callback_location(f, args)
+    return "$func", "@ $loc"
 end
 
 function Base.show(io::IO, edge::ComputeEdge)

--- a/src/basic_recipes/voxels.jl
+++ b/src/basic_recipes/voxels.jl
@@ -401,16 +401,14 @@ end
 # TODO: for CairoMakie
 
 function voxel_size(p::Voxels)
-    mini = minimum.(to_value.(p.converted[1:3]))
-    maxi = maximum.(to_value.(p.converted[1:3]))
-    _size = size(p.converted[4][])
-    return Vec3f((maxi .- mini) ./ _size .- convert_attribute(p.gap[], key"gap"(), key"voxels"()))
+    mini, maxi = extrema(data_limits(p))
+    _size = size(p.chunk[])
+    return Vec3f((maxi .- mini) ./ _size .- p.gap[])
 end
 
 function voxel_positions(p::Voxels)
-    mini = minimum.(to_value.(p.converted[1:3]))
-    maxi = maximum.(to_value.(p.converted[1:3]))
-    voxel_id = p.converted[4][]
+    mini, maxi = extrema(data_limits(p))
+    voxel_id = p.chunk_u8[]
     _size = size(voxel_id)
     step = (maxi .- mini) ./ _size
     return [
@@ -421,15 +419,14 @@ function voxel_positions(p::Voxels)
 end
 
 function voxel_colors(p::Voxels)
-    voxel_id = p.converted[4][]
-    colormapping = p.calculated_colors[]
+    voxel_id = p.chunk_u8[]
     uv_map = p.uvmap[]
     if !isnothing(uv_map)
         @warn "Voxel textures are not implemented in this backend!"
-    elseif colormapping isa ColorMapping
-        color = colormapping.colormap[]
+    elseif haskey(p, :voxel_colormap)
+        color = p.colormap[]
     else
-        color = colormapping
+        color = p.voxel_color[]
     end
 
     return [color[id] for id in voxel_id if id !== 0x00]

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -690,7 +690,7 @@ function compute_plot(::Type{Volume}, args::Tuple, user_kw::Dict{Symbol,Any})
     attr = ComputeGraph()
     add_attributes!(Volume, attr, user_kw)
     register_arguments!(Volume, attr, user_kw, args...)
-    register_position_transforms!(attr)
+    register_position_transforms!(attr) # TODO: isn't this skipped
     register_colormapping!(attr, :volume)
     register_computation!(attr, [:x, :y, :z], [:data_limits]) do (x, y, z), changed, last
         return (Rect3d(Vec3.(x, y, z)...),)

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -427,7 +427,7 @@ function surface2mesh(xs, ys, zs::AbstractMatrix, transform_func = identity)
     # create valid tessellations (triangulations) for the mesh
     # knowing that it is a regular grid makes this simple
     rect = Tessellation(Rect2f(0, 0, 1, 1), size(zs))
-    # we use quad faces so that color handling is consistent
+    # we use quad faces so that nan handling is consistent
     faces = decompose(QuadFace{Int}, rect)
     # and remove quads that contain a NaN coordinate to avoid drawing triangles
     faces = filter(f -> !any(i -> isnan(ps[i]), f), faces)
@@ -435,7 +435,7 @@ function surface2mesh(xs, ys, zs::AbstractMatrix, transform_func = identity)
     # uv = map(x-> Vec2f(1f0 - x[2], 1f0 - x[1]), decompose_uv(rect))
     uv = decompose_uv(rect)
     # return a mesh with known uvs and normals.
-    return ps, faces, uv, nan_aware_normals(ps, faces)
+    return ps, decompose(GLTriangleFace, faces), uv, nan_aware_normals(ps, faces)
 end
 
 


### PR DESCRIPTION
This should get all primitives (except text) working in CairoMakie. Mesh, Surface, MeshScatter and Voxels drawing functions got refactored so they don't rely on `Attributes()` anymore. Heatmap and Image are mostly the same. I also didn't add much in terms of computations here, because most of it is rather unique to CairoMakie I think.