### PR TITLE
compute text changes

### DIFF
--- a/CairoMakie/src/new_primitives.jl
+++ b/CairoMakie/src/new_primitives.jl
@@ -277,7 +277,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Text
         marker_offset,
         text_rotation,
         text_scales,
-        strokewidth,
+        text_strokewidth,
         text_strokecolor,
         markerspace,
         transform_marker,
@@ -309,6 +309,7 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Text
             font = font_per_char[glyph_idx]
             rotation = Makie.sv_getindex(text_rotation, glyph_idx)
             color = Makie.sv_getindex(text_color, glyph_idx)
+            strokewidth = Makie.sv_getindex(text_strokewidth, glyph_idx)
             strokecolor = Makie.sv_getindex(text_strokecolor, glyph_idx)
             scale = Makie.sv_getindex(text_scales, glyph_idx)
 

--- a/CairoMakie/src/new_primitives.jl
+++ b/CairoMakie/src/new_primitives.jl
@@ -1,47 +1,6 @@
-# TODO:
-#   - Embed camera matrices in compute pipeline so we can easily and consistently
-#     do projections here
-
-# TODO: update Makie.Sampler to include lowclip, highclip, nan_color
-#       and maybe also just RGBAf color types?
-#       Or just move this to make as a more generic function?
-# Note: This assumes to be called with data from ComputePipeline, i.e.
-#       alpha and colorscale already applied
-function sample_color(
-        colormap::Vector{RGBAf}, value::Real, colorrange::VecTypes{2},
-        lowclip::RGBAf = first(colormap), highclip::RGBAf = last(colormap),
-        nan_color::RGBAf = RGBAf(0,0,0,0), interpolation = Makie.Linear
-    )
-    isnan(value) && return nan_color
-    value < colorrange[1] && return lowclip
-    value > colorrange[2] && return highclip
-    if interpolation == Makie.Linear
-        return Makie.interpolated_getindex(colormap, value, colorrange)
-    else
-        return Makie.nearest_getindex(colormap, value, colorrange)
-    end
-end
-
 function cairo_colors(@nospecialize(plot), color_name = :scaled_color)
-    Makie.register_computation!(plot.attributes::Makie.ComputeGraph,
-            [color_name, :scaled_colorrange, :alpha_colormap, :nan_color, :lowclip_color, :highclip_color],
-            [:cairo_colors]
-        ) do inputs, changed, cached
-        (color, colorrange, colormap, nan_color, lowclip, highclip) = inputs
-        # colormapping
-        if color isa AbstractArray{<:Real} || color isa Real
-            output = map(color) do v
-                return sample_color(colormap, v, colorrange, lowclip, highclip, nan_color)
-            end
-            return (output,)
-        else # Raw colors
-            # Avoid update propagation if nothing changed
-            !isnothing(last) && !changed[1] && return nothing
-            return (color,)
-        end
-    end
-
-    return plot.cairo_colors[]
+    Makie.add_computation!(plot.attributes, Val(:computed_color), color_name)
+    return plot.computed_color[]
 end
 
 function cairo_project_to_screen_impl(projectionview, resolution, model, pos, output_type = Point2f, yflip = true)
@@ -322,9 +281,9 @@ function draw_atomic(scene::Scene, screen::Screen, @nospecialize(primitive::Text
         text_strokecolor,
         markerspace,
         transform_marker,
+        text_color
     ))
 
-    text_color = cairo_colors(primitive, :text_color)
     ctx = screen.context
     attr = primitive.attributes::Makie.ComputeGraph
 

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -510,8 +510,11 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Text)
     generate_clip_planes!(attr)
 
     # TODO:
-    # - rotation -> billboard missing
     # - intensity_convert
+
+    # TODO:
+    # text_strokewidth doesn't work because the shader only accepts a uniform float
+    # this is also true on master
 
     # To take the human error out of the bookkeeping of two lists
     # Could also consider using this in computation since Dict lookups are

--- a/GLMakie/src/new-primitives.jl
+++ b/GLMakie/src/new-primitives.jl
@@ -457,24 +457,10 @@ end
 ################################################################################
 
 function assemble_text_robj!(data, screen::Screen, attr, args, input2glname)
-    colormap = args.alpha_colormap
-    color = args.text_color
-    colornorm = args.scaled_colorrange
-
     data[:distancefield] = get_texture!(screen.glscreen, args.atlas)
     data[:shape] = Cint(DISTANCEFIELD)
     data[:image] = nothing
     data[:rotation] = args.text_rotation
