### PR TITLE
[WIP] move most of the texture atlas logic to JS, to be able to use bigger atlas

### DIFF
--- a/WGLMakie/src/Serialization.js
+++ b/WGLMakie/src/Serialization.js
@@ -1,8 +1,7 @@
 import * as THREE from "https://cdn.esm.sh/v66/three@0.173/es2021/three.js";
 import * as Camera from "./Camera.js";
 import { create_line, create_linesegments } from "./Lines.js";
-
-
+import { get_texture_atlas } from "./TextureAtlas.js";
 /**
  * Updates the value of a given uniform with a new value.
  *
@@ -30,7 +29,6 @@ function update_uniform(uniform, new_value) {
     }
 }
 
-
 class Plot {
     mesh = undefined;
     parent = undefined;
@@ -49,6 +47,9 @@ class Plot {
             this.mesh = create_line(scene, this.plot_data);
         } else if (data.plot_type === "linesegments") {
             this.mesh = create_linesegments(scene, this.plot_data);
+        } else if (data.plot_type === "text") {
+            this.is_instanced = true;
+            this.mesh = create_text_mesh(scene, this.plot_data);
         } else if ("instance_attributes" in data) {
             this.is_instanced = true;
             this.mesh = create_instanced_mesh(scene, this.plot_data);
@@ -253,20 +254,7 @@ function to_uniform(scene, data) {
             return data;
         }
         // else, we convert it to THREE vector/matrix types
-        if (data.length == 2) {
-            return new THREE.Vector2().fromArray(data);
-        }
-        if (data.length == 3) {
-            return new THREE.Vector3().fromArray(data);
-        }
-        if (data.length == 4) {
-            return new THREE.Vector4().fromArray(data);
-        }
-        if (data.length == 16) {
-            const mat = new THREE.Matrix4();
-            mat.fromArray(data);
-            return mat;
-        }
+        return to_three_vector(data);
     }
     // else, leave unchanged
     return data;
@@ -307,7 +295,9 @@ function connect_plot(scene, plot) {
     // fill in the camera uniforms, that we don't sent in serialization per plot
     const cam = scene.wgl_camera;
     const identity = new THREE.Uniform(new THREE.Matrix4());
-    const uniforms = plot.mesh ? plot.mesh.material.uniforms : plot.plot_data.uniforms;
+    const uniforms = plot.mesh
+        ? plot.mesh.material.uniforms
+        : plot.plot_data.uniforms;
     const space = plot.plot_data.cam_space;
     if (space == "data") {
         uniforms.view = cam.view;
@@ -328,7 +318,7 @@ function connect_plot(scene, plot) {
         uniforms.projection = identity;
         uniforms.projectionview = identity;
     } else {
-        throw new Error(`Space ${space} not supported!`)
+        throw new Error(`Space ${space} not supported!`);
     }
     const { px_per_unit } = scene.screen;
     uniforms.resolution = cam.resolution;
@@ -345,7 +335,6 @@ function connect_plot(scene, plot) {
     uniforms.light_direction = scene.light_direction;
 }
 
-
 export function add_plot(scene, plot_data) {
     // fill in the camera uniforms, that we don't sent in serialization per plot
     const p = new Plot(scene, plot_data);
@@ -359,7 +348,7 @@ export function add_plot(scene, plot_data) {
 function convert_RGB_to_RGBA(rgbArray) {
     const length = rgbArray.length;
     const rgbaArray = new rgbArray.constructor((length / 3) * 4);
-    const a = (rgbArray instanceof Uint8Array) ? 255 : 1.0;
+    const a = rgbArray instanceof Uint8Array ? 255 : 1.0;
 
     for (let i = 0, j = 0; i < length; i += 3, j += 4) {
         rgbaArray[j] = rgbArray[i]; // R
@@ -407,26 +396,14 @@ function create_texture(scene, data) {
     // Special care has to be taken to deregister the callback when the context gets destroyed
     // Since TEXTURE_ATLAS uses "Bonito.Retain" and will live for the whole browser session.
     if (buffer == "texture_atlas") {
-        const {texture_atlas} = scene.screen
-        if (texture_atlas) {
-            return texture_atlas;
-        } else {
-            data.data = TEXTURE_ATLAS[0].value
-            const texture = create_texture_from_data(data);
-            scene.screen.texture_atlas = texture;
-            TEXTURE_ATLAS[0].on((new_data) => {
-                if (new_data === texture) {
-                    // if the data is our texture, it means the WGL context got destroyed and we want to deregister
-                    // TODO, better Observables.js API for this
-                    return false; // deregisters the callback
-                } else {
-                    texture.image.data.set(new_data);
-                    texture.needsUpdate = true;
-                    return
-                }
-            });
-            return texture;
+        const { texture_atlas, renderer, tex_atlas } = scene.screen;
+        if (!texture_atlas) {
+            const atlas = get_texture_atlas();
+            console.log("Setting atlas from JS")
+            tex_atlas.notify(atlas.data)
+            scene.screen.texture_atlas = atlas.get_texture(renderer);
         }
+        return scene.screen.texture_atlas;
     } else {
         return create_texture_from_data(data);
     }
@@ -459,7 +436,6 @@ function re_create_texture(old_texture, buffer, size) {
     }
     return tex;
 }
-
 
 function BufferAttribute(buffer) {
     const jsbuff = new THREE.BufferAttribute(buffer.flat, buffer.type_length);
@@ -564,6 +540,113 @@ function create_mesh(scene, program) {
         mesh.geometry.setIndex(new THREE.BufferAttribute(x, 1));
     });
     return mesh;
+}
+
+/**
+ * Returns x[i] if x is an array, otherwise returns x.
+ * @param {*} x - Either an array or a scalar value
+ * @param {number} i - Index to access if x is an array
+ * @returns {*} - The indexed value or x itself
+ */
+function broadcast_getindex(a, x, i) {
+    if (a.length == (x.length / 2)) {
+        return new THREE.Vector2(x[i * 2], x[i * 2 + 1]);
+    } else if (x.length == 2) {
+        return new THREE.Vector2(x[0], x[1]);
+    } else {
+        throw new Error(
+            `broadcast_getindex: x has length ${x.length}, but a has length ${a.length}`
+        );
+    }
+}
+
+function per_glyph_data(glyph_hashes, scales, offsets) {
+    const atlas = get_texture_atlas();
+    const uv_offset_width = new Float32Array(glyph_hashes.length * 4);
+    const markersize = new Float32Array(glyph_hashes.length * 2);
+    const char_offsets = new Float32Array(glyph_hashes.length * 2);
+    const quad_offsets = new Float32Array(glyph_hashes.length * 2);
+    for (let i = 0; i < glyph_hashes.length; i++) {
+        const hash = glyph_hashes[i];
+        const [uv, c_width, c_offset, q_offset] = atlas.get_glyph_data(
+            hash,
+            broadcast_getindex(glyph_hashes, scales, i),
+            broadcast_getindex(glyph_hashes, offsets, i)
+        );
+        uv_offset_width.set(uv.toArray(), i * 4);
+        markersize.set(c_width.toArray(), i * 2);
+        char_offsets.set(c_offset.toArray(), i * 2);
+        quad_offsets.set(q_offset.toArray(), i * 2);
+    }
+
+    return [uv_offset_width, markersize, char_offsets, quad_offsets];
+}
+
+function to_three_vector(data) {
+    if (data.length == 2) {
+        return new THREE.Vector2().fromArray(data);
+    }
+    if (data.length == 3) {
+        return new THREE.Vector3().fromArray(data);
+    }
+    if (data.length == 4) {
+        return new THREE.Vector4().fromArray(data);
+    }
+    if (data.length == 16) {
+        const mat = new THREE.Matrix4();
+        mat.fromArray(data);
+        return mat;
+    }
+    return data
+}
+
+function update_glyph_data(scene, glyph_data) {
+    const atlas = get_texture_atlas();
+    Object.keys(glyph_data).forEach((hash) => {
+        const [uv, sdf, origin, width, minimum] = glyph_data[hash];
+        atlas.insert_glyph(
+            hash,
+            sdf,
+            to_three_vector(uv),
+            to_three_vector(origin),
+            to_three_vector(width),
+            to_three_vector(minimum)
+        );
+    });
+    if (Object.keys(glyph_data).length > 0) {
+        atlas.upload_tex_data(scene);
+    }
+}
+
+
+function get_glyph_data_attributes(scene, glyph_data) {
+    const { glyph_hashes, atlas_updates, offsets, scales } = glyph_data;
+    update_glyph_data(scene, atlas_updates);
+    const [uv_offset_width, markersize, marker_offset, quad_offset] =
+        per_glyph_data(glyph_hashes, scales, offsets);
+    return { uv_offset_width, markersize, marker_offset, quad_offset };
+}
+
+function create_text_mesh(scene, program) {
+    const glyph_obs = program.glyph_data;
+    const updater = program.attribute_updater;
+    const lengths = { uv_offset_width: 4 };
+    glyph_obs.on((glyph_data) => {
+        const data = get_glyph_data_attributes(scene, glyph_data);
+        for (const name in data) {
+            const buff = data[name];
+            const len = lengths[name] || 2;
+            updater.notify([name, buff, buff.length / len]);
+        }
+    });
+    const gdata = get_glyph_data_attributes(scene, glyph_obs.value);
+    for (const name in gdata) {
+        const buff = gdata[name];
+        const len = lengths[name] || 2;
+        program.vertexarrays[name] = { flat: buff, type_length: len };
+    }
+
+    return create_instanced_mesh(scene, program);
 }
 
 function create_instanced_mesh(scene, program) {
@@ -717,7 +800,6 @@ export function deserialize_scene(data, screen) {
         });
     }
 
