### PR TITLE
Compute lighting

### DIFF
--- a/CairoMakie/src/new_primitives.jl
+++ b/CairoMakie/src/new_primitives.jl
@@ -621,14 +621,6 @@ function draw_mesh3D(
         align_pattern(per_face_col, scene, f32c_model)
     end
 
-    # TODO: assume Symbol here after this has been deprecated for a while
-    if shading isa Bool
-        @warn "`shading::Bool` is deprecated. Use `shading = NoShading` instead of false and `shading = FastShading` or `shading = MultiLightShading` instead of true."
-        shading_bool = shading
-    else
-        shading_bool = shading != NoShading
-    end
-
     if !isnothing(meshnormals) && to_value(get(plot, :invert_normals, false))
         meshnormals .= -meshnormals
     end
@@ -638,7 +630,7 @@ function draw_mesh3D(
 
     draw_mesh3D(
         scene, screen, space, world_points, screen_points, meshfaces, meshnormals, per_face_col,
-        model, shading_bool::Bool, diffuse::Vec3f,
+        model, shading::Bool, diffuse::Vec3f,
         specular::Vec3f, shininess::Float32, faceculling::Int, clip_planes, plot.eyeposition[]
     )
 end

--- a/CairoMakie/src/new_primitives.jl
+++ b/CairoMakie/src/new_primitives.jl
@@ -643,6 +643,8 @@ function draw_mesh3D(
     )
 end
 
+to_vec(c::Colorant) = Vec3f(red(c), green(c), blue(c))
+
 function draw_mesh3D(
         scene, screen, space, world_points, screen_points, meshfaces, meshnormals, per_face_col,
         model, shading, diffuse, specular, shininess, faceculling, clip_planes, eyeposition
@@ -685,36 +687,16 @@ function draw_mesh3D(
         return draw_mesh2D(ctx, per_face_col, screen_points, meshfaces, reverse(zorder))
     end
 
-    # Light math happens in view/camera space
-    dirlight = Makie.get_directional_light(scene)
-    if !isnothing(dirlight)
-        lightdirection = if dirlight.camera_relative
-            T = inv(scene.camera.view[][Vec(1,2,3), Vec(1,2,3)])
-            normalize(T * dirlight.direction[])
-        else
-            normalize(dirlight.direction[])
-        end
-        c = dirlight.color[]
-        light_color = Vec3f(red(c), green(c), blue(c))
-    else
-        lightdirection = Vec3f(0,0,-1)
-        light_color = Vec3f(0)
-    end
-
-    ambientlight = Makie.get_ambient_light(scene)
-    ambient = if !isnothing(ambientlight)
-        c = ambientlight.color[]
-        Vec3f(c.r, c.g, c.b)
-    else
-        Vec3f(0)
-    end
+    ambient = to_vec(scene.compute[:ambient_color][])
+    light_color = to_vec(scene.compute[:dirlight_color][])
+    light_direction = scene.compute[:dirlight_final_direction][]
 
     # vs are used as camdir (camera to vertex) for light calculation (in world space)
     vs = map(v -> normalize(v[i] - eyeposition), world_points)
 
     draw_pattern(
         ctx, zorder, shading, meshfaces, screen_points, per_face_col, ns, vs,
-        lightdirection, light_color, shininess, diffuse, ambient, specular)
+        light_direction, light_color, shininess, diffuse, ambient, specular)
 
     return
 end

--- a/GLMakie/assets/shader/lighting.frag
+++ b/GLMakie/assets/shader/lighting.frag
@@ -17,6 +17,7 @@ uniform vec3 diffuse;
 uniform vec3 specular;
 uniform float shininess;
 
+uniform vec3 ambient;
 uniform float backlight;
 
 in vec3 o_camdir;
@@ -72,7 +73,6 @@ vec3 illuminate(vec3 normal, vec3 base_color);
 
 #ifdef FAST_SHADING
 
-uniform vec3 ambient;
 uniform vec3 light_color;
 uniform vec3 light_direction;
 
@@ -175,13 +175,10 @@ vec3 calc_rect_light(vec3 light_color, int idx, vec3 world_pos, vec3 camdir, vec
 }
 
 vec3 illuminate(vec3 world_pos, vec3 camdir, vec3 normal, vec3 base_color) {
-    vec3 final_color = vec3(0);
+    vec3 final_color = ambient * base_color;
     int idx = 0;
     for (int i = 0; i < min(N_lights, MAX_LIGHTS); i++) {
         switch (light_types[i]) {
-        case Ambient:
-            final_color += light_colors[i] * base_color;
-            break;
         case PointLight:
             final_color += calc_point_light(light_colors[i], idx, world_pos, camdir, normal, base_color);
             idx += 5; // 3 position, 2 attenuation params

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -145,7 +145,7 @@ function generate_clip_planes!(attr, target_space::Symbol = :world, modelname = 
     return
 end
 
-# TODO: handle these on the scene level once and reuse them
+# TODO: Consider separating this from plot (i.e. update this in render using scene graph)
 function register_light_attributes!(screen, scene, attr, uniforms)
     haskey(attr, :shading) || return
 

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -151,9 +151,11 @@ function register_light_attributes!(screen, scene, attr, uniforms)
         return
     end
 
+    shading = Makie.get_shading_mode(scene)
+    shading == NoShading && return
+
     add_input!(attr, :ambient, scene.compute[:ambient_color]::Computed)
 
-    shading = Makie.get_lighting_mode(scene)
     if shading == FastShading
 
         add_input!(attr, :light_color, scene.compute[:dirlight_color])

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -151,7 +151,7 @@ function register_light_attributes!(screen, scene, attr, uniforms)
 
     add_input!(attr, :ambient, scene.compute[:ambient_color]::Computed)
 
-    shading = attr[:shading][]
+    shading = scene.compute[:lighting_mode][]
     if shading == FastShading
 
         add_input!(attr, :light_color, scene.compute[:dirlight_color])
@@ -170,7 +170,6 @@ function register_light_attributes!(screen, scene, attr, uniforms)
             add_input!(attr, key, scene.compute[key]::Computed)
         end
         push!(uniforms, :ambient, names...)
-
     end
 end
 

--- a/GLMakie/test/glmakie_refimages.jl
+++ b/GLMakie/test/glmakie_refimages.jl
@@ -95,7 +95,7 @@ end
     ]
 
     scene = Scene(size = (400, 400), camera = cam3d!, lights = lights)
-    mesh!(
+    p = mesh!(
         scene,
         Rect3f(Point3f(-10, -10, -2.99), Vec3f(20, 20, 0.02)),
         color = :white, shading = MultiLightShading, specular = Vec3f(0)
@@ -132,8 +132,8 @@ end
         RectLight(RGBf(0.5, 0.5, 0.5), Point3f( 1, -1, 2), Vec3f(3, 0, 0), Vec3f(0, 3, 0), Vec3f(-0.3, 0.3, -1)),
     ]
     # Test transformations
-    translate!(lights[2], Vec3f(-1, 1, 2)) # translate to by default
-    scale!(lights[2], 3, 1)
+    lights[2] = Makie.translate(lights[2], Vec3f(-1, 1, 2)) # translate to by default
+    lights[2] = Makie.scale(lights[2], 3, 1)
 
     scene = Scene(lights = lights, camera = cam3d!, size = (400, 400))
     p = mesh!(scene, Rect3f(Point3f(-10, -10, 0.01), Vec3f(20, 20, 0.02)), color = :white)

--- a/GLMakie/test/glmakie_refimages.jl
+++ b/GLMakie/test/glmakie_refimages.jl
@@ -95,10 +95,11 @@ end
     ]
 
     scene = Scene(size = (400, 400), camera = cam3d!, lights = lights)
+    @test Makie.get_shading_mode(scene) == MultiLightShading
     p = mesh!(
         scene,
         Rect3f(Point3f(-10, -10, -2.99), Vec3f(20, 20, 0.02)),
-        color = :white, shading = MultiLightShading, specular = Vec3f(0)
+        color = :white, specular = Vec3f(0)
     )
     center!(scene)
     update_cam!(scene, Vec3f(0, 0, 10), Vec3f(0, 0, 0), Vec3f(0, 1, 0))
@@ -115,8 +116,9 @@ end
     ]
 
     scene = Scene(size = (400, 400), camera = cam3d!, center = false, lights = lights, backgroundcolor = :black)
+    @test Makie.get_shading_mode(scene) == MultiLightShading
     mesh!(
-        scene, Sphere(Point3f(0), 1f0), color = :white, shading = MultiLightShading,
+        scene, Sphere(Point3f(0), 1f0), color = :white,
         specular = Vec3f(1), shininess = 16f0
     )
     update_cam!(scene, Vec3f(0, 0, 3), Vec3f(0, 0, 0), Vec3f(0, 1, 0))
@@ -136,6 +138,7 @@ end
     lights[2] = Makie.scale(lights[2], 3, 1)
 
     scene = Scene(lights = lights, camera = cam3d!, size = (400, 400))
+    @test Makie.get_shading_mode(scene) == MultiLightShading
     p = mesh!(scene, Rect3f(Point3f(-10, -10, 0.01), Vec3f(20, 20, 0.02)), color = :white)
     update_cam!(scene, Vec3f(0, 0, 7), Vec3f(0, 0, 0), Vec3f(0, 1, 0))
 

--- a/MakieCore/src/basic_plots.jl
+++ b/MakieCore/src/basic_plots.jl
@@ -149,7 +149,7 @@ end
 """
 ### 3D shading attributes
 
-- `shading = Makie.automatic` sets the lighting algorithm used. Options are `NoShading` (no lighting), `FastShading` (AmbientLight + PointLight) or `MultiLightShading` (Multiple lights, GLMakie only). Note that this does not affect RPRMakie.
+- `shading = true` controls if the plot object is shaded by the parent scenes lights or not. The lighting algorithm used is controlled by the scenes `shading` attribute.
 - `diffuse::Vec3f = Vec3f(1.0)` sets how strongly the red, green and blue channel react to diffuse (scattered) light.
 - `specular::Vec3f = Vec3f(0.4)` sets how strongly the object reflects light in the red, green and blue channels.
 - `shininess::Real = 32.0` sets how sharp the reflection is.
@@ -157,7 +157,7 @@ end
 - `ssao::Bool = false` adjusts whether the plot is rendered with ssao (screen space ambient occlusion). Note that this only makes sense in 3D plots and is only applicable with `fxaa = true`.
 """
 function shading_attributes!(attr)
-    attr[:shading] = automatic
+    attr[:shading] = true
     attr[:diffuse] = 1.0
     attr[:specular] = 0.2
     attr[:shininess] = 32.0f0
@@ -178,8 +178,8 @@ end
 
 function mixin_shading_attributes()
     @DocumentedAttributes begin
-        "Sets the lighting algorithm used. Options are `NoShading` (no lighting), `FastShading` (AmbientLight + PointLight) or `MultiLightShading` (Multiple lights, GLMakie only). Note that this does not affect RPRMakie."
-        shading = automatic
+        "Controls if the plot object is shaded by the parent scenes lights or not. The lighting algorithm used is controlled by the scenes `shading` attribute."
+        shading = true
         "Sets how strongly the red, green and blue channel react to diffuse (scattered) light."
         diffuse = 1.0
         "Sets how strongly the object reflects light in the red, green and blue channels."
@@ -711,7 +711,7 @@ Plots polygons, which are defined by
     joinstyle = @inherit joinstyle
     miter_limit = @inherit miter_limit
 
-    shading = NoShading
+    shading = false
 
     cycle = [:color => :patchcolor]
     """

--- a/WGLMakie/assets/mesh.frag
+++ b/WGLMakie/assets/mesh.frag
@@ -9,6 +9,9 @@ in vec3 o_camdir;
 in float o_clip_distance[8];
 
 uniform int num_clip_planes;
+uniform vec3 light_color;
+uniform vec3 ambient;
+uniform vec3 light_direction;
 
 // Smoothes out edge around 0 light intensity, see GLMakie
 float smooth_zero_max(float x) {
@@ -33,7 +36,7 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
         spec_coeff = 0.0;
 
     // final lighting model
-    return get_light_color() * vec3(
+    return light_color * vec3(
         get_diffuse() * diff_coeff * color +
         get_specular() * spec_coeff
     );
@@ -143,10 +146,10 @@ void main()
     vec3 shaded_color = real_color.rgb;
 
     if(get_shading()){
-        vec3 L = get_light_direction();
+        vec3 L = light_direction;
         vec3 N = normalize(o_normal);
         vec3 light = blinnphong(N, normalize(o_camdir), L, real_color.rgb);
-        shaded_color = get_ambient() * real_color.rgb + light;
+        shaded_color = ambient * real_color.rgb + light;
     }
 
     if (picking && (real_color.a > 0.1)) {

--- a/WGLMakie/assets/volume.frag
+++ b/WGLMakie/assets/volume.frag
@@ -12,6 +12,9 @@ const int num_samples = 200;
 const float step_size = max_distance / float(num_samples);
 
 uniform vec4 clip_planes[8];
+uniform vec3 light_color;
+uniform vec3 ambient;
+uniform vec3 light_direction;
 
 float _normalize(float val, float from, float to) { return (val-from) / (to - from); }
 
@@ -86,7 +89,7 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
     vec3 H = normalize(L + V);
     float spec_coeff = pow(max(dot(H, -N), 0.0) + max(dot(H, N), 0.0), shininess);
     // final lighting model
-    return ambient * color + get_light_color() * vec3(
+    return ambient * color + light_color * vec3(
         get_diffuse() * diff_coeff * color +
         get_specular() * spec_coeff
     );
@@ -177,7 +180,7 @@ vec4 isosurface(vec3 front, vec3 dir)
         float density = texture(uniform_color, pos).x;
         if(abs(density - isovalue) < isorange){
             vec3 N = gennormal(pos, step_size);
-            vec3 L = get_light_direction();
+            vec3 L = light_direction;
             c = vec4(
                 blinnphong(N, camdir, L, diffuse_color.rgb),
                 diffuse_color.a

--- a/WGLMakie/assets/voxel.frag
+++ b/WGLMakie/assets/voxel.frag
@@ -20,6 +20,9 @@ flat in int plane_front;
 
 uniform int num_clip_planes;
 uniform vec4 clip_planes[8];
+uniform vec3 light_color;
+uniform vec3 ambient;
+uniform vec3 light_direction;
 
 vec4 debug_color(uint id) {
     return vec4(
@@ -105,7 +108,7 @@ vec3 blinnphong(vec3 N, vec3 V, vec3 L, vec3 color){
         spec_coeff = 0.0;
 
     // final lighting model
-    return get_light_color() * vec3(
+    return light_color * vec3(
         get_diffuse() * diff_coeff * color +
         get_specular() * spec_coeff
     );
@@ -170,9 +173,9 @@ void main()
 #endif
 
     if(get_shading()){
-        vec3 L = get_light_direction();
+        vec3 L = light_direction;
         vec3 light = blinnphong(o_normal, normalize(o_camdir), L, voxel_color.rgb);
-        voxel_color.rgb = get_ambient() * voxel_color.rgb + light;
+        voxel_color.rgb = ambient * voxel_color.rgb + light;
     }
 
     if (picking) {

--- a/WGLMakie/src/javascript/Plots.js
+++ b/WGLMakie/src/javascript/Plots.js
@@ -55,6 +55,8 @@ function connect_plot(scene, plot) {
         );
     }
     uniforms.light_direction = scene.light_direction;
+    uniforms.ambient = scene.ambient;
+    uniforms.light_color = scene.light_color;
 }
 
 export class Plot {

--- a/WGLMakie/src/javascript/Serialization.js
+++ b/WGLMakie/src/javascript/Serialization.js
@@ -225,9 +225,21 @@ export function deserialize_scene_recursive(data, screen) {
         );
         scene.light_direction = new THREE.Uniform(light_dir);
         data.light_direction.on((value) => {
-            plot_data.uniforms.light_direction.value.fromArray(value);
+            scene.light_direction.value.fromArray(value);
         });
     }
+
+    const ambient = new THREE.Vector3().fromArray(data.ambient.value);
+    scene.ambient = new THREE.Uniform(ambient);
+    data.ambient.on((value) => {
+        scene.ambient.value.fromArray(value);
+    })
+
+    const light_color = new THREE.Vector3().fromArray(data.light_color.value);
+    scene.light_color = new THREE.Uniform(light_color);
+    data.light_color.on((value) => {
+        scene.light_color.value.fromArray(value);
+    })
 
     data.plots.forEach((plot_data) => {
         add_plot(scene, plot_data);

--- a/WGLMakie/src/javascript/WGLMakie.bundled.js
+++ b/WGLMakie/src/javascript/WGLMakie.bundled.js
@@ -22822,6 +22822,8 @@ function connect_plot(scene, plot) {
         uniforms.preprojection = cam.preprojection_matrix(space, markerspace);
     }
     uniforms.light_direction = scene.light_direction;
+    uniforms.ambient = scene.ambient;
+    uniforms.light_color = scene.light_color;
 }
 function filter_by_key(dict, keys, default_value = false) {
     const result = {};
@@ -23000,6 +23002,16 @@ function deserialize_scene_recursive(data, screen) {
             plot_data.uniforms.light_direction.value.fromArray(value);
         });
     }
+    const ambient = new mod.Vector3().fromArray(data.ambient.value);
+    scene.ambient = new mod.Uniform(ambient);
+    data.ambient.on((value)=>{
+        scene.ambient.value.fromArray(value);
+    });
+    const light_color = new mod.Vector3().fromArray(data.light_color.value);
+    scene.light_color = new mod.Uniform(light_color);
+    data.light_color.on((value)=>{
+        scene.light_color.value.fromArray(value);
+    });
     data.plots.forEach((plot_data1)=>{
         add_plot(scene, plot_data1);
     });

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -355,15 +355,12 @@ end
 function meshscatter_program(args)
     instance = args.marker
     data = Dict{Symbol, Any}(
-        :ambient => Vec3f(0.5),
         :diffuse => args.diffuse,
         :specular => args.specular,
         :shininess => args.shininess,
         :pattern => false,
         :uniform_color => false,
         :uv_transform => Mat3f(I),
-        :light_direction => Vec3f(1),
-        :light_color => Vec3f(1),
         :PICKING_INDEX_FROM_UV => false,
         :shading => args.shading == false || args.shading != NoShading,
         :backlight => args.backlight,
@@ -445,9 +442,6 @@ function mesh_program(attr)
         :specular => attr.specular,
         :shininess => attr.shininess,
         :backlight => attr.backlight,
-        :ambient => Vec3f(1),
-        :light_direction => Vec3f(1),
-        :light_color => Vec3f(1),
 
         :model => Mat4f(attr.model_f32c),
         :PICKING_INDEX_FROM_UV => true,
@@ -606,10 +600,7 @@ function create_volume_shader(attr)
         :depth_shift => attr.depth_shift,
         # these get filled in later by serialization, but we need them
         # as dummy values here, so that the correct uniforms are emitted
-        :light_direction => Vec3f(1),
-        :light_color => Vec3f(1),
         :eyeposition => Vec3f(1),
-        :ambient => Vec3f(1),
         :picking => false,
         :object_id => UInt32(0)
     )

--- a/WGLMakie/src/serialization.jl
+++ b/WGLMakie/src/serialization.jl
@@ -190,11 +190,17 @@ function serialize_scene(scene::Scene)
 
     children = map(child-> serialize_scene(child), scene.children)
 
-    light_dir = Observable(Vec3f(1), ignore_equal_values = true)
-    cam_rel = Observable(false, ignore_equal_values = true)
+
+    light_dir = Observable(serialize_three(Vec3f(1)), ignore_equal_values = true)
+    cam_rel = Observable(serialize_three(false), ignore_equal_values = true)
+    ambient = Observable(serialize_three(RGBf(0,0,1)), ignore_equal_values = true)
+    light_color = Observable(serialize_three(RGBf(1,0,0)), ignore_equal_values = true)
+
     on(scene.compute.onchange, update = true) do _
-        light_dir[] = scene.compute[:dirlight_direction][]
-        cam_rel[] = scene.compute[:dirlight_cam_relative][]
+        ambient[] = serialize_three(scene.compute[:ambient_color][])
+        light_color[] = serialize_three(scene.compute[:dirlight_color][])
+        light_dir[] = serialize_three(scene.compute[:dirlight_direction][])
+        cam_rel[] = serialize_three(scene.compute[:dirlight_cam_relative][])
         return
     end
 
@@ -206,6 +212,8 @@ function serialize_scene(scene::Scene)
         :camera => serialize_camera(scene),
         :light_direction => light_dir,
         :camera_relative_light => cam_rel,
+        :ambient => ambient,
+        :light_color => light_color,
         :plots => serialize_plots(scene, scene.plots),
         :cam3d_state => cam3d_state,
         :visible => scene.visible,

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -389,13 +389,6 @@ function add_theme!(plot::T, scene::Scene) where {T}
     return
 end
 
-function resolve_shading_default!(scene::Scene, attr::ComputeGraph)
-    haskey(attr, :shading) || return
-    # TODO: just return true/false?
-    update!(attr, shading = FastShading)
-    return
-end
-
 register_camera!(scene::Scene, plot::Plot) = register_camera!(plot.args[1], scene.compute)
 
 function connect_plot!(parent::SceneLike, plot::ComputePlots)
@@ -423,8 +416,6 @@ function computed_plot!(parent, plot::T) where {T}
     on(tf -> update!(attr; transform_func=tf), plot, plot.transformation.transform_func; update=true)
 
     register_camera!(scene, plot)
-
-    resolve_shading_default!(scene, plot.args[1])
 
     push!(parent, plot)
     plot!(plot)

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -389,57 +389,10 @@ function add_theme!(plot::T, scene::Scene) where {T}
     return
 end
 
-resolve_shading_default!(scene::Scene, attr::ComputeGraph) = resolve_shading_default!(attr, scene.lights)
-function resolve_shading_default!(attr::ComputeGraph, lights::Vector{<: AbstractLight})
+function resolve_shading_default!(scene::Scene, attr::ComputeGraph)
     haskey(attr, :shading) || return
-
-    # shading is a compile time adjustment so it doesn't make sense to add
-    # dynamic comoputations for it. Instead we just replace the initial value
-
-    # Bad type
-    # TODO: This is hacky - we don't want to resolve shading and pin it to a potentially bad type
-    shading = attr.inputs[:shading].value
-    if !(shading isa MakieCore.ShadingAlgorithm || shading === automatic)
-        prev = shading
-        if (shading isa Bool) && (shading == false)
-            shading = NoShading
-        else
-            shading = automatic
-        end
-        @warn "`shading = $prev` is not valid. Use `Makie.automatic`, `NoShading`, `FastShading` or `MultiLightShading`. Defaulting to `$shading`."
-    end
-
-    # automatic conversion
-    if shading === automatic
-        ambient_count = 0
-        dir_light_count = 0
-
-        for light in lights
-            if light isa AmbientLight
-                ambient_count += 1
-            elseif light isa DirectionalLight
-                dir_light_count += 1
-            elseif light isa EnvironmentLight
-                continue
-            else
-                update!(attr, shading = MultiLightShading)
-                return
-            end
-            if ambient_count > 1 || dir_light_count > 1
-                update!(attr, shading = MultiLightShading)
-                return
-            end
-        end
-
-        if dir_light_count + ambient_count == 0
-            shading = NoShading
-        else
-            shading = FastShading
-        end
-    end
-
-    update!(attr, shading = shading)
-
+    # TODO: just return true/false?
+    update!(attr, shading = FastShading)
     return
 end
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -2004,6 +2004,15 @@ convert_attribute(value, ::key"specular") = Vec3f(value)
 
 convert_attribute(value, ::key"backlight") = Float32(value)
 
+convert_attribute(value::Automatic, ::key"shading") = true
+function convert_attribute(value::MakieCore.ShadingAlgorithm, ::key"shading")
+    if value != NoShading
+        @warn "`shading = $value` is deprecated in favor of `shading = true` as a plot attribute. To switch between `FastShading` and `MultiLightShading` explicitly, use scene attributes."
+    end
+    return value != NoShading
+end
+
+
 convert_attribute(value, ::key"depth_shift") = Float32(value)
 
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -437,7 +437,6 @@ function connect_plot!(parent::SceneLike, plot::Plot{F}) where {F}
     apply_theme!(scene, plot)
     handle_transformation!(plot, parent)
     calculated_attributes!(Plot{F}, plot)
-    default_shading!(plot, parent_scene(parent))
 
     if to_value(get(attributes(plot), :clip_planes, automatic)) === automatic
         attributes(plot)[:clip_planes] = map(identity, plot, clip_planes_obs(parent))

--- a/src/lighting.jl
+++ b/src/lighting.jl
@@ -365,9 +365,3 @@ get_lights(graph::ComputeGraph) = graph[:lights][]
 
 set_lights!(scene, lights) = get_lights(scene.compute, lights)
 set_lights!(graph::ComputeGraph, lights) = update!(graph, lights = lights)
-
-
-################################################################################
-
-# TODO: delete once plot interface is cleaned up
-default_shading!(plot, lights::Vector{<: AbstractLight}) = automatic

--- a/src/lighting.jl
+++ b/src/lighting.jl
@@ -263,15 +263,15 @@ end
 
 # If we add dynamic plot reconstruction/shader recompilation this could be dynamic.
 # Without it needs to be a constant once the first renderobject is constructed
-function get_lighting_mode(scene)
+function get_shading_mode(scene)
     graph = scene.compute
     if haskey(graph, :lighting_mode)
         return graph[:lighting_mode][]
     else
         shading = get(scene.theme, :shading, automatic)
         mode = if shading === automatic
-            lights = graph[:lights][]
-            is_fast = (length(lights) == 0) || (lights[1] isa DirectionalLight)
+            lights = filter(l -> !isa(l, EnvironmentLight), graph[:lights][])
+            is_fast = length(lights) == 0 || (length(lights) == 1 && lights[1] isa DirectionalLight)
             ifelse(is_fast, FastShading, MultiLightShading)
         else
             shading

--- a/src/lighting.jl
+++ b/src/lighting.jl
@@ -311,8 +311,8 @@ function register_multi_light_computation(scene, MAX_LIGHTS, MAX_PARAMS)
         end
 
         usable_lights = view(lights, 1:n_lights)
-        types = light_type.(usable_lights)
-        colors = light_color.(usable_lights)
+        types = Int32.(light_type.(usable_lights))
+        colors = RGBf.(light_color.(usable_lights))
         parameters = Float32[]
         foreach(light -> push_parameters!(parameters, light, iview), usable_lights)
 

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -136,7 +136,7 @@ mutable struct Scene <: AbstractScene
             false
         )
         add_camera_computation!(scene.compute, scene)
-        add_light_computation!(scene.compute, lights)
+        add_light_computation!(scene.compute, scene, lights)
         on(scene, events.window_open) do open
             if !open
                 scene.isclosed = true

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -299,9 +299,6 @@ function Scene(;
     return scene
 end
 
-# TODO: just true?
-default_shading!(plot, scene::Scene) = FastShading
-
 function Scene(
         parent::Scene;
         events=parent.events,

--- a/src/scenes.jl
+++ b/src/scenes.jl
@@ -88,7 +88,6 @@ mutable struct Scene <: AbstractScene
     backgroundcolor::Observable{RGBAf}
     visible::Observable{Bool}
     ssao::SSAO
-    lights::Vector{AbstractLight}
     deregister_callbacks::Vector{Observables.ObserverFunction}
     cycler::Cycler
     compute::ComputeGraph
@@ -130,7 +129,6 @@ mutable struct Scene <: AbstractScene
             backgroundcolor,
             visible,
             ssao,
-            convert(Vector{AbstractLight}, lights),
             deregister_callbacks,
             Cycler(),
             ComputeGraph(),
@@ -138,6 +136,7 @@ mutable struct Scene <: AbstractScene
             false
         )
         add_camera_computation!(scene.compute, scene)
+        add_light_computation!(scene.compute, lights)
         on(scene, events.window_open) do open
             if !open
                 scene.isclosed = true
@@ -252,6 +251,28 @@ function Scene(;
     cam = camera isa Camera ? camera : Camera(viewport)
     _lights = lights isa Automatic ? AbstractLight[] : lights
 
+    if lights isa Automatic
+        haskey(m_theme, :lightposition) && @warn("`lightposition` is deprecated. Set `light_direction` instead.")
+
+        if haskey(m_theme, :lights)
+            copyto!(_lights, m_theme.lights[])
+        else
+            haskey(m_theme, :light_direction) || error("Theme must contain `light_direction::Vec3f` or an explicit `lights::Vector`!")
+            haskey(m_theme, :light_color) || error("Theme must contain `light_color::RGBf` or an explicit `lights::Vector`!")
+            haskey(m_theme, :camera_relative_light) || @warn("Theme should contain `camera_relative_light::Bool`.")
+
+            if haskey(m_theme, :ambient)
+                push!(_lights, AmbientLight(m_theme[:ambient][]))
+            end
+
+            push!(_lights, DirectionalLight(
+                m_theme[:light_color][], m_theme[:light_direction][],
+                to_value(get(m_theme, :camera_relative_light, false))
+            ))
+        end
+    end
+
+
     # if we have an opaque background, automatically set clear to true!
     if clear isa Automatic
         clear = Observable(alpha(bg[]) == 1 ? true : false)
@@ -275,34 +296,11 @@ function Scene(;
         end
     end
 
-    if lights isa Automatic
-        haskey(m_theme, :lightposition) && @warn("`lightposition` is deprecated. Set `light_direction` instead.")
-
-        if haskey(m_theme, :lights)
-            copyto!(scene.lights, m_theme.lights[])
-        else
-            haskey(m_theme, :light_direction) || error("Theme must contain `light_direction::Vec3f` or an explicit `lights::Vector`!")
-            haskey(m_theme, :light_color) || error("Theme must contain `light_color::RGBf` or an explicit `lights::Vector`!")
-            haskey(m_theme, :camera_relative_light) || @warn("Theme should contain `camera_relative_light::Bool`.")
-
-            if haskey(m_theme, :ambient)
-                push!(scene.lights, AmbientLight(m_theme[:ambient][]))
-            end
-
-            push!(scene.lights, DirectionalLight(
-                m_theme[:light_color][], m_theme[:light_direction],
-                to_value(get(m_theme, :camera_relative_light, false))
-            ))
-        end
-    end
-
     return scene
 end
 
-get_directional_light(scene::Scene) = get_one_light(scene.lights, DirectionalLight)
-get_point_light(scene::Scene) = get_one_light(scene.lights, PointLight)
-get_ambient_light(scene::Scene) = get_one_light(scene.lights, AmbientLight)
-default_shading!(plot, scene::Scene) = default_shading!(plot, scene.lights)
+# TODO: just true?
+default_shading!(plot, scene::Scene) = FastShading
 
 function Scene(
         parent::Scene;

--- a/src/theming.jl
+++ b/src/theming.jl
@@ -123,7 +123,7 @@ const MAKIE_DEFAULT_THEME = Attributes(
         # transparency. This should be the same for all of them (within one rendering
         # pipeline) otherwise depth "order" will be broken.
         transparency_weight_scale = 1000f0,
-        # maximum number of lights with shading = :verbose
+        # maximum number of lights with shading = MultiLightShading
         max_lights = 64,
         max_light_parameters = 5 * 64
     ),

--- a/test/SceneLike/scenes.jl
+++ b/test/SceneLike/scenes.jl
@@ -10,56 +10,47 @@ end
 
 @testset "Lighting" begin
     @testset "Shading default" begin
-        plot = (attributes = Attributes(), ) # simplified "plot"
-
         # Based on number of lights
         lights = Makie.AbstractLight[]
-        Makie.default_shading!(plot, lights)
-        @test !haskey(plot.attributes, :shading)
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == FastShading # Should this be NoShading?
 
-        plot.attributes[:shading] = Observable(Makie.automatic)
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === NoShading
-
-        plot.attributes[:shading] = Observable(Makie.automatic)
-        push!(lights, AmbientLight(RGBf(0.1, 0.1, 0.1)))
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === FastShading
-
-        plot.attributes[:shading] = Observable(Makie.automatic)
-        push!(lights, DirectionalLight(RGBf(0.1, 0.1, 0.1), Vec3f(1)))
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === FastShading
-
-        plot.attributes[:shading] = Observable(Makie.automatic)
+        # shading mode should be constant after the first get_shading_mode() call
+        # (Which should happen when the first renderobject is created)
         push!(lights, PointLight(RGBf(0.1, 0.1, 0.1), Point3f(0)))
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === MultiLightShading
+        @test Makie.get_shading_mode(scene) == FastShading
+
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == MultiLightShading
+
+        lights = Makie.AbstractLight[]
+        push!(lights, AmbientLight(RGBf(0.1, 0.1, 0.1)))
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == FastShading
+
+        push!(lights, DirectionalLight(RGBf(0.1, 0.1, 0.1), Vec3f(1)))
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == FastShading
+
+        push!(lights, PointLight(RGBf(0.1, 0.1, 0.1), Point3f(0)))
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == MultiLightShading
 
         # Based on light types
-        plot.attributes[:shading] = Observable(Makie.automatic)
         lights = [SpotLight(RGBf(0.1, 0.1, 0.1), Point3f(0), Vec3f(1), Vec2f(0.2, 0.3))]
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === MultiLightShading
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == MultiLightShading
 
-        plot.attributes[:shading] = Observable(Makie.automatic)
         lights = [EnvironmentLight(1.0, rand(2,2))]
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === NoShading # only affects RPRMakie so skipped here
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == FastShading # only affects RPRMakie so skipped here
 
-        plot.attributes[:shading] = Observable(Makie.automatic)
         lights = [PointLight(RGBf(0.1, 0.1, 0.1), Point3f(0))]
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === MultiLightShading
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == MultiLightShading
 
-        plot.attributes[:shading] = Observable(Makie.automatic)
         lights = [PointLight(RGBf(0.1, 0.1, 0.1), Point3f(0), Vec2f(0.1, 0.2))]
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === MultiLightShading
-
-        # keep existing shading type
-        lights = Makie.AbstractLight[]
-        Makie.default_shading!(plot, lights)
-        @test to_value(plot.attributes[:shading]) === MultiLightShading
+        scene = Scene(lights = lights)
+        @test Makie.get_shading_mode(scene) == MultiLightShading
     end
 end


### PR DESCRIPTION
# Description

Refactors lighting to be part of the scene compute graph. Currently is and probably will be breaking, because the Observables in Light structs are annoying keep and lights are a bit awkward in general

TODO:
- [x] prototype Makie code
- [x] get fast shading working in GLMakie
- [x] get multi light shading working in GLMakie
- [ ] update WGLMakie
- [x] update CairoMakie
- [x] probably make `plot.shading` a Bool again
- [x] make multi-light vs fast shading pickable per scene
- [x] add utility functions for updating lights
- [x] cleanup FastShading and MultiLightShading in tests
- [ ] update docs (maybe leave this for later when the interface changes had some time to solidify)

Deprecates:
- FastShading & MultiLightShading as a plot attribute

Breaking Changes:
- lights no longer have Observable fields
- `RectLight` transformation function are no longer inplace (they now generate a new RectLight and no longer uses ! postifx)