-
-    add_color_attributes!(screen, attr, data, color, colormap, colornorm)
-
-    # Correct the name mapping
-    if !isnothing(get(data, :intensity, nothing))
-        input2glname[:scaled_color] = :intensity
-    end
-    if !isnothing(get(data, :image, nothing))
-        input2glname[:scaled_color] = :image
-    end
 
     # pass nothing to avoid going into image generating functions
     return draw_scatter(screen, (nothing, data[:position]), data)
@@ -507,17 +493,12 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Text)
 
     Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
 
-    inputs = [
-        # Special
-        :atlas,
-        # Needs explicit handling
-        :alpha_colormap, :text_color, :scaled_colorrange,
-    ]
+    inputs = [:atlas,]
 
     # Simple forwards
     uniforms = [
-        :positions_transformed_f32c, # :text_color,
-        :text_strokecolor, :text_rotation,
+        :positions_transformed_f32c,
+        :text_color, :text_strokecolor, :text_rotation,
         :marker_offset, :quad_offset, :sdf_uv, :quad_scale,
         :lowclip_color, :highclip_color, :nan_color,
         :strokewidth, :glowcolor, :glowwidth,
@@ -538,8 +519,6 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Text)
     input2glname = Dict{Symbol, Symbol}(
         :text_rotation => :rotation,
         :positions_transformed_f32c => :position,
-        :alpha_colormap => :color_map,
-        :scaled_colorrange => :color_norm,
         :text_color => :color,
         :sdf_uv => :uv_offset_width,
         :gl_markerspace => :markerspace,

--- a/WGLMakie/assets/sprites.frag
+++ b/WGLMakie/assets/sprites.frag
@@ -22,6 +22,7 @@ in vec4 frag_uv_offset_width;
 flat in uint frag_instance_id;
 in float o_clip_distance[8];
 flat in vec2 f_sprite_scale;
+flat in vec4 frag_strokecolor;
 
 uniform int num_clip_planes;
 
@@ -182,7 +183,7 @@ void main() {
     vec4 final_color = fill(frag_color, uniform_color, frag_uv);
     final_color.a = final_color.a * inside;
 
-    stroke(get_strokecolor(), signed_distance, -stroke_width, final_color, aa_radius);
+    stroke(frag_strokecolor, signed_distance, -stroke_width, final_color, aa_radius);
     glow(get_glowcolor(), signed_distance, aastep(-stroke_width, signed_distance, aa_radius), final_color);
 
     // debug - show background

--- a/WGLMakie/assets/sprites.vert
+++ b/WGLMakie/assets/sprites.vert
@@ -14,6 +14,7 @@ out float frag_uvscale;
 out float frag_distancefield_scale;
 out vec4 frag_uv_offset_width;
 out float o_clip_distance[8];
+flat out vec4 frag_strokecolor;
 
 flat out uint frag_instance_id;
 flat out vec2 f_sprite_scale;
@@ -152,6 +153,7 @@ void main(){
     vec2 uv_pad_scale = padded_bbox_size / bbox_radius;
 
     frag_color = tovec4(get_vertex_color());
+    frag_strokecolor = tovec4(get_strokecolor());
     frag_uv_offset_width = get_sdf_uv();
     // get_uv() returns (0, 0), (1, 0), (0, 1) or (1, 1)
     // to accomodate stroke and glowwidth we need to extrude uv's outwards from (0.5, 0.5)

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -349,7 +349,7 @@ function create_shader(scene::Scene, plot::Makie.Text)
         :vertex_color, :uniform_color, :uniform_colormap, :uniform_colorrange, :nan_color, :highclip_color, :lowclip_color, :pattern,
         :strokewidth, :glowwidth, :glowcolor,
 
-        :text_rotation, :text_strokecolor, # TODO: do these even work per glyph?
+        :text_rotation, :text_strokecolor,
         :marker_offset, :sdf_marker_shape, :glyph_data,
         # :quad_scale, :quad_offset, :sdf_uv,
         :depth_shift, :atlas, :markerspace,

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -206,6 +206,9 @@ function convert_text_string!(
     append!(outputs.text_rotation, rotations)
     append!(outputs.text_scales, scales)
 
+    append!(outputs.text_strokecolor, per_glyph_block(strokecolor, i, N, block))
+    append!(outputs.text_strokewidth, per_glyph_block(strokewidth, i, N, block))
+
     return
 end
 
@@ -228,8 +231,8 @@ function convert_text_string!(
 
     append!(outputs.font_per_char, collect_vector(gc.fonts, n))
     append!(outputs.text_color, collect_vector(gc.colors, n))
-    # append!(outputs.text_strokecolor, collect_vector(gc.strokecolors, n))
-    # append!(outputs.strokewidth, collect_vector(gc.strokewidths, n))
+    append!(outputs.text_strokecolor, collect_vector(gc.strokecolors, n))
+    append!(outputs.text_strokewidth, collect_vector(gc.strokewidths, n))
     append!(outputs.text_rotation, collect_vector(gc.rotations, n))
     append!(outputs.text_scales, collect_vector(gc.scales, n))
 
@@ -254,8 +257,8 @@ function convert_text_string!(
     append!(outputs.glyph_extents, gc.extents)
     append!(outputs.font_per_char, collect_vector(gc.fonts, n))
     append!(outputs.text_color, collect_vector(gc.colors, n))
-    # append!(outputs.text_strokecolor, collect_vector(gc.strokecolors, n))
-    # append!(outputs.strokewidth, collect_vector(gc.strokewidths, n))
+    append!(outputs.text_strokecolor, collect_vector(gc.strokecolors, n))
+    append!(outputs.text_strokewidth, collect_vector(gc.strokewidths, n))
     append!(outputs.text_rotation, collect_vector(gc.rotations, n))
     append!(outputs.text_scales, collect_vector(gc.scales, n))
 
@@ -288,7 +291,9 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :text_blocks,
         :text_color,
         :text_rotation,
-        :text_scales
+        :text_scales,
+        :text_strokewidth,
+        :text_strokecolor,
     ]
     register_computation!(attr, inputs, outputs) do (input_texts, _inputs...), changed, cached
         if isnothing(cached)
@@ -302,6 +307,8 @@ function compute_glyph_collections!(attr::ComputeGraph)
                 text_color = RGBAf[],
                 text_rotation = Quaternionf[],
                 text_scales = Vec2f[],
+                text_strokewidth = Float32[],
+                text_strokecolor = RGBAf[]
             )
         else
             foreach(empty!, values(cached))
@@ -317,8 +324,6 @@ function compute_glyph_collections!(attr::ComputeGraph)
         return values(_outputs)
     end
 
-    # TODO: per-glyph strokecolor and strokewidth?
-    map!(identity, attr, :strokecolor, :text_strokecolor)
 end
 
 function register_text_computations!(attr::ComputeGraph)

--- a/src/basic_recipes/text.jl
+++ b/src/basic_recipes/text.jl
@@ -275,7 +275,7 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :word_wrap_width,
         :offset,
         :fonts,
-        :color,
+        :computed_color,
         :strokecolor,
         :strokewidth
     ]
@@ -331,6 +331,10 @@ function register_text_computations!(attr::ComputeGraph)
     register_computation!(attr, [:fonts, :font], [:selected_font]) do (fs, f), changed, cached
         return (to_font(fs, f),)
     end
+
+    # Resolve colormapping to colors early. This allows rich text which returns
+    # its own colors to be mixed with other text types which dont.
+    add_computation!(attr, Val(:computed_color))
 
     # This computes :glyphindices, :font_per_char, :glyph_origins, :glyph_extents, :text_blocks
     # And :glyphcollection if applicable

--- a/src/layouting/text_layouting.jl
+++ b/src/layouting/text_layouting.jl
@@ -137,6 +137,16 @@ This layout in text coordinates, relative to the anchor point [0,0] can then be 
 rotated to wherever it is needed in the plot.
 """
 function glyph_collection(
+        str::AbstractString, font_per_char, fontscale_px, (halign, valign),
+        lineheight_factor, justification, word_wrap_width, rotation
+    )
+    return glyph_collection(
+        str, font_per_char, fontscale_px, halign, valign,
+        lineheight_factor, justification, word_wrap_width, rotation
+    )
+end
+
+function glyph_collection(
         str::AbstractString, font_per_char, fontscale_px, halign, valign,
         lineheight_factor, justification, word_wrap_width, rotation
     )


### PR DESCRIPTION
Changes:
- refactor text to do layouting per string (fixes PolarAxis decorations test error)
- move cairo's colormap resolution to Makie and use it to resolve colors early. This fixes "Scalar colors from colormaps"
- process strokewidth and color and enable at least per-element strokecolor in all backends