-
     data.plots.forEach((plot_data) => {
         add_plot(scene, plot_data);
     });
@@ -729,7 +811,7 @@ export function deserialize_scene(data, screen) {
 }
 
 export function delete_plot(plot) {
-    plot.plot_object.dispose()
+    plot.plot_object.dispose();
 }
 
 export function delete_three_scene(scene) {

--- a/WGLMakie/src/TextureAtlas.js
+++ b/WGLMakie/src/TextureAtlas.js
@@ -1,0 +1,165 @@
+import * as THREE from "https://cdn.esm.sh/v66/three@0.173/es2021/three.js";
+
+/**
+ * Converts a UV rectangle to pixel bounds.
+ * @param {THREE.Vector4} uv
+ * @param {number} tex_width
+ * @param {number} tex_height
+ * @returns {{x_start: number, y_start: number, x_end: number, y_end: number}}
+ */
+function uv_to_pixel_bounds(uv, tex_width, tex_height) {
+    const tex_size = new THREE.Vector2(tex_width, tex_height);
+
+    const uv_left_bottom = new THREE.Vector2(uv.x, uv.y);
+    const uv_right_top = new THREE.Vector2(uv.z, uv.w);
+
+    const px_left_bottom = uv_left_bottom
+        .clone()
+        .multiply(tex_size)
+        .subScalar(0.5)
+        .floor();
+
+    const px_right_top = uv_right_top
+        .clone()
+        .multiply(tex_size)
+        .addScalar(0.5)
+        .ceil();
+    const wx = Math.abs(px_right_top.x - px_left_bottom.x);
+    const wy = Math.abs(px_right_top.y - px_left_bottom.y);
+    return [px_left_bottom, new THREE.Vector2(wx, wy)];
+}
+
+export class TextureAtlas {
+    /**
+     * @param {number} width - Width of the texture atlas.
+     * @param {number} height - Height of the texture atlas.
+     */
+    constructor(width, pix_per_glyph, glyph_padding) {
+        console.log("Creating texture atlas");
+        this.pix_per_glyph = pix_per_glyph; // Pixels per glyph
+        this.glyph_padding = glyph_padding; // Padding around each glyph
+        this.width = width;
+        this.height = width;
+        this.data = new Float32Array(width * width); // Flat 1-channel data
+        for (let i = 0; i < this.data.length; i++) {
+            this.data[i] = 0.0; //0.5 * pix_per_glyph + glyph_padding;
+        }
+        this.glyph_data = new Map(); // Map<UInt32, THREE.Vector4>
+        this.textures = new Map(); // Map<WebGLContext, THREE.DataTexture>
+    }
+
+    /**
+     * Insert a glyph into the atlas.
+     * @param {number} hash - UInt32 hash of the glyph.
+     * @param {Float32Array} glyph_data - Flattened glyph pixel data (single channel).
+     * @param {THREE.Vector4} uv_pos - UV coordinates of the glyph in the atlas.
+     * @param {THREE.Vector2} origin - origins for each character by rotating each character around the common origin.
+     * @param {THREE.Vector2} width - with of the glyph boundingbox
+     * @param {THREE.Vector2} minimum - minimum of the glyph boundingbox
+     */
+    insert_glyph(hash, glyph_data, uv_pos, origin, width, minimum) {
+        console.log("Insert glyph", hash);
+        this.glyph_data.set(hash, [uv_pos, origin, width, minimum]);
+
+        const [px_start, px_width] = uv_to_pixel_bounds(
+            uv_pos,
+            this.width,
+            this.height
+        );
+
+        for (let col = 0; col < px_width.y; col++) {
+            for (let row = 0; row < px_width.x; row++) {
+                // Column-major indexing
+                const glyph_index = col * px_width.x + row;
+                const atlas_index =
+                    (px_start.y + col) * this.height + (px_start.x + row);
+                this.data[atlas_index] = glyph_data.array[glyph_index];
+            }
+        }
+    }
+
+    /**
+     * Get glyph metadata from the atlas.
+     * @param {number} hash - UInt32 hash of the glyph.
+     * @returns {{ uv: THREE.Vector4, offset: THREE.Vector2 } | null}
+     */
+    get_glyph_data(hash, scale, offset) {
+        const [uv_offset_width, origin, width, mini] = this.glyph_data.get(
+            hash.toString()
+        );
+        const pad = this.glyph_padding / this.pix_per_glyph;
+        const scaled_pad = scale.clone().multiplyScalar(2 * pad);
+        const scales = width.clone().add(scaled_pad);
+
+        const char_offsets = new THREE.Vector2(origin.x, origin.y).add(offset);
+
+        const quad_offsets = mini
+            .clone()
+            .sub(scale.clone().multiplyScalar(pad));
+
+        return [uv_offset_width, scales, char_offsets, quad_offsets];
+    }
+
+    /**
+     * Get or create a THREE.DataTexture for the given renderer.
+     * @param {THREE.WebGLRenderer} renderer
+     * @returns {THREE.DataTexture}
+     */
+    get_texture(renderer) {
+        console.log("Creating texture");
+        if (this.textures.has(renderer)) {
+            return this.textures.get(renderer);
+        }
+
+        const texture = new THREE.DataTexture(
+            this.data,
+            this.width,
+            this.height,
+            THREE.RedFormat,
+            THREE.FloatType
+        );
+        texture.magFilter = THREE.NearestFilter;
+        texture.minFilter = THREE.NearestFilter;
+        texture.wrapS = THREE.ClampToEdgeWrapping;
+        texture.wrapT = THREE.ClampToEdgeWrapping;
+        this.textures.set(renderer, texture);
+        return texture;
+    }
+
+    /**
+     * Upload a sub-region of the atlas to the GPU.
+     * @private
+     * @param {THREE.WebGLRenderer} renderer
+     * @param {THREE.DataTexture} texture
+     * @param {number} start_x - X pixel coordinate in the atlas.
+     * @param {number} start_y - Y pixel coordinate in the atlas.
+     * @param {number} width - Width of the updated region in pixels.
+     * @param {number} height - Height of the updated region in pixels.
+     * @param {Float32Array} glyph_data - Flattened glyph pixel data to upload.
+     */
+    upload_tex_data(scene) {
+        const { tex_atlas } = scene.screen;
+        tex_atlas.notify(this.data);
+        console.log("Uploading texture data");
+        // Update all GPU textures
+        for (const [renderer, texture] of this.textures.entries()) {
+            console.log(texture);
+            if (!texture.image) {
+                this.textures.delete(renderer);
+                continue;
+            }
+            texture.image.data.set(this.data);
+            texture.needsUpdate = true;
+        }
+    }
+}
+
+const TEXTURE_ATLAS = [];
+
+export function get_texture_atlas() {
+    if (TEXTURE_ATLAS.length === 0) {
+        const atlas = new TextureAtlas(2048, 64, 12);
+        TEXTURE_ATLAS.push(atlas);
+    }
+    return TEXTURE_ATLAS[0];
+}

--- a/WGLMakie/src/WGLMakie.jl
+++ b/WGLMakie/src/WGLMakie.jl
@@ -68,21 +68,11 @@ function activate!(; inline::Union{Automatic,Bool}=LAST_INLINE[], screen_config.
     return
 end
 
-const TEXTURE_ATLAS = Observable(Float32[])
-
-wgl_texture_atlas() = Makie.get_texture_atlas(1024, 32)
+wgl_texture_atlas() = Makie.get_texture_atlas(2048, 64)
 
 function __init__()
     # Activate WGLMakie as backend!
     activate!()
-    # We need to update the texture atlas whenever it changes!
-    # We do this in three_plot!
-    atlas = wgl_texture_atlas()
-    TEXTURE_ATLAS[] = convert(Vector{Float32}, vec(atlas.data))
-    Makie.font_render_callback!(atlas) do sd, uv
-        TEXTURE_ATLAS[] = convert(Vector{Float32}, vec(atlas.data))
-        return
-    end
     DISABLE_JS_FINALZING[] = false
     return
 end

--- a/WGLMakie/src/imagelike.jl
+++ b/WGLMakie/src/imagelike.jl
@@ -51,7 +51,7 @@ function create_shader(mscene::Scene, plot::Surface)
         end
     end
 
-    return draw_mesh(mscene, per_vertex, plot, uniforms)
+    return draw_mesh(mscene, per_vertex, plot, uniforms), nothing
 end
 
 function create_shader(mscene::Scene, plot::Union{Heatmap, Image})
@@ -83,7 +83,7 @@ function create_shader(mscene::Scene, plot::Union{Heatmap, Image})
         uniforms[:uv_transform] = Observable(Mat3f(0,1,0, -1,0,0, 1,0,1))
     end
 
-    return draw_mesh(mscene, mesh, plot, uniforms)
+    return draw_mesh(mscene, mesh, plot, uniforms), nothing
 end
 
 function create_shader(mscene::Scene, plot::Volume)
@@ -129,7 +129,7 @@ function create_shader(mscene::Scene, plot::Volume)
     )
 
     handle_color!(plot, uniforms, nothing, :volumedata; permute_tex=false)
-    return Program(WebGL(), lasset("volume.vert"), lasset("volume.frag"), box, uniforms)
+    return Program(WebGL(), lasset("volume.vert"), lasset("volume.frag"), box, uniforms), nothing
 end
 
 

--- a/WGLMakie/src/meshes.jl
+++ b/WGLMakie/src/meshes.jl
@@ -152,5 +152,5 @@ function create_shader(scene::Scene, plot::Makie.Mesh)
     attributes[:faces] = faces
     attributes[:positions] = positions
 
-    return draw_mesh(scene, attributes, plot, uniforms; permute_tex=false)
+    return draw_mesh(scene, attributes, plot, uniforms; permute_tex=false), nothing
 end

--- a/WGLMakie/src/precompiles.jl
+++ b/WGLMakie/src/precompiles.jl
@@ -32,8 +32,6 @@ let
         shared_precompile = joinpath(base_path, "shared-precompile.jl")
         include(shared_precompile)
         Makie.CURRENT_FIGURE[] = nothing
-        Observables.clear(TEXTURE_ATLAS)
-        TEXTURE_ATLAS[] = Float32[]
         # This should happen in atexit in Bonito, but on Julia versions below v1.11
         # atexit isn't called
         for (task, (task, close_ref)) in Bonito.SERVER_CLEANUP_TASKS

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -324,8 +324,11 @@ end
 
 # TODO: lines overwrites this
 function serialize_three(scene::Scene, @nospecialize(plot::AbstractPlot))
-    program = create_shader(scene, plot)
+    program, additional = create_shader(scene, plot)
     mesh = serialize_three(plot, program)
+    if additional !== nothing
+        merge!(mesh, additional)
+    end
     mesh[:name] = string(Makie.plotkey(plot)) * "-" * string(objectid(plot))
     mesh[:visible] = plot.visible
     mesh[:uuid] = js_uuid(plot)

--- a/WGLMakie/src/voxel.jl
+++ b/WGLMakie/src/voxel.jl
@@ -107,7 +107,7 @@ function create_shader(scene::Scene, plot::Makie.Voxels)
     notify(plot.gap)
 
     instance = GeometryBasics.mesh(Rect2(0f0, 0f0, 1f0, 1f0))
-
-    return InstancedProgram(WebGL(), lasset("voxel.vert"), lasset("voxel.frag"),
+    program = InstancedProgram(WebGL(), lasset("voxel.vert"), lasset("voxel.frag"),
                         instance, VertexArray(dummy = dummy_data), uniform_dict)
+    return program, nothing
 end

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -204,7 +204,6 @@ edisplay = Bonito.use_electron_display(devtools=true)
         session_size = Base.summarysize(session) / 10^6
         texture_atlas_size = Base.summarysize(WGLMakie.TEXTURE_ATLAS) / 10^6
 
-        @test length(WGLMakie.TEXTURE_ATLAS.listeners) == 1 # Only one from permanent Retain
         @test length(session.session_objects) == 1 # Also texture atlas because of Retain
         @testset "Session fields empty" for field in [:on_document_load, :stylesheets, :imports, :message_queue, :deregister_callbacks, :inbox]
             @test isempty(getfield(session, field))
@@ -215,8 +214,6 @@ edisplay = Bonito.use_electron_display(devtools=true)
         @test length(server.routes.table) == 2
         @test server.routes.table[1][1] == "/browser-display"
         @test server.routes.table[2][2] isa HTTPAssetServer
-        @show typeof.(last.(WGLMakie.TEXTURE_ATLAS.listeners))
-        @show length(WGLMakie.TEXTURE_ATLAS.listeners)
         @show session_size texture_atlas_size
 
         # TODO, this went up from 6 to 11mb, likely because of a session not getting freed
@@ -230,7 +227,6 @@ edisplay = Bonito.use_electron_display(devtools=true)
         js_objects = run(edisplay.window, "Bonito.Sessions.GLOBAL_OBJECT_CACHE")
         # @test Set([app.session[].id, app.session[].parent.id]) == keys(js_sessions)
         # we used Retain for global_obs, so it should stay as long as root session is open
-        @test keys(js_objects) == Set([WGLMakie.TEXTURE_ATLAS.id])
     end
 
 end

--- a/src/utilities/texture_atlas.jl
+++ b/src/utilities/texture_atlas.jl
@@ -309,6 +309,34 @@ function insert_glyph!(atlas::TextureAtlas, hash::UInt32, path_or_glyp::Union{Be
     end
 end
 
+
+function sdf_uv_to_pixel(atlas::TextureAtlas, uv_width::Vec4f)
+    tex_size = Vec2f(size(atlas.data)) # (width, height)
+    # uv: (left, bottom, right, top)
+    uv_left_bottom = Vec2f(uv_width[1], uv_width[2])
+    uv_right_top = Vec2f(uv_width[3], uv_width[4])
+
+    # reverse the normalization to get pixel coordinates
+    px_left_bottom = floor.(Int, uv_left_bottom .* tex_size .- 0.5)
+    px_right_top = ceil.(Int, uv_right_top .* tex_size .+ 0.5)
+
+    # create pixel ranges
+    x_range = (px_left_bottom[1] + 1):(px_right_top[1])
+    y_range = (px_left_bottom[2] + 1):(px_right_top[2])
+    return x_range, y_range
+end
+
+function get_glyph_data(atlas::TextureAtlas, hash::UInt32)
+    index = atlas.mapping[hash]
+    uv = atlas.uv_rectangles[index]
+    # create pixel ranges
+    x_range, y_range = sdf_uv_to_pixel(atlas, uv)
+    @show x_range y_range
+    # slice the data
+    return atlas.data[x_range, y_range]
+end
+
+
 """
     sdistancefield(img, downsample, pad)
 Calculates a distance fields, that is downsampled `downsample` time,

--- a/test/texture_atlas.jl
+++ b/test/texture_atlas.jl
@@ -1,0 +1,24 @@
+using Makie
+using Makie.FreeTypeAbstraction
+
+
+atlas = Makie.get_texture_atlas()
+
+rendered = []
+Makie.font_render_callback!(atlas) do sd, uv
+    push!(rendered, (sd, uv))
+end
+
+font = Makie.to_font("default")
+glyph = 'π'
+glyphindex = FreeTypeAbstraction.glyph_index(font, glyph)
+h = Makie.fast_stable_hash((glyphindex, FreeTypeAbstraction.fontname(font)))
+x = Makie.insert_glyph!(atlas, h, (glyphindex, font))
+rendered
+
+uvoff = atlas.uv_rectangles[atlas.mapping[h]]
+ranges = Makie.sdf_uv_to_pixel(atlas, uvoff)
+rect = rendered[1][2]
+data = rendered[1][1]
+Makie.get_glyph_data(atlas, h) ≈ data
+Base.to_indices(atlas.data, (rect,)) == ranges


### PR DESCRIPTION
Since we've been running into texture atlas size problems on CI and for users, and for https://github.com/MakieOrg/Makie.jl/pull/4630, it would be great to use the same texture atlas between GL and WGLMakie. I decided to make this refactor in a separate pr against master, to help with the next release and the CI hangs.

Another motivation is, that I suspect the former way of updating the texture atlas to be a bit racy, which may explain the CI time outs when adding new tests, which mutate the texture atlas.
Hopefully fixes: https://github.com/MakieOrg/Makie.jl/pull/4938
Status:
Most of the logic is in place, but there are still small problems in the size calculations on the JS side:
![image](https://github.com/user-attachments/assets/54d15d78-033d-4aa7-93ec-97bdcb0ff20f)
I also need to update the logic for scatter plots using the texture atlas.

This should send _much_ less data to JS when updating text, which should make zooming etc smoother for WGLMakie.