### PR TITLE
fix line iteration order in `convert_arguments(::Lines, ::Rect3)` (fix #4953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added ticks and minorticks to `PolarAxis`. Ticks and tick labels can now also be mirrored to the other side of a sector style PolarAxis. [#4902](https://github.com/MakieOrg/Makie.jl/pull/4902)
 - Fixed `Axis.panbutton` not working [#4932](https://github.com/MakieOrg/Makie.jl/pull/4932)
 - Added `direction = :y` option for vertical `band`s [#4949](https://github.com/MakieOrg/Makie.jl/pull/4949).
+- Fixed line-ordering of `lines(::Rect3)` [#4954](https://github.com/MakieOrg/Makie.jl/pull/4954).
 
 ## [0.22.4] - 2025-04-11
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -195,7 +195,7 @@ function convert_arguments(::Type{<: Lines}, rect::Rect3{T}) where {T}
     PT = Point3{float_type(T)}
     points = decompose(PT, rect)
     push!(points, PT(NaN)) # use to separate linesegments
-    return (points[[1, 2, 3, 4, 1, 5, 6, 2, 9, 6, 8, 3, 9, 5, 7, 4, 9, 7, 8]],)
+    return (points[[1, 3, 4, 2, 1, 5, 6, 2, 9, 6, 8, 7, 5, 9, 8, 4, 9, 7, 3]],)
 end
 """
 

--- a/test/conversions/convert_arguments.jl
+++ b/test/conversions/convert_arguments.jl
@@ -520,4 +520,11 @@ end
         @test nan_equal(convert_arguments(PointBased(), ls2)[1], ps12)
         @test nan_equal(convert_arguments(PointBased(), ls3)[1], ps3)
     end
+
+    @testset "Lines" begin
+        r = Rect3f(0,0,0,1,1,1)
+        ps = Point3f[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [NaN, NaN, NaN]]
+        ps = ps[[1, 3, 4, 2, 1, 5, 6, 2, 9, 6, 8, 7, 5, 9, 8, 4, 9, 7, 3]]
+        @test nan_equal(convert_arguments(Lines, r)[1], ps)
+    end
 end


### PR DESCRIPTION
This is explicitly tied to the way `decompose` (in turn, `coordinates`) iterates the vertices of a `Rect`. For `Rect(0,0,0,1,1,1)` this is:
```
julia> Makie.GeometryBasics.coordinates(r)
8-element Vector{Point{3, Int64}}:
 [0, 0, 0]
 [0, 0, 1]
 [0, 1, 0]
 [0, 1, 1]
 [1, 0, 0]
 [1, 0, 1]
 [1, 1, 0]
 [1, 1, 1]
```

Based on this ordering, one correcting pathing choice for the boundaries is: `[1, 3, 4, 2, 1, 5, 6, 2, 9, 6, 8, 7, 5, 9, 8, 4, 9, 7, 3]`, with the `9`th index indicating a `NaN`-break.

As we discussed on Slack, there's probably a better fix out there that doesn't explicitly depend on the iteration order of coordinates from GeometryBasics - but this is better than leaving it as-is.

Closes #4953 