### PR TITLE
Add option to change label and label value fontsize in SligerGrid

### DIFF
--- a/src/makielayout/blocks/slidergrid.jl
+++ b/src/makielayout/blocks/slidergrid.jl
@@ -23,10 +23,10 @@ function initialize_block!(sg::SliderGrid, nts::NamedTuple...)
         range = nt.range
         format = haskey(nt, :format) ? nt.format : default_format
         remaining_pairs = filter(pair -> pair[1] ∉ (:label, :range, :format), pairs(nt))
-        l = Label(sg.layout[i, 1], label, halign = :left)
+        l = Label(sg.layout[i, 1], label, halign = :left, fontsize = sg.labelsize)
         slider = Slider(sg.layout[i, 2]; range = range, remaining_pairs...)
         vl = Label(sg.layout[i, 3],
-            lift(x -> apply_format(x, format), slider.value), halign = :right)
+            lift(x -> apply_format(x, format), slider.value), halign = :right,fontsize = sg.valuesize)
         push!(sg.valuelabels, vl)
         push!(sg.sliders, slider)
         push!(sg.labels, l)

--- a/src/makielayout/types.jl
+++ b/src/makielayout/types.jl
@@ -1031,6 +1031,10 @@ end
         alignmode = Inside()
         "The width of the value label column. If `automatic`, the width is determined by sampling a few values from the slider ranges and picking the largest label size found."
         value_column_width = automatic
+        "The font size of the entry labels."
+        labelsize = @inherit(:fontsize, 16f0)
+        "The font size of the entry value labels."
+        valuesize = @inherit(:fontsize, 16f0)
     end
 end
 


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #2377 

* Adds `labelsize` attribute to `SliderGrid` block to change the fontsize of the slider labels.
* Adds `valuesize` attribute to `SliderGrid` block to change the fontsize of the slider label values.

Maybe `valuesize` is not the most appropiate name. Should `valuelabelsize` or something else be used instead?

For reference, this is how it looks like on the example of the docs:

![example](https://github.com/user-attachments/assets/9c269025-1bf9-4ffd-a8fd-61459886eea9)

I have exagerated the fontsize of both elements to perceive the difference. The code is the following:

```julia
using GLMakie


fig = Figure()

ax = Axis(fig[1, 1])

sg = SliderGrid(
    fig[1, 2],
    (label = "Voltage", range = 0:0.1:10, format = "{:.1f}V", startvalue = 5.3),
    (label = "Current", range = 0:0.1:20, format = "{:.1f}A", startvalue = 10.2),
    (label = "Resistance", range = 0:0.1:30, format = "{:.1f}Ω", startvalue = 15.9),
    width = 350,
    tellheight = false,
    labelsize = 8,
    valuesize = 30)

sliderobservables = [s.value for s in sg.sliders]
bars = lift(sliderobservables...) do slvalues...
    [slvalues...]
end

barplot!(ax, bars, color = [:yellow, :orange, :red])
ylims!(ax, 0, 30)

fig
```

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
