### PR TITLE
Open circle and square markers

### DIFF
--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -582,6 +582,16 @@ end
     current_figure()
 end
 
+@reference_test "Open scatter markers" begin
+    data = RNG.randn(200, 2)
+    f = Figure()
+    scatter(f[1, 1], data, marker = open_circle())
+    scatter(f[1, 2], data, marker = open_circle(0.5))
+    scatter(f[2, 1], data, marker = open_square())
+    scatter(f[2, 2], data, marker = open_square(0.5))
+    f
+end
+
 @reference_test "2D surface with explicit color" begin
     surface(1:10, 1:10, ones(10, 10); color = [RGBf(x*y/100, 0, 0) for x in 1:10, y in 1:10], shading = NoShading)
 end

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -241,6 +241,7 @@ include("event-recorder.jl")
 
 # bezier paths
 export BezierPath, MoveTo, LineTo, CurveTo, EllipticalArc, ClosePath
+export open_circle, open_square
 
 # help functions and supporting functions
 export help, help_attributes, help_arguments

--- a/src/bezier.jl
+++ b/src/bezier.jl
@@ -844,3 +844,45 @@ const BezierCross = let
 end
 
 const BezierX = rotate(BezierCross, pi / 4)
+
+"""
+    open_circle(radius_fraction = 0.8; r)
+
+Returns a `BezierPath` of an open circle whose radius `r` is by default size-matched
+to the `:circle` marker. The relative size of the radius of the hole is
+determined by `radius_fraction`.
+"""
+function open_circle(radius_fraction = 0.8; r = 0.47)
+    r_inner = r * radius_fraction
+    BezierPath([
+        MoveTo(Point(r, 0.0)),
+        EllipticalArc(Point(0.0, 0), r, r, 0.0, 0.0, 2pi),
+        ClosePath(),
+        MoveTo(Point(r_inner, 0.0)),
+        EllipticalArc(Point(0.0, 0), r_inner, r_inner, 0.0, 2pi, 0.0),
+        ClosePath(),
+    ])
+end
+
+"""
+    open_square(radius_fraction = 0.8; r)
+
+Returns a `BezierPath` of an open square whose radius `r` is by default size-matched
+to the `:rect` marker. The relative size of the radius of the hole is
+determined by `radius_fraction`.
+"""
+function open_square(radius_fraction = 0.8; r = 0.95 * sqrt(pi) / 2 / 2)
+    r_inner = r * radius_fraction
+    BezierPath([
+        MoveTo(Point2d(r, -r)),
+        LineTo(Point2d(r, r)),
+        LineTo(Point2d(-r, r)),
+        LineTo(Point2d(-r, -r)),
+        ClosePath(),
+        MoveTo(Point2d(r_inner, -r_inner)),
+        LineTo(Point2d(-r_inner, -r_inner)),
+        LineTo(Point2d(-r_inner, r_inner)),
+        LineTo(Point2d(r_inner, r_inner)),
+        ClosePath(),
+    ])
+end


### PR DESCRIPTION
Open markers are often recommended because they allow discriminating overlapping data points better than closed markers. Here I'm adding convenience functions that match `:circle` and `:rect` markers with adjustable inner radius. I've not really seen many other open markers in the wild but more could be added later. One can also use stroked markers for the same effect, but for example in AoG, one can then not use the default `color` mapping which is annoying when switching between markers.

```julia
data = RNG.randn(200, 2)
f = Figure()
scatter(f[1, 1], data, marker = open_circle())
scatter(f[1, 2], data, marker = open_circle(0.5))
scatter(f[2, 1], data, marker = open_square())
scatter(f[2, 2], data, marker = open_square(0.5))
f
```

<img width="584" alt="image" src="https://github.com/user-attachments/assets/4b78db5f-d559-4e51-9d67-163584f35297" />
