### PR TITLE
scene/camera compute graph

### DIFF
--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -509,7 +509,7 @@ function add_inputs!(conversion_func, attr::ComputeGraph; kw...)
     return attr
 end
 
-compute_identity(inputs, changed, cached) = getindex.(values(inputs))
+compute_identity(inputs, changed, cached) = values(inputs)
 
 # TODO: These functions place the given Computed node into the graph. This
 #       typically results in `key != node.name`, which invites errors

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -486,7 +486,6 @@ function _add_input!(func, attr::ComputeGraph, key::Symbol, value)
     @assert !(value isa Computed)
     if haskey(attr.inputs, key) || haskey(attr.outputs, key)
         error("Cannot attach input with name $key - already exists!")
-        return
     end
 
     output = Computed(key, RefValue{Any}())
@@ -496,13 +495,14 @@ function _add_input!(func, attr::ComputeGraph, key::Symbol, value)
     # Needs to be Any, since input can change type
     attr.inputs[key] = input
     attr.outputs[key] = output
-    return
+    return attr
 end
 
 function add_inputs!(conversion_func, attr::ComputeGraph; kw...)
     for (k, v) in pairs(kw)
         add_input!(conversion_func, attr, k, v)
     end
+    return attr
 end
 
 compute_identity(inputs, changed, cached) = getindex.(values(inputs))
@@ -529,7 +529,7 @@ function add_input!(attr::ComputeGraph, key::Symbol, value::Computed)
     # 2. output does not exist (or is already what we want to create)
     # which are given here
     unsafe_register!(compute_identity, attr, [value], (key,))
-    return
+    return attr
 end
 
 # for recipe -> primitive (mostly)
