### PR TITLE
Embed Ref outputs in Computed (comptue graph)

### DIFF
--- a/CairoMakie/src/new_primitives.jl
+++ b/CairoMakie/src/new_primitives.jl
@@ -221,15 +221,14 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(p::Scatter))
     Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
 
     @get_attribute(p, (
-        markersize, strokecolor, strokewidth, marker, marker_offset, rotation,
-        transform_marker, model, markerspace, space, clip_planes, f32c_scale
+        markersize, strokecolor, strokewidth, marker, marker_offset,
+        converted_rotation, billboard, transform_marker, model, markerspace,
+        space, clip_planes, f32c_scale
     ))
-
 
     Makie.register_computation!(attr, [:marker], [:cairo_marker]) do (marker,), changed, outputs
         return (cairo_scatter_marker(marker),)
     end
-
 
     # TODO: This requires (cam.projectionview, resolution) as inputs otherwise
     #       the output can becomes invalid from render to render.
@@ -245,12 +244,11 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(p::Scatter))
 
     font = p.font[]
     colors = cairo_colors(p)
-    billboard = p.rotation[] isa Billboard
 
     return draw_atomic_scatter(
         scene, ctx, markerspace_pos, indices, colors, markersize, strokecolor, strokewidth,
-        marker, marker_offset, rotation, size_model, font, markerspace, billboard
-        )
+        marker, marker_offset, converted_rotation, size_model, font, markerspace, billboard
+    )
 end
 
 is_approx_zero(x) = isapprox(x, 0)

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -1105,8 +1105,8 @@ function add_mesh_color_attributes!(screen, attr, data, color, colormap, colorno
 
     else # colormapped
 
-        interp = attr.color_mapping_type[] === Makie.continuous ? :linear : :nearest
-        data[:color_map] = Texture(screen.glscreen, colormap, minfilter = interp)
+        cm_interp = attr.color_mapping_type[] === Makie.continuous ? :linear : :nearest
+        data[:color_map] = Texture(screen.glscreen, colormap, minfilter = cm_interp)
         data[:color_norm] = colornorm
 
         if color isa Union{AbstractMatrix{<: Real}, AbstractArray{<: Real, 3}}

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -1023,11 +1023,10 @@ end
 
 function assemble_surface_robj!(data, screen::Screen, attr, args, input2glname)
     colorname = add_mesh_color_attributes!(
-        screen, data,
+        screen, attr, data,
         args.scaled_color,
         args.alpha_colormap,
         args.scaled_colorrange,
-        attr[:interpolate][]
     )
     @assert colorname == :image
 
@@ -1086,9 +1085,9 @@ end
 ################################################################################
 
 # mesh_inner part 1
-function add_mesh_color_attributes!(screen, data, color, colormap, colornorm, interpolate)
+function add_mesh_color_attributes!(screen, attr, data, color, colormap, colornorm)
     # Note: assuming el32convert, Pattern convert to happen in Makie or earlier elsewhere
-    interp = interpolate ? :linear : :nearest
+    interp = attr[:interpolate][] ? :linear : :nearest
     colorname = :vertex_color
 
     if color isa Colorant
@@ -1129,11 +1128,10 @@ end
 
 function assemble_mesh_robj!(data, screen::Screen, attr, args, input2glname)
     input2glname[:scaled_color] = add_mesh_color_attributes!(
-        screen, data,
+        screen, attr, data,
         args.scaled_color,
         args.alpha_colormap,
-        args.scaled_colorrange,
-        attr[:interpolate][]
+        args.scaled_colorrange
     )
 
     data[:normals] === nothing && delete!(data, :normals)

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -412,7 +412,7 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Scatter)
             :sdf_uv, :quad_scale, :quad_offset,
             :image, :lowclip_color, :highclip_color, :nan_color,
             :strokecolor, :strokewidth, :glowcolor, :glowwidth,
-            :model_f32c, :rotation, :transform_marker,
+            :model_f32c, :converted_rotation, :billboard, :transform_marker,
             :gl_indices, :gl_len, :marker_offset, :f32c_scale,
         ]
     end
@@ -439,7 +439,8 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Scatter)
         :glowcolor => :glow_color, :glowwidth => :glow_width,
         :model_f32c => :model, :transform_marker => :scale_primitive,
         :lowclip_color => :lowclip, :highclip_color => :highclip,
-        :gl_indices => :indices, :gl_len => :len
+        :gl_indices => :indices, :gl_len => :len,
+        :converted_rotation => :rotation
     )
 
     robj = register_robj!(assemble_scatter_robj!, screen, scene, plot, inputs, uniforms, input2glname)

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -159,7 +159,13 @@ function assemble_particle_robj!(attr, data)
     handle_color!(data, attr)
     handle_color_getter!(data)
 
-    data[:rotation] = get(()-> attr.text_rotation, attr, :rotation)
+    data[:rotation] = if haskey(attr, :converted_rotation)
+        attr.converted_rotation
+    elseif haskey(attr, :rotation)
+        attr.rotation
+    else
+        attr.text_rotation
+    end
     data[:f32c_scale] = attr.f32c_scale
 
     # Uniforms will be set in JavaScript
@@ -199,7 +205,8 @@ const SCATTER_INPUTS = [
     :lowclip_color,
     :pattern,
 
-    :rotation,
+    :converted_rotation,
+    :billboard,
     :quad_scale,
     :quad_offset,
     :sdf_uv,
@@ -229,7 +236,7 @@ function scatter_program(attr)
         :resolution => Vec2f(0),
         :preprojection => Mat4f(I),
         :atlas_texture_size => Float32(size(atlas.data, 2)),
-        :billboard => get(()-> attr.text_rotation, attr, :rotation) isa Billboard,
+        :billboard => haskey(attr, :converted_rotation) ? attr.billboard : true,
         :distancefield => distancefield,
 
         :marker_offset => attr.marker_offset,

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -20,7 +20,8 @@ conversion_trait(::Type{<: Text}, args...) = PointBased()
 
 convert_attribute(o, ::key"offset", ::key"text") = to_3d_offset(o) # same as marker_offset in scatter
 convert_attribute(f, ::key"font", ::key"text") = f # later conversion with fonts
-convert_attribute(align, ::key"align", ::key"text") = align # text also allows :baseline and resolves it later
+# text also allows :baseline and resolves it later
+convert_attribute(align, ::key"align", ::key"text") = Ref{Any}(align)
 
 # Positions are always vectors so text should be too
 convert_attribute(str::AbstractString, ::key"text", ::key"text") = [str]

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -342,13 +342,6 @@ function add_attributes!(::Type{T}, attr, kwargs) where {T}
     name = plotkey(T)
     is_primitive = T <: PrimitivePlotTypes
 
-    # Hack-fix variable types
-    abstract_type_init = Dict{Symbol, RefValue}(
-        :lowclip => RefValue{Union{Automatic, Colorant}}(automatic),
-        :highclip => RefValue{Union{Automatic, Colorant}}(automatic),
-        :colorrange => RefValue{Union{Automatic, VecTypes{2}, Tuple{<: Real, <: Real}}}(automatic),
-        :colorscale => RefValue{Any}(identity),
-    )
     for (k, v) in documented_attr
         if haskey(kwargs, k)
             if v isa Attributes
@@ -372,11 +365,6 @@ function add_attributes!(::Type{T}, attr, kwargs) where {T}
             end
         else
             add_input!((k,v) -> Ref{Any}(v), attr, k, value)
-        end
-
-        # Hack-fix variable type
-        if is_primitive && haskey(abstract_type_init, k)
-            attr[k].value = abstract_type_init[k]
         end
     end
     if !haskey(attr, :model)

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -619,7 +619,10 @@ function calculated_attributes!(::Type{Scatter}, plot::Plot)
     register_marker_computations!(attr)
     register_colormapping!(attr)
     register_position_transforms!(attr)
-    register_computation!(attr, [:positions, :space, :markerspace, :quad_scale, :quad_offset, :rotation],
+    register_computation!(attr, [:rotation], [:converted_rotation, :billboard]) do (rotation,), changed, cached
+        return (convert_attribute(rotation, key"rotation"()), rotation isa Billboard)
+    end
+    register_computation!(attr, [:positions, :space, :markerspace, :quad_scale, :quad_offset, :converted_rotation],
                           [:data_limits]) do args, changed, last
         return (scatter_limits(args...),)
     end

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -304,7 +304,7 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
         return args.converted # destructure
     end
 
-    add_input!((k, v) -> Ref{Any}(identity), attr, :transform_func, identity)
+    add_input!((k, v) -> Ref{Any}(v), attr, :transform_func, identity)
 
     # TODO: Should we get rid of model as a documented attribute?
     #       (On master, it acts as an overwrite, making translate!() etc not work)

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -378,10 +378,6 @@ function add_attributes!(::Type{T}, attr, kwargs) where {T}
         if is_primitive && haskey(abstract_type_init, k)
             attr[k].value = abstract_type_init[k]
         end
-        # text also allows :baseline and resolves it later
-        if T <: Makie.Text && k == :align
-            attr[k].value = RefValue{Any}((:center, :center))
-        end
     end
     if !haskey(attr, :model)
         add_input!(attr, :model, Mat4d(I))

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -907,17 +907,26 @@ end
 convert_attribute(x, key::Key, ::Key) = convert_attribute(x, key)
 convert_attribute(x, key::Key) = x
 
+convert_attribute(font, ::key"font") = to_font(font)
+convert_attribute(align, ::key"align") = to_align(align)
+
 convert_attribute(x::Automatic, ::key"color") = x
 convert_attribute(color, ::key"color") = to_color(color)
 
 convert_attribute(colormap, ::key"colormap") = to_colormap(colormap)
-convert_attribute(font, ::key"font") = to_font(font)
-convert_attribute(align, ::key"align") = to_align(align)
 
-convert_attribute(p, ::key"highclip") = to_color(p)
-convert_attribute(p::Union{Automatic, Nothing}, ::key"highclip") = p
-convert_attribute(p, ::key"lowclip") = to_color(p)
-convert_attribute(p::Union{Automatic,Nothing}, ::key"lowclip") = p
+convert_attribute(c, ::key"highclip") = Ref{Union{Automatic, RGBAf}}(to_color(c))
+convert_attribute(::Union{Automatic, Nothing}, ::key"highclip") = Ref{Union{Automatic, RGBAf}}(automatic)
+convert_attribute(c, ::key"lowclip") = Ref{Union{Automatic, RGBAf}}(to_color(c))
+convert_attribute(::Union{Automatic,Nothing}, ::key"lowclip") = Ref{Union{Automatic, RGBAf}}(automatic)
+
+convert_attribute(x, ::key"colorscale") = Ref{Any}(x)
+
+# TODO: is it worth typing this as Ref{Union{Automatic, VecTypes{2}, Tuple{<: Real, <: Real}}} ?
+convert_attribute(x::Automatic, ::key"colorrange") = Ref{Any}(x)
+convert_attribute(x, ::key"colorrange") = Ref{Any}(to_colorrange(x))
+to_colorrange(x) = isnothing(x) ? nothing : Vec2f(x)
+
 convert_attribute(p, ::key"nan_color") = to_color(p)
 
 struct Palette
@@ -1477,10 +1486,6 @@ to_rotation(s::Tuple{VecTypes, Number}) = qrotation(to_ndim(Vec3f, s[1], 0.0), s
 to_rotation(angle::Number) = qrotation(Vec3f(0, 0, 1), angle)
 to_rotation(r::AbstractVector) = to_rotation.(r)
 to_rotation(r::AbstractVector{<: Quaternionf}) = r
-
-convert_attribute(x::Automatic, ::key"colorrange") = x
-convert_attribute(x, ::key"colorrange") = to_colorrange(x)
-to_colorrange(x) = isnothing(x) ? nothing : Vec2f(x)
 
 convert_attribute(x, ::key"fontsize") = to_fontsize(x)
 to_fontsize(x::Number) = Float32(x)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -902,9 +902,9 @@ end
 
 
 
+# convert_attribute(s::SceneLike, x, key::Key, ::Key) = convert_attribute(s, x, key)
+# convert_attribute(s::SceneLike, x, key::Key) = convert_attribute(x, key)
 convert_attribute(x, key::Key, ::Key) = convert_attribute(x, key)
-convert_attribute(s::SceneLike, x, key::Key, ::Key) = convert_attribute(s, x, key)
-convert_attribute(s::SceneLike, x, key::Key) = convert_attribute(x, key)
 convert_attribute(x, key::Key) = x
 
 convert_attribute(x::Automatic, ::key"color") = x

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -948,6 +948,7 @@ function to_color(c::Tuple{<: Any,  <: Number})
     return RGBAf(Colors.color(col), alpha(col) * c[2])
 end
 
+convert_attribute(r, ::key"rotation", ::key"scatter") = Ref{Any}(r)
 convert_attribute(b::Billboard{Float32}, ::key"rotation") = to_rotation(b.rotation)
 convert_attribute(b::Billboard{Vector{Float32}}, ::key"rotation") = to_rotation.(b.rotation)
 convert_attribute(r::AbstractArray, ::key"rotation") = to_rotation.(r)


### PR DESCRIPTION
To allow typing `comuted.value` instead of generating `computed.value::RefValue{RefValue{...}}`

TODO:
- [x] adjusted init and updates of compute graph to resolve refs
- [x] update scatter rotation
- [x] replace abstract_type_init dict with conversion returning any-refs
- [x] replace text align with any-refs
- ~~add generic convert_attributes returning any-ref for recipes~~ seems easier not to? 3 lines vs like 10 methods?
- [x] fix color_mapping_type in GLMakie
- [ ] fix color CairoMakie, WGLMakie
- [ ] fix billboard for text (does text care?)