### PR TITLE
Make axis cycling contingent on the PlotFunc only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `Axis.panbutton` not working [#4932](https://github.com/MakieOrg/Makie.jl/pull/4932)
 - Added `direction = :y` option for vertical `band`s [#4949](https://github.com/MakieOrg/Makie.jl/pull/4949).
 - Fixed line-ordering of `lines(::Rect3)` [#4954](https://github.com/MakieOrg/Makie.jl/pull/4954).
+- Fixed cycling not being consistent when the same plot function was called with different input types (float32 vs float64 lines, for example) [#4960](https://github.com/MakieOrg/Makie.jl/pull/4960)
 
 ## [0.22.4] - 2025-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added `alpha` keyword to `density` recipe [#4975](https://github.com/MakieOrg/Makie.jl/pull/4975).
 - Improved CairoMakie rendering of normal `band`s with array-valued colors [#4989](https://github.com/MakieOrg/Makie.jl/pull/4989).
+- Fixed cycling not being consistent when the same plot function was called with different input types (float32 vs float64 lines, for example) [#4960](https://github.com/MakieOrg/Makie.jl/pull/4960)
 
 ## [0.22.5] - 2025-05-12
 
@@ -18,7 +19,6 @@
 - Fixed issues with anisotropic markersizes (e.g. `(10, 50)`) causing anti-aliasing to become blurry in GLMakie and WGLMakie. [#4918](https://github.com/MakieOrg/Makie.jl/pull/4918)
 - Added `direction = :y` option for vertical `band`s [#4949](https://github.com/MakieOrg/Makie.jl/pull/4949).
 - Fixed line-ordering of `lines(::Rect3)` [#4954](https://github.com/MakieOrg/Makie.jl/pull/4954).
-- Fixed cycling not being consistent when the same plot function was called with different input types (float32 vs float64 lines, for example) [#4960](https://github.com/MakieOrg/Makie.jl/pull/4960)
 - Fixed issue with `sprint`ing to SVG using CairoMakie in Julia 1.11 and above [#4971](https://github.com/MakieOrg/Makie.jl/pull/4971).
 
 ## [0.22.4] - 2025-04-11

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -675,7 +675,12 @@ validate_limits_for_scale(lims, scale) = all(x -> x in defined_interval(scale), 
 palettesyms(cycle::Cycle) = [c[2] for c in cycle.cycle]
 attrsyms(cycle::Cycle) = [c[1] for c in cycle.cycle]
 
-function get_cycler_index!(c::Cycler, P::Type)
+function get_cycler_index!(c::Cycler, P::Type{Plot{Func, Args}}) where {Func, Args}
+    # We want to avoid indexing into the cycler by the arguments of the plot, 
+    # since those can change on input type (float32 vs float64, polygon vs multipolygon, etc)
+    # so instead, we re-create the plot type with only the function, not the arguments!
+    P = Plot{Func}
+    # Now we can index into the cycler using this abstract type.
     if !haskey(c.counters, P)
         return c.counters[P] = 1
     else

--- a/src/makielayout/blocks/axis.jl
+++ b/src/makielayout/blocks/axis.jl
@@ -675,11 +675,11 @@ validate_limits_for_scale(lims, scale) = all(x -> x in defined_interval(scale), 
 palettesyms(cycle::Cycle) = [c[2] for c in cycle.cycle]
 attrsyms(cycle::Cycle) = [c[1] for c in cycle.cycle]
 
-function get_cycler_index!(c::Cycler, P::Type{Plot{Func, Args}}) where {Func, Args}
+function get_cycler_index!(c::Cycler, P::Type{Plot{func, Args}}) where {func, Args}
     # We want to avoid indexing into the cycler by the arguments of the plot, 
     # since those can change on input type (float32 vs float64, polygon vs multipolygon, etc)
     # so instead, we re-create the plot type with only the function, not the arguments!
-    P = Plot{Func}
+    P = typeof(func) # note: func is the actual function as a type parameter of the plot.
     # Now we can index into the cycler using this abstract type.
     if !haskey(c.counters, P)
         return c.counters[P] = 1

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -54,4 +54,38 @@
         @test p.calculated_colors[].colorrange_scaled[][2] == -minimum(data)
         @test issorted(p.calculated_colors[].colorrange_scaled[])
     end
+
+    @testset "#4957 axis cycling for same plot type with different argument types" begin
+        @testset "Lines" begin
+            f, a, p1 = lines(rand(Float64, 10))
+            p2 = lines!(a, rand(Float32, 10))
+            p3 = lines!(a, rand(Float64, 10))
+
+            palette_colors = a.scene.theme.palette.color[]
+
+            @test p1.color[] == palette_colors[1]
+            @test p2.color[] == palette_colors[2]
+            @test p3.color[] == palette_colors[3]
+
+            p4 = lines!(a, rand(Float32, 10))
+            @test p4.color[] = palette_colors[4]
+        end
+
+        @testset "Poly" begin
+            poly1 = Makie.GeometryBasics.Polygon(Point2f[(0,0), (0, 1), (1, 1), (1, 0), (0, 0)])
+            multipoly1 = Makie.GeometryBasics.MultiPolygon([poly1, poly1])
+
+            f, a, p1 = poly(poly1; alpha = 1)
+            p2 = poly!(a, [poly1, poly1])
+            p3 = poly!(a, multipoly1)
+
+            # convert to RGBf here, because poly decreases alpha by 0.2
+            palette_colors = Makie.RGBf.(a.scene.theme.palette.color[])
+
+            @test Makie.RGBf(p1.color[]) == palette_colors[1]
+            @test Makie.RGBf(p2.color[]) == palette_colors[2]
+            @test Makie.RGBf(p3.color[]) == palette_colors[3]
+
+        end
+    end
 end

--- a/test/issues.jl
+++ b/test/issues.jl
@@ -68,7 +68,7 @@
             @test p3.color[] == palette_colors[3]
 
             p4 = lines!(a, rand(Float32, 10))
-            @test p4.color[] = palette_colors[4]
+            @test p4.color[] == palette_colors[4]
         end
 
         @testset "Poly" begin


### PR DESCRIPTION
# Description

Previously it was specific to the concrete type of the plot, which we don't want, since it causes each different set of (post-conversion) args to be cycled individually.  This fixes that by lifting the plot function out of the `Plot` type and reconstructing `Plot{Func}`.

Fixes #4957

This causes three refimage tests to fail, but those failures seem expected (and kind of harmless?).  We can fix either by updating the refimages, or fixing the color in the refimages to be consistent (maybe Cycled(1) on all of them).

<img width="1325" alt="Screenshot 2025-05-08 at 7 44 59 PM" src="https://github.com/user-attachments/assets/5d755c0d-dafe-4974-a0f3-b28a6d62811a" />
<img width="1430" alt="Screenshot 2025-05-08 at 7 45 31 PM" src="https://github.com/user-attachments/assets/7bb13c3b-a737-49f4-89a6-aa525dd83a8d" />
<img width="1409" alt="Screenshot 2025-05-08 at 7 45 57 PM" src="https://github.com/user-attachments/assets/2d692c5c-114b-4b8d-bcf9-507b58393414" />


## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

Potentially visually breaking?  But I think we can all agree this is correct behaviour.  I was personally working around it by manually assigning Cycled, I'm sure other people were too.

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [X] Added unit tests for new algorithms, conversion methods, etc.
