### PR TITLE
Fix `eltype` of `entry_observer_funcs` inside `initialize_block!(leg::Legend; entrygroups)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed regression in the updating logic of `Legend` [#4979](https://github.com/MakieOrg/Makie.jl/pull/4979).
+
 ## [0.22.6] - 2025-05-17
 
 - Added `alpha` keyword to `density` recipe [#4975](https://github.com/MakieOrg/Makie.jl/pull/4975).

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -313,10 +313,16 @@ end
 @reference_test "Legend update" begin
     fig = Figure()
     ax = Axis(fig[1, 1])
-    lines!(ax, [0, 1], [1, 1]; color = :blue, label = "lines")
-    scatter!(ax, [0], [0]; color = :red, label = "scatter")
-    legend = axislegend(ax; position = :rb)
-    reverse!(legend.entrygroups[][1][2])
+    l = lines!(ax, [0, 1], [1, 1]; color = :blue)
+    s = scatter!(ax, [0], [0]; color = :red)
+    p = poly!(ax, [(0, 0), (0, 1), (0.5, 0.7)])
+    make_legend(pos) = Legend(pos, [[l, s, p], [p, l, s]], [["line", "scatter", "poly"], ["LINE", "SCATTER", "POLY"]], ["Group1", "Group2"])
+    make_legend(fig[1, 2])
+    legend = make_legend(fig[1, 3])
+    reverse!(legend.entrygroups[])
+    for (title, group) in legend.entrygroups[]
+        popfirst!(group)
+    end
     notify(legend.entrygroups)
     fig
 end

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -310,6 +310,17 @@ end
     st
 end
 
+@reference_test "Legend update" begin
+    fig = Figure()
+    ax = Axis(fig[1, 1])
+    lines!(ax, [0, 1], [1, 1]; color = :blue, label = "lines")
+    scatter!(ax, [0], [0]; color = :red, label = "scatter")
+    legend = axislegend(ax; position = :rb)
+    reverse!(legend.entrygroups[][1][2])
+    notify(legend.entrygroups)
+    fig
+end
+
 @reference_test "LaTeXStrings in Axis3 plots" begin
     xs = LinRange(-10, 10, 100)
     ys = LinRange(0, 15, 100)

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -214,7 +214,7 @@ function initialize_block!(leg::Legend; entrygroups)
             tilesize=(hatch_width,hatch_width), linecolor=shade_color)
 
     # For cleaning up visible listeners on relayouting
-    entry_observer_funcs = Observable[]
+    entry_observer_funcs = ObserverFunction[]
 
     on(blockscene, entry_groups) do entry_groups
         # first delete all existing labels and patches
@@ -244,7 +244,7 @@ function initialize_block!(leg::Legend; entrygroups)
         foreach(halfshade_rects -> foreach(delete!, halfshade_rects), entryhalfshades)
         empty!(entryhalfshades)
 
-        foreach(off ∘ getindex, entry_observer_funcs)
+        foreach(off, entry_observer_funcs)
         empty!(entry_observer_funcs)
 
         # the attributes for legend entries that the legend itself carries

--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -244,7 +244,7 @@ function initialize_block!(leg::Legend; entrygroups)
         foreach(halfshade_rects -> foreach(delete!, halfshade_rects), entryhalfshades)
         empty!(entryhalfshades)
 
-        foreach(off, entry_observer_funcs)
+        foreach(off ∘ getindex, entry_observer_funcs)
         empty!(entry_observer_funcs)
 
         # the attributes for legend entries that the legend itself carries


### PR DESCRIPTION
The vector `entry_observer_funcs` should contain `ObserverFunctions` instead of `Observables`.
Its elements are populated by
```julia
obsfunc = onany(visibilities...) do vis...
  ...
end
append!(entry_observer_funcs, obsfunc)
```
Here `obsfunc` is a vector of `ObserverFunctions` which at the moment get wrapped automatically by `Observables` when they are appended to `entry_observer_funcs`.
This leads to an error when
```julia
foreach(off, entry_observer_funcs)
```
is later called, since `off` does not work on `Observables` but only on `ObserverFunctions`.
Fixing the `eltype` of `entry_observer_funcs` solves the issue.