### PR TITLE
Add `direction = :y` attribute for vertical bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed issue with UInt8 voxel data not updating correctly when Observable input is updated [#4914](https://github.com/MakieOrg/Makie.jl/pull/4914)
 - Added ticks and minorticks to `PolarAxis`. Ticks and tick labels can now also be mirrored to the other side of a sector style PolarAxis. [#4902](https://github.com/MakieOrg/Makie.jl/pull/4902)
 - Fixed `Axis.panbutton` not working [#4932](https://github.com/MakieOrg/Makie.jl/pull/4932)
+- Added `direction = :y` option for vertical `band`s [#4949](https://github.com/MakieOrg/Makie.jl/pull/4949).
 
 ## [0.22.4] - 2025-04-11
 

--- a/CairoMakie/src/overrides.jl
+++ b/CairoMakie/src/overrides.jl
@@ -264,8 +264,10 @@ function draw_plot(scene::Scene, screen::Screen,
         model = band.model[]
         space = band.space[]
 
-        upperpoints = band[1][]
-        lowerpoints = band[2][]
+        xdir::Bool = band.direction[] === :x
+
+        upperpoints = xdir ? band[1][] : reverse.(band[1][])
+        lowerpoints = xdir ? band[2][] : reverse.(band[2][])
 
         for rng in band_segment_ranges(lowerpoints, upperpoints)
             points = vcat(@view(lowerpoints[rng]), reverse(@view(upperpoints[rng])))

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -168,10 +168,14 @@ end
     X = cumsum(RNG.randn(n, m), dims=2)
     X = X .- X[:, 1]
     μ = vec(mean(X, dims=1)) # mean
-    lines(t, μ)              # plot mean line
+    f, ax, _ = lines(t, μ)              # plot mean line
     σ = vec(std(X, dims=1))  # stddev
-    band!(t, μ + σ, μ - σ)   # plot stddev band
-    current_figure()
+    band!(ax, t, μ + σ, μ - σ)   # plot stddev band
+
+    # vertical version
+    ax2, _ = lines(f[1, 2], μ, t)
+    band!(ax2, t, μ + σ, μ - σ, direction = :y)   # plot stddev band
+    f
 end
 
 @reference_test "Band with NaN" begin

--- a/src/basic_recipes/band.jl
+++ b/src/basic_recipes/band.jl
@@ -96,7 +96,7 @@ end
 
 export fill_between!
 
-function attribute_examples(::Type{Scatter})
+function attribute_examples(::Type{Band})
     Dict(
         :direction => [
             Example(

--- a/src/basic_recipes/band.jl
+++ b/src/basic_recipes/band.jl
@@ -95,3 +95,23 @@ function fill_between!(scenelike, x, y1, y2; where = nothing, kw_args...)
 end
 
 export fill_between!
+
+function attribute_examples(::Type{Scatter})
+    Dict(
+        :direction => [
+            Example(
+                code = """
+                    fig = Figure()
+                    location = range(0, 4pi, length = 200)
+                    lower =   cos.(location) .- location
+                    upper = .-cos.(location) .+ location .+ 5
+                    band(fig[1, 1], location, lower, upper,
+                        axis = (; title = "direction = :x"))
+                    band(fig[1, 2], location, lower, upper, direction = :y,
+                        axis = (; title = "direction = :y"))
+                    fig
+                    """
+            )
+        ],
+    )
+end


### PR DESCRIPTION
# Description

Adds a simpler option for a vertical `band` via `direction = :y`, currently this has to be done by manually constructing two `Point2` arrays which is especially annoying in AlgebraOfGraphics.

```julia
n, m = 100, 101
t = range(0, 1, length=m)
X = cumsum(RNG.randn(n, m), dims=2)
X = X .- X[:, 1]
μ = vec(mean(X, dims=1)) # mean
f, ax, _ = lines(t, μ)              # plot mean line
σ = vec(std(X, dims=1))  # stddev
band!(ax, t, μ + σ, μ - σ)   # plot stddev band

# vertical version
ax2, _ = lines(f[1, 2], μ, t)
band!(ax2, t, μ + σ, μ - σ, direction = :y)   # plot stddev band
f
```

<img width="550" alt="image" src="https://github.com/user-attachments/assets/09a91ed6-f321-4d17-8951-0a8d2c617de8" />


## Type of change

Delete options that do not apply:

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
