### PR TITLE
Special-case band with array valued colors in CairoMakie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Added `alpha` keyword to `density` recipe [#4975](https://github.com/MakieOrg/Makie.jl/pull/4975).
+- Improved CairoMakie rendering of normal `band`s with array-valued colors [#4989](https://github.com/MakieOrg/Makie.jl/pull/4989).
 
 ## [0.22.5] - 2025-05-12
 

--- a/CairoMakie/src/overrides.jl
+++ b/CairoMakie/src/overrides.jl
@@ -268,7 +268,13 @@ function draw_plot(scene::Scene, screen::Screen,
         band::Band{<:Tuple{<:AbstractVector{<:Point2},<:AbstractVector{<:Point2}}})
     if is_linear_gradient_compatible(band) || !(band.color[] isa AbstractArray)
         basecolor = to_cairo_color(band.color[], band)
-        color = coloralpha.(basecolor, alpha.(basecolor) .* band.alpha[])
+        color = if basecolor isa Cairo.CairoPattern
+            basecolor
+        elseif basecolor isa AbstractVector # CairoPattern doesn't broadcast
+            coloralpha.(basecolor, alpha.(basecolor) .* band.alpha[])
+        else
+            coloralpha(basecolor, alpha(basecolor) * band.alpha[])
+        end
 
         model = band.model[]
         space = band.space[]

--- a/CairoMakie/src/overrides.jl
+++ b/CairoMakie/src/overrides.jl
@@ -254,12 +254,21 @@ function band_segment_ranges(lowerpoints, upperpoints)
     return ranges
 end
 
+# we can draw an array-colored band using a linear gradient if it's a "normal" band
+# in which all upper/lower values with the same index are at the same x value.
+# the linear gradient will look much better than falling back to mesh drawing, which
+# results in many little triangles when colors are semitransparent and a jagged corner
+function is_linear_gradient_compatible(band)
+    all(zip(band[1][], band[2][])) do (p1, p2)
+        p1 isa Point2 && p2 isa Point2 && p1[1] == p2[1]
+    end
+end
+
 function draw_plot(scene::Scene, screen::Screen,
         band::Band{<:Tuple{<:AbstractVector{<:Point2},<:AbstractVector{<:Point2}}})
-
-    if !(band.color[] isa AbstractArray)
+    if is_linear_gradient_compatible(band) || !(band.color[] isa AbstractArray)
         basecolor = to_cairo_color(band.color[], band)
-        color = coloralpha(basecolor, alpha(basecolor) * band.alpha[])
+        color = coloralpha.(basecolor, alpha.(basecolor) .* band.alpha[])
 
         model = band.model[]
         space = band.space[]
@@ -270,16 +279,36 @@ function draw_plot(scene::Scene, screen::Screen,
         lowerpoints = xdir ? band[2][] : reverse.(band[2][])
 
         for rng in band_segment_ranges(lowerpoints, upperpoints)
-            points = vcat(@view(lowerpoints[rng]), reverse(@view(upperpoints[rng])))
-            points = clip_poly(band.clip_planes[], points, space, model)
+            points_segment = vcat(@view(lowerpoints[rng]), reverse(@view(upperpoints[rng])))
+            points = clip_poly(band.clip_planes[], points_segment, space, model)
             points = project_position.(Ref(band), space, points, Ref(model))
             Cairo.move_to(screen.context, points[1]...)
             for p in points[2:end]
                 Cairo.line_to(screen.context, p...)
             end
             Cairo.close_path(screen.context)
-            set_source(screen.context, color)
-            Cairo.fill(screen.context)
+            if color isa AbstractVector
+                # for the gradient we use all points, irrespective of clipping
+                lower_proj = project_position.(Ref(band), space, points_segment[1:end÷2], Ref(model))
+                p_first = lower_proj[begin]
+                p_last = lower_proj[end]
+                P = typeof(p_last)
+                # the gradient must be parallel to x or y axis
+                p_last = xdir ? P(p_last[1], p_first[2]) : P(p_first[1], p_last[2])
+                dist = p_last - p_first
+                pat = Cairo.pattern_create_linear(p_first..., p_last...)
+                for (p, c) in zip(lower_proj, color)
+                    i = xdir ? 1 : 2
+                    fraction = (p[i] - p_first[i]) / dist[i]
+                    Cairo.pattern_add_color_stop_rgba(pat, fraction, red(c), green(c), blue(c), alpha(c))
+                end
+                Cairo.set_source(screen.context, pat)
+                Cairo.fill(screen.context)
+                Cairo.destroy(pat)
+            else
+                set_source(screen.context, color)
+                Cairo.fill(screen.context)
+            end
         end
 
         if basecolor isa Cairo.CairoPattern

--- a/ReferenceTests/src/tests/examples2d.jl
+++ b/ReferenceTests/src/tests/examples2d.jl
@@ -175,6 +175,10 @@ end
     # vertical version
     ax2, _ = lines(f[1, 2], μ, t)
     band!(ax2, t, μ + σ, μ - σ, direction = :y)   # plot stddev band
+
+    # array colors
+    band(f[2, 1], t, μ + σ, μ - σ, direction = :x, color = eachindex(t))
+    band(f[2, 2], t, μ + σ, μ - σ, direction = :y, color = eachindex(t), colormap = :Blues)
     f
 end
 


### PR DESCRIPTION
In SankeyMakie, half-transparent gradient bands look quite bad when they fall back to mesh rendering:

<img width="821" alt="image" src="https://github.com/user-attachments/assets/8ab3289d-c47d-417d-8417-4f7551f83a00" />

With this PR one poly is drawn instead, with a linear gradient for the color (which works only for this special case of a band, and not generically, because of the limitations of a linear gradient).

<img width="833" alt="image" src="https://github.com/user-attachments/assets/68e4ad7b-43c8-4759-ae50-49cc80926300" />
