### PR TITLE
allow Legend to be created from multiple Axis

### DIFF
--- a/src/makielayout/blocks/legend.jl
+++ b/src/makielayout/blocks/legend.jl
@@ -934,6 +934,50 @@ function Legend(fig_or_scene,
     return _block(Legend, fig_or_scene, (), legend_defaults, bbox; kwdict_complete=true)
 end
 
+"""
+    Legend(fig_or_scene, axes::Union{Vector{Axis},Vector{Axis3},Vector{LScene},Vector{Scene}}, title = nothing; merge=true, kwargs...)
+
+Create a single-group legend with all plots from `axes` that have the attribute `label` set.
+
+If `merge` is `true`, all plot objects with the same label will be layered on top of each other into one legend entry.
+If `unique` is `true`, all plot objects with the same plot type and label will be reduced to one occurrence.
+
+
+"""
+function Legend(
+    fig_or_scene,
+    axes::Union{Vector{Axis},Vector{Axis3},Vector{LScene},Vector{Scene}},
+    title=nothing;
+    merge=false,
+    unique=false,
+    kwargs...,
+)
+
+    lplots = AbstractPlot[]
+    labels = AbstractString[]
+    for ax in axes
+        pl, lb = Makie.get_labeled_plots(ax, merge=false, unique=false)
+        append!(lplots, pl)
+        append!(labels, lb)
+    end
+
+    if unique
+        plots_labels = Base.unique(((p, l),) -> (typeof(p), l), zip(lplots, labels))
+        lplots = first.(plots_labels)
+        labels = last.(plots_labels)
+    end
+
+    if merge
+        ulabels = Base.unique(labels)
+        mergedplots = [[lp for (i, lp) in enumerate(lplots) if labels[i] == ul]
+            for ul in ulabels]
+
+        lplots, labels = mergedplots, ulabels
+    end
+    
+    return Legend(fig_or_scene, lplots, labels, title; kwargs...)
+end
+
 
 """
     Legend(fig_or_scene, axis::Union{Axis, Scene, LScene}, title = nothing; merge = false, unique = false, kwargs...)


### PR DESCRIPTION
# Description

Adds the ability to create a Legend from a vector of axes. 

Modified from https://discourse.julialang.org/t/how-to-combine-the-legend-of-multiple-axes-on-same-figure-into-one-in-makie-jl/97299/3?u=tomrottier


```julia
using GLMakie

f = Figure()
ax1 = Axis(f[1,1])
ax2 = Axis(f[1,2])

ps = [0.1, 0.2, 0.3, 0.4]
xs = range(0, 5, 100)
f1(x, p) = p * x^2
f2(x, p) = p * sin(x)

for p in ps
    lines!(ax1, xs, f1.(xs, p), label=string(p))
    lines!(ax2, xs, f2.(xs, p), label=string(p))
end

scatter!(ax1, xs[1:5:end], f1.(xs[1:5:end], ps[1]), label=string(ps[1]), )

Legend(f[2,:], [ax1, ax2], orientation=:horizontal, merge=true, unique=false)
```
![tmp](https://github.com/user-attachments/assets/84cb7916-541e-4ab2-ac8c-50116b83c38b)



## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