@@ -538,7 +538,7 @@ function add_input!(conversion_func, attr::ComputeGraph, key::Symbol, value::Com
         error("Cannot attach throughput with name $key - already exists!")
     end
     unsafe_register!(InputFunctionWrapper(key, conversion_func), attr, [value], (key,))
-    return
+    return attr
 end
 
 """
@@ -560,7 +560,7 @@ function add_input!(attr::ComputeGraph, k::Symbol, obs::Observable)
         setproperty!(attr, k, new_val)
         return Consume(false)
     end
-    return
+    return attr
 end
 
 function add_input!(f, attr::ComputeGraph, k::Symbol, obs::Observable)
@@ -569,7 +569,7 @@ function add_input!(f, attr::ComputeGraph, k::Symbol, obs::Observable)
         setproperty!(attr, k, new_val)
         return Consume(false)
     end
-    return
+    return attr
 end
 
 get_callback(computed::Computed) = hasparent(computed) ? computed.parent.callback : nothing

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -290,6 +290,7 @@ end
 
 """
     update!(graph; kwargs...)
+    update!(graph, pairs::Pair{Symbol, Any}...)
 
 Updates any number of inputs in the graph based on the passed `key = value`
 keyword arguments. The `key` refers to the name of the input and the `value` is
@@ -301,10 +302,13 @@ the new value.
 graph = ComputeGraph()
 add_input!(graph, :first_node, 1)
 update!(graph, first_node = 2)
+update!(graph, :first_node => 2)
 ```
 """
-function update!(attr::ComputeGraph; kwargs...)
-    for (key, value) in pairs(kwargs)
+update!(attr::ComputeGraph; kwargs...) = update!(attr, kwargs...)
+
+function update!(attr::ComputeGraph, pairs...)
+    for (key, value) in pairs
         if haskey(attr.inputs, key)
             _setproperty!(attr, key, value)
         else

--- a/GLMakie/assets/shader/dots.vert
+++ b/GLMakie/assets/shader/dots.vert
@@ -65,14 +65,14 @@ void main(){
     process_clip_planes(world_position.xyz);
     vec4 clip_pos = projectionview * world_position;
     if (markerspace == PIXEL_SPACE) {
-        clip_pos += vec4(2.0 * px_per_unit * marker_offset / vec3(resolution, 1), 0);
+        clip_pos += vec4(2.0 * marker_offset / vec3(resolution, 1), 0);
         gl_PointSize = px_per_unit * scale.x;
     } else {
         // to have a billboard, we project the upvector
         vec3 scale_vec = upvector * f32c_scale.y * scale.x;
         vec4 up_clip = projectionview * vec4(world_position.xyz + scale_vec, 1);
         float yup = abs(up_clip.y - clip_pos.y) / clip_pos.w;
-        gl_PointSize = ceil(0.5 * yup *  resolution.y);
+        gl_PointSize = ceil(0.5 * yup *  px_per_unit * resolution.y);
         clip_pos += projectionview * vec4(f32c_scale * marker_offset, 0);
     }
     gl_Position = vec4(clip_pos.xy, clip_pos.z + (clip_pos.w * depth_shift), clip_pos.w);

--- a/GLMakie/assets/shader/line_segment.geom
+++ b/GLMakie/assets/shader/line_segment.geom
@@ -9,6 +9,7 @@ layout(lines) in;
 layout(triangle_strip, max_vertices = 4) out;
 
 uniform vec2 resolution;
+uniform float px_per_unit;
 uniform float pattern_length;
 {{pattern_type}} pattern;
 uniform int linecap;
@@ -57,9 +58,9 @@ bool process_clip_planes(inout vec4 p1, inout vec4 p2)
             p2 = p1;
             return true;
         }
-        
+
         // one outside - shorten segment
-        else if (d1 < 0.0) 
+        else if (d1 < 0.0)
         {
             // solve 0 = m * t + b = (d2 - d1) * t + d1 with t in (0, 1)
             p1       = p1       - d1 * (p2 - p1)             / (d2 - d1);
@@ -77,7 +78,7 @@ bool process_clip_planes(inout vec4 p1, inout vec4 p2)
 
 
 vec3 screen_space(vec4 vertex) {
-    return vec3((0.5 * vertex.xy / vertex.w + 0.5) * resolution, vertex.z / vertex.w);
+    return vec3((0.5 * vertex.xy / vertex.w + 0.5) * px_per_unit * resolution, vertex.z / vertex.w);
 }
 
 vec2 normal_vector(in vec2 v) { return vec2(-v.y, v.x); }
@@ -107,13 +108,13 @@ void main(void)
         if (process_clip_planes(_p1, _p2))
             return;
 
-        // remaining world -> clip projection 
+        // remaining world -> clip projection
         _p1 = projectionview * _p1;
         _p2 = projectionview * _p2;
 
         _p1.z += _p1.w * depth_shift;
         _p2.z += _p2.w * depth_shift;
-        
+
         // Handle near/far clip planes
         vec4 v1 = _p2 - _p1;
 
@@ -168,7 +169,7 @@ void main(void)
             // Get offset in y direction & compute vertex position
             float n_offset = (2 * y - 1) * (halfwidth + AA_THICKNESS);
             vec3 position = vec3[2](p1, p2)[x] + v_offset * v1 + n_offset * vec3(n1, 0);
-            gl_Position = vec4(2.0 * position.xy / resolution - 1.0, position.z, 1.0);
+            gl_Position = vec4(2.0 * position.xy / (px_per_unit * resolution) - 1.0, position.z, 1.0);
 
             // Generate SDF's
 

--- a/GLMakie/assets/shader/sprites.geom
+++ b/GLMakie/assets/shader/sprites.geom
@@ -38,6 +38,7 @@ uniform float stroke_width;
 uniform float glow_width;
 uniform int shape; // for RECTANGLE hack below
 uniform vec2 resolution;
+uniform float px_per_unit;
 uniform float depth_shift;
 uniform mat4 preprojection, projection, view, model;
 uniform int num_clip_planes;
@@ -167,7 +168,7 @@ void main(void)
                              0.0,         1.0/vclip.w, 0.0,         0.0,
                              0.0,         0.0,         1.0/vclip.w, 0.0,
                              -vclip.xyz/(vclip.w*vclip.w),          0.0);
-    mat2 dxyv_dxys = diagm(0.5*resolution) * mat2(d_ndc_d_clip*trans);
+    mat2 dxyv_dxys = diagm(0.5 * px_per_unit * resolution) * mat2(d_ndc_d_clip*trans);
     // Now, our buffer size is expressed in viewport pixels but we get back to
     // the sprite coordinate system using the scale factor of the
     // transformation (for isotropic transformations). For anisotropic

--- a/GLMakie/src/glshaders/image_like.jl
+++ b/GLMakie/src/glshaders/image_like.jl
@@ -49,6 +49,7 @@ function draw_heatmap(screen, data::Dict)
             )
         )
         fxaa = false
+        px_per_unit = 1f0
     end
     return assemble_shader(data)
 end
@@ -73,6 +74,7 @@ function draw_volume(screen, main::VolumeTypes, data::Dict)
         backlight = 1f0
         enable_depth = true
         transparency = false
+        px_per_unit = 1f0
         shader = GLVisualizeShader(
             screen,
             "volume.vert",

--- a/GLMakie/src/glshaders/lines.jl
+++ b/GLMakie/src/glshaders/lines.jl
@@ -62,6 +62,7 @@ function draw_lines(screen, position::Union{VectorTypes{T}, MatTypes{T}}, data::
         lastlen             = Float32[] => GLBuffer
         pattern_length      = 1f0 # we divide by pattern_length a lot.
         debug               = false
+        px_per_unit = 1f0
     end
     return assemble_shader(data)
 end
@@ -94,6 +95,7 @@ function draw_linesegments(screen, positions::VectorTypes{T}, data::Dict) where 
         gl_primitive        = GL_LINES
         pattern_length      = 1f0
         debug               = false
+        px_per_unit = 1f0
     end
     robj = assemble_shader(data)
     return robj

--- a/GLMakie/src/glshaders/mesh.jl
+++ b/GLMakie/src/glshaders/mesh.jl
@@ -51,6 +51,7 @@ function draw_mesh(screen, data::Dict)
         texturecoordinates = Vec2f(0) => GLBuffer
         uv_transform = Mat{2,3,Float32}(1, 0, 0, -1, 0, 1)
         transparency = false
+        px_per_unit = 1f0
         interpolate_in_fragment_shader = true
         shader = GLVisualizeShader(
             screen,

--- a/GLMakie/src/glshaders/particles.jl
+++ b/GLMakie/src/glshaders/particles.jl
@@ -124,6 +124,7 @@ function draw_mesh_particle(screen, p, data)
 
         instances = const_lift(length, position)
         transparency = false
+        px_per_unit = 1f0
         shader = GLVisualizeShader(
             screen,
             "util.vert", "particles.vert",
@@ -160,6 +161,7 @@ function draw_pixel_scatter(screen, position::VectorTypes, data::Dict)
         scale        = 2f0
         f32c_scale   = Vec3f(1)
         transparency = false
+        px_per_unit = 1f0
         shader       = GLVisualizeShader(
             screen,
             "fragment_output.frag", "dots.vert", "dots.frag",
@@ -271,6 +273,7 @@ function draw_scatter(screen, (marker, position), data)
         billboard        = rotation == Vec4f(0,0,0,1) => "if `billboard` == true, particles will always face camera"
         fxaa             = false
         transparency     = false
+        px_per_unit = 1f0
         shader           = GLVisualizeShader(
             screen,
             "fragment_output.frag", "util.vert", "sprites.geom",

--- a/GLMakie/src/glshaders/surface.jl
+++ b/GLMakie/src/glshaders/surface.jl
@@ -64,6 +64,7 @@ function draw_surface(screen, main, data::Dict)
         uv_transform = Mat{2,3,Float32}(1, 0, 0, -1, 0, 1)
         instances = const_lift(x->(size(x,1)-1) * (size(x,2)-1), main) => "number of planes used to render the surface"
         transparency = false
+        px_per_unit = 1f0
         shader = GLVisualizeShader(
             screen,
             "util.vert", "surface.vert",

--- a/GLMakie/src/glshaders/voxel.jl
+++ b/GLMakie/src/glshaders/voxel.jl
@@ -17,6 +17,7 @@ function draw_voxels(screen, main::VolumeTypes, data::Dict)
         color = nothing => Texture
         color_map = nothing => Texture
         uv_transform = nothing => Texture
+        px_per_unit = 1f0
         shader = GLVisualizeShader(
             screen,
             "voxel.vert",

--- a/GLMakie/src/rendering.jl
+++ b/GLMakie/src/rendering.jl
@@ -129,6 +129,7 @@ function GLAbstraction.render(filter_elem_func, screen::Screen)
             ppu = screen.px_per_unit[]
             a = viewport(scene)[]
             glViewport(round.(Int, ppu .* minimum(a))..., round.(Int, ppu .* widths(a))...)
+            elem[:px_per_unit] = ppu
             render(elem)
         end
     catch e

--- a/WGLMakie/src/new-scatter.jl
+++ b/WGLMakie/src/new-scatter.jl
@@ -660,7 +660,6 @@ using Makie.ComputePipeline
 function serialize_three(scene::Scene, plot::Union{Lines, LineSegments})
     attr = plot.args[1]
 
-    Makie.add_computation!(attr, scene, :scene_origin)
     Makie.add_computation!(attr, :uniform_pattern, :uniform_pattern_length)
     backend_colors!(attr)
 

--- a/src/Makie.jl
+++ b/src/Makie.jl
@@ -45,6 +45,7 @@ using OffsetArrays
 using Downloads
 using ShaderAbstractions
 using Dates
+using ComputePipeline
 
 import Unitful
 import UnicodeFun

--- a/src/backend-functionality.jl
+++ b/src/backend-functionality.jl
@@ -6,21 +6,6 @@ add_computation!(attr::ComputeGraph, scene::Scene, symbols::Symbol...) =
 
 add_computation!(attr::ComputeGraph, symbols::Symbol...) = add_computation!(attr, Val.(symbols)...)
 
-# TODO: px_per_unit?
-function add_computation!(attr, scene, ::Val{:scene_origin})
-    # # TODO: avoid calling this multiple times?
-    # haskey(attr, :viewport) || add_input!(attr, :viewport, scene.viewport[])
-    # register_computation!(attr, [:viewport], [:scene_origin]) do (viewport,), changed, last
-    #     !changed[1] && return nothing
-    #     new_val = Vec2f(origin(viewport))
-    #     if !isnothing(last) && last[1] == new_val
-    #         return nothing
-    #     else
-    #         return (new_val,)
-    #     end
-    # end
-end
-
 function add_computation!(attr, ::Val{:gl_miter_limit})
     register_computation!(attr, [:miter_limit], [:gl_miter_limit]) do (miter,), changed, output
         return (Float32(cos(pi - miter)),)
@@ -257,9 +242,6 @@ end
 # optionally converts uv_transform to the one used with patterns
 # WGLMakie should call this with target_mat3 = true
 function add_computation!(attr, scene, ::Val{:pattern_uv_transform}; modelname = :model_f32c, colorname = :color, target_mat3 = false)
-    # haskey(attr, :projectionview) || add_input!(attr, :projectionview, camera(scene).projectionview)
-    # haskey(attr, :viewport) || add_input!(attr, :viewport, viewport(scene))
-
     register_computation!(attr,
         [:uv_transform, :projectionview, :viewport, modelname, colorname, :fetch_pixel],
         [:pattern_uv_transform]) do (uvt, pv, vp, model, pattern, is_pattern), changed, cached

--- a/src/backend-functionality.jl
+++ b/src/backend-functionality.jl
@@ -8,17 +8,17 @@ add_computation!(attr::ComputeGraph, symbols::Symbol...) = add_computation!(attr
 
 # TODO: px_per_unit?
 function add_computation!(attr, scene, ::Val{:scene_origin})
-    # TODO: avoid calling this multiple times?
-    haskey(attr, :viewport) || add_input!(attr, :viewport, scene.viewport[])
-    register_computation!(attr, [:viewport], [:scene_origin]) do (viewport,), changed, last
-        !changed[1] && return nothing
-        new_val = Vec2f(origin(viewport))
-        if !isnothing(last) && last[1] == new_val
-            return nothing
-        else
-            return (new_val,)
-        end
-    end
+    # # TODO: avoid calling this multiple times?
+    # haskey(attr, :viewport) || add_input!(attr, :viewport, scene.viewport[])
+    # register_computation!(attr, [:viewport], [:scene_origin]) do (viewport,), changed, last
+    #     !changed[1] && return nothing
+    #     new_val = Vec2f(origin(viewport))
+    #     if !isnothing(last) && last[1] == new_val
+    #         return nothing
+    #     else
+    #         return (new_val,)
+    #     end
+    # end
 end
 
 function add_computation!(attr, ::Val{:gl_miter_limit})
@@ -257,8 +257,8 @@ end
 # optionally converts uv_transform to the one used with patterns
 # WGLMakie should call this with target_mat3 = true
 function add_computation!(attr, scene, ::Val{:pattern_uv_transform}; modelname = :model_f32c, colorname = :color, target_mat3 = false)
-    haskey(attr, :projectionview) || add_input!(attr, :projectionview, camera(scene).projectionview)
-    haskey(attr, :viewport) || add_input!(attr, :viewport, viewport(scene))
+    # haskey(attr, :projectionview) || add_input!(attr, :projectionview, camera(scene).projectionview)
+    # haskey(attr, :viewport) || add_input!(attr, :viewport, viewport(scene))
 
     register_computation!(attr,
         [:uv_transform, :projectionview, :viewport, modelname, colorname, :fetch_pixel],

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -145,10 +145,6 @@ function add_camera_computation!(graph::ComputeGraph, scene)
         on(x -> update!(graph, key => x), scene, getproperty(scene.camera, key), update = true)
     end
 
-    # TODO: Should we have px_per_unit + ppu_resolution in here? A float * Vec2d
-    # isn't much to calculate so maybe not?
-    # TODO: Consider discarding updates if they match cached (like in backend_functionality)
-    # Note that this needs to exist without ppu too
     register_computation!(graph, [:viewport], [:scene_origin, :resolution]) do (viewport,), changed, cached
         return (Vec2d(origin(viewport)), Vec2d(widths(viewport)),)
     end

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -140,9 +140,9 @@ function add_camera_computation!(graph::ComputeGraph, scene)
     end
 
     # TODO: Should we move viewport to the graph entirely?
-    on(viewport -> update!(graph, viewport = viewport), scene, scene.viewport)
+    on(viewport -> update!(graph, viewport = viewport), scene, scene.viewport, update = true)
     for key in [:view, :projection, :eyeposition, :upvector, :view_direction]
-        on(x -> update!(graph, key => x), scene, getproperty(scene.camera, key))
+        on(x -> update!(graph, key => x), scene, getproperty(scene.camera, key), update = true)
     end
 
     # TODO: Should we have px_per_unit + ppu_resolution in here? A float * Vec2d

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -135,6 +135,9 @@ function add_camera_computation!(graph::ComputeGraph, scene)
     add_input!(graph, :view, Mat4d(I))
     add_input!(graph, :projection, Mat4d(I))
     add_input!(graph, :viewport, Rect2d(0,0,0,0))
+    for key in [:eyeposition, :upvector, :view_direction]
+        add_input!(graph, key, Vec3d(0))
+    end
 
     # TODO: Should we move viewport to the graph entirely?
     on(viewport -> update!(graph, viewport = viewport), scene, scene.viewport)

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -270,6 +270,9 @@ end
 function (cb::CameraMatrixCallback)(inputs, changed, cached)
     graph = cb.graph
     space = inputs.space
+    # TODO: more fine grained updates?
+    # e.g. log if space related matrices or markerspace related matrices need
+    # update in camera_trigger and only update those?
     if haskey(inputs, :markerspace)
         markerspace = inputs.markerspace
         # TODO: breaks FastPixel?

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -137,7 +137,10 @@ function add_camera_computation!(graph::ComputeGraph, scene)
     add_input!(graph, :viewport, Rect2d(0,0,0,0))
 
     # TODO: Should we move viewport to the graph entirely?
-    on(viewport -> update!(graph, :viewport = viewport), scene, scene.viewport)
+    on(viewport -> update!(graph, viewport = viewport), scene, scene.viewport)
+    for key in [:view, :projection, :eyeposition, :upvector, :view_direction]
+        on(x -> update!(graph, key => x), scene, getproperty(scene.camera, key))
+    end
 
     # TODO: Should we have px_per_unit + ppu_resolution in here? A float * Vec2d
     # isn't much to calculate so maybe not?
@@ -280,8 +283,10 @@ function register_camera!(plot_graph::ComputeGraph, scene_graph::ComputeGraph)
 
     # Do we need those? Maybe also viewport?
     add_input!(plot_graph, :pixel_space, scene_graph.pixel_to_clip)
-    add_input!(plot_graph, :resolution, scene_graph.resolution)
-    add_input!(plot_graph, :scene_origin, scene_graph.scene_origin)
+    for key in [:resolution, :scene_origin, :eyeposition, :upvector, :view_direction]
+        # type assert for safety
+        add_input!(plot_graph, key, getproperty(scene_graph, key)::Computed)
+    end
 
     return
 end

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -1,7 +1,6 @@
 using Base: RefValue
 using LinearAlgebra
 using GeometryBasics
-using ComputePipeline
 
 ################################################################################
 

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -443,6 +443,8 @@ function resolve_shading_default!(attr::ComputeGraph, lights::Vector{<: Abstract
     return
 end
 
+register_camera!(scene::Scene, plot::Plot) = register_camera!(plot.args[1], scene.compute)
+
 function computed_plot!(parent, plot::T) where {T}
     scene = parent_scene(parent)
     add_theme!(plot, scene)
@@ -462,6 +464,8 @@ function computed_plot!(parent, plot::T) where {T}
     on(model -> attr.model = model, plot, plot.transformation.model, update = true)
     on(tf -> update!(attr; transform_func=tf), plot, plot.transformation.transform_func; update=true)
 
+    register_camera!(scene, plot)
+
     resolve_shading_default!(scene, plot.args[1])
 
     push!(parent, plot)
@@ -470,7 +474,6 @@ function computed_plot!(parent, plot::T) where {T}
     if !isnothing(scene) && haskey(attr, :cycle)
         add_cycle_attribute!(plot, scene, get_cycle_for_plottype(attr[:cycle][]))
     end
-
 
     documented_attr = MakieCore.documented_attributes(T).d
     for (k, v) in plot.kw
@@ -482,6 +485,7 @@ function computed_plot!(parent, plot::T) where {T}
             end
         end
     end
+
     return
 end
 

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -91,6 +91,7 @@ mutable struct Scene <: AbstractScene
     lights::Vector{AbstractLight}
     deregister_callbacks::Vector{Observables.ObserverFunction}
     cycler::Cycler
+    compute::ComputeGraph
 
     conversions::DimConversions
     isclosed::Bool
@@ -132,9 +133,11 @@ mutable struct Scene <: AbstractScene
             convert(Vector{AbstractLight}, lights),
             deregister_callbacks,
             Cycler(),
+            ComputeGraph(),
             DimConversions(),
             false
         )
+        add_camera_computation!(scene.compute, scene)
         on(scene, events.window_open) do open
             if !open
                 scene.isclosed = true


### PR DESCRIPTION
# Description

Adds a compute graph to `Scene` which takes care of camera handling with space and markerspace. 

Currently the compute branch caches observables for space1 -> space2 matrices, which creates Problems whenever computations need those matrices. It also forces space and markerspace to be static.

This branch moves camera matrix calculations into a scene compute graph.
This should:
- continue to avoid the redundancy of per-plot matrix generation from master
- allow embedding camera matrices into the plot compute tree for CPU side projections (e.g. lines, CairoMakie)
- make space and markerspace dynamic again
- not introduce redundant updates, e.g. a view matrix update triggering a pixel_to_clip matrix

TODO:
- [x] add scene compute graph
- [x] calculate camera matrices
- [ ] clean up integration (should graph inform Camera?)
- [x] update GLMakie
- [x] update CairoMakie
- [x] update WGLMakie?
- [ ] maybe figure out why markers stretch/squish while resizing in GLMakie (no re-render until done? do we care?)
- [ ] check camera update logic for redundant updates and overengineering

Handling of lights should also be done by this compute graph. But maybe in another pr.