### PR TITLE
Handle `dim_conversions` in `Axis3`

### DIFF
--- a/src/makielayout/blocks/axis3d.jl
+++ b/src/makielayout/blocks/axis3d.jl
@@ -28,6 +28,10 @@ function initialize_block!(ax::Axis3)
 
     scene = Scene(blockscene, scenearea, clear = false, backgroundcolor = ax.backgroundcolor)
     ax.scene = scene
+    # transfer conversions from axis to scene if there are any
+    # or the other way around
+    connect_conversions!(scene.conversions, ax)
+
     cam = Axis3Camera()
     cameracontrols!(scene, cam)
     scene.theme.clip_planes = map(scene, scene.transformation.model, ax.finallimits, ax.clip) do model, lims, clip
@@ -84,17 +88,17 @@ function initialize_block!(ax::Axis3)
 
     ticknode_1 = Observable{Any}()
     map!(scene, ticknode_1, finallimits, ax.xticks, ax.xtickformat) do lims, ticks, format
-        get_ticks(ticks, identity, format, minimum(lims)[1], maximum(lims)[1])
+        get_ticks(ax.scene.conversions[1], ticks, identity, format, minimum(lims)[1], maximum(lims)[1])
     end
 
     ticknode_2 = Observable{Any}()
     map!(scene, ticknode_2, finallimits, ax.yticks, ax.ytickformat) do lims, ticks, format
-        get_ticks(ticks, identity, format, minimum(lims)[2], maximum(lims)[2])
+        get_ticks(ax.scene.conversions[2], ticks, identity, format, minimum(lims)[2], maximum(lims)[2])
     end
 
     ticknode_3 = Observable{Any}()
     map!(scene, ticknode_3, finallimits, ax.zticks, ax.ztickformat) do lims, ticks, format
-        get_ticks(ticks, identity, format, minimum(lims)[3], maximum(lims)[3])
+        get_ticks(ax.scene.conversions[3], ticks, identity, format, minimum(lims)[3], maximum(lims)[3])
     end
 
     add_panel!(scene, ax, 1, 2, 3, finallimits, mi3)


### PR DESCRIPTION
# Description

Fixes #4963.

This is my attempt on fixing the issue #4963 I created, namely handling `DimConversions` in `Axis3`. It solves the problem I reported in the issue, but I cannot judge whether this is a full solution, so maybe some expert should review and judge the completeness of this.

I looked into how `dim_conversion` is handled in `Axis`, and it looks like, in `Axis3`,
1. the dimensions passed to the `axis` were just not passed to the newly created `Scene` when initializing the block
2. the conversions were not passed to `get_ticks` when creating the ticknodes.

This should be fixed now in this PR.

Example 1: 
```julia
using CairoMakie, Unitful
fig = Makie.Figure()
ax = Makie.Axis3(fig[1,1], dim1_conversion = Makie.UnitfulConversion(u"m", units_in_label = true))
@show ax.scene.conversions[1]
fig
```

Before this PR:
`ax.scene.conversions` would ignore what was passed and the axis ticklabels would not show the unit.
```
ax.scene.conversions[1] = nothing
```
![image](https://github.com/user-attachments/assets/c42b8e49-0299-4c9c-8b78-a657bae65c38)

Using this PR:
The `ax.scene.conversions` has the `dim_conversion` passed to it and the axis ticklabels show units now.
```
ax.scene.conversions[1] = Makie.UnitfulConversion(Observable{Any}(m), false, Observable(true), Dict{String, Tuple{Any, Any}}())
```
![image](https://github.com/user-attachments/assets/d62a2994-6f6e-4033-8116-ae7252ae7ae2)


Example 2:
```julia
using CairoMakie, Unitful
fig = Makie.Figure()
ax = Makie.Axis3(fig[1,1], dim1_conversion = Makie.UnitfulConversion(u"m", units_in_label = true))
Makie.scatter!(ax, rand(10)*u"m", rand(10), rand(10))
@show ax.scene.conversions[1]
fig
```

Before this PR:
`ax.scene.conversions` would "guess" the unit conversion (`automatic`), in this case `dm` (decimeter) but not display them --> BUG
```
ax.scene.conversions[1] = Makie.UnitfulConversion(Observable{Any}(dm), true, Observable(true), Dict{String, Tuple{Any, Any}}("656252" => (0.0911379250149652 m, 0.8551460469135354 m)))
```
![image](https://github.com/user-attachments/assets/9f557dc8-80d1-4744-ae1b-2afafdee9ce8)

Using this PR:
`ax.scene.conversions` would still use the `dim_conversion` defined when creating the `Axis3`
```
ax.scene.conversions[1] = Makie.UnitfulConversion(Observable{Any}(m), false, Observable(true), Dict{String, Tuple{Any, Any}}())
```
![image](https://github.com/user-attachments/assets/b5f36172-959f-483c-b0a2-43daec2bac7d)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
