### PR TITLE
Fix automatic unit decision for Unitful axes

### DIFF
--- a/src/dim-converts/unitful-integration.jl
+++ b/src/dim-converts/unitful-integration.jl
@@ -91,10 +91,10 @@ function get_all_base10_units(x::Unitful.Unit{Sym, Unitful.𝐓}) where {Sym}
 end
 
 function best_unit(min, max)
-    middle = (min + max) / 2.0
-    all_units = get_all_base10_units(middle)
+    axis_length = max - min
+    all_units = get_all_base10_units(axis_length)
     _, index = findmin(all_units) do unit
-        raw_value = abs(unit_convert(unit, middle))
+        raw_value = abs(unit_convert(unit, axis_length))
         # We want the unit that displays the value with the smallest number possible, but not something like 1.0e-19
         # So, for fractions between 0..1, we use inv to penalize really small fractions
         positive = raw_value < 1.0 ? (inv(raw_value) + 100) : raw_value


### PR DESCRIPTION
# Description

Fixes the automatically determined units for Unitful axes that are symmetric.

Currently if an axis has the same absolute value for its positive and negative extrema, the determination of the best unit in `Makie.best_unit` gives the smallest possible prefix. E.g. `Makie.best_unit(-1.0u"mm", 1.0u"mm")` gives ym=yoctometer=10^-24 m because it only uses the value in the middle between min and max which is zero in this case.
This results in useless units for these types of axes:
```julia
lines(range(start=-1.0u"mm", stop=1.0u"mm", length=50), randn(50))
```
![grafik](https://github.com/user-attachments/assets/68577a89-7fcc-42aa-abf0-e7f2446dcf51)
For a non-symmetric axis everything is fine
```julia
lines(range(start=0.0u"mm", stop=1.0u"mm", length=50), randn(50))
```
![grafik](https://github.com/user-attachments/assets/156c854c-7f06-48ac-8cc2-038ef185e1d0)

## Proposed fix
In this PR I changed the decision of the unit to not use the middle value but instead the total length of the axis, which should be a characteristic value based on which the correct unit can be determined:
![grafik](https://github.com/user-attachments/assets/fa53b4c3-d0b8-4b17-ad81-35c7ac7e3ecd)
![grafik](https://github.com/user-attachments/assets/e0b09881-695d-4737-b09b-736c1aa32eed)

There are cases where the automatically decided axis unit is different than before, but I do not think this would count as a breaking change.
Before:
```julia
Makie.best_unit(0u"mm",10u"mm") # mm
```
This PR:
```julia
Makie.best_unit(0u"mm",10u"mm") # cm
```

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

