### PR TITLE
deprecate `attr[key] = Observable` (compute)

### DIFF
--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -224,7 +224,12 @@ function get_observable!(attr::ComputeGraph, key::Symbol)
         result = Observable(val[])
         on(attr.onchange) do _
             _val = val[]
-            if !is_same(result[], _val)
+            # Using !is_same(result[], _val) here results in StackOverflows
+            # from Observables repeatedly updating, e.g. tricontourf:
+            #   c.attributes[:_computed_levels] = lift(..., c, zs, c.levels, c.mode)
+            #   which calls add_input!(attr, :_computed_levels, obs)
+            # will infinitely update zs (_arg2) when levels get updated
+            if result[] != _val
                 result[] = _val
             end
             return Consume(false)

--- a/src/compute-plots.jl
+++ b/src/compute-plots.jl
@@ -17,6 +17,18 @@ function Base.setindex!(plot::Plot, val, key::Int)
     setindex!(plot, val, sym)
 end
 
+Base.setindex!(plot::Plot, val::Observable, key::Symbol) = setindex!(plot.attributes, val, key)
+function Base.setindex!(attr::ComputeGraph, val::Observable, key::Symbol)
+    @warn "`plot[key] = val::Observable` is deprecated. If the observable is produced by `lift` or `map` use the compute graph directly with `register_computation!()` or keep the Observable seperately. If you are trying to add an input, use `add_input!()`."
+
+    # This assumes a user may also do plot[key] = Observable(...) to create a
+    # new attribute input, that they later update (1)
+    add_input!(attr, key, val)
+
+    # (1) implies that val is not the only source of updates. So we do need to
+    # react to onchange
+    return ComputePipeline.get_observable!(attr, key)
+end
 
 function data_limits(plot::Plot)
     if haskey(plot, :data_limits)

--- a/src/makielayout/blocks/colorbar.jl
+++ b/src/makielayout/blocks/colorbar.jl
@@ -43,7 +43,8 @@ function extract_colormap(plot::Plot{volumeslices})
     return extract_colormap(plot.plots[1])
 end
 
-function extract_colormap(plot::Union{Contourf,Tricontourf})
+# TODO: revert to _names?
+function extract_colormap(plot::Contourf)
     levels = ComputePipeline.get_observable!(plot.computed_levels)
     limits = lift(l -> (l[1], l[end]), levels)
     function extend_color(color, computed)
@@ -57,6 +58,23 @@ function extract_colormap(plot::Union{Contourf,Tricontourf})
         ComputePipeline.get_observable!(plot.computed_colormap), limits,
         ComputePipeline.get_observable!(plot.colorscale), Observable(1.0),
         elow, ehigh, ComputePipeline.get_observable!(plot.nan_color))
+end
+
+function extract_colormap(plot::Tricontourf)
+    levels = plot._computed_levels
+    limits = lift(l -> (l[1], l[end]), levels)
+    function extend_color(color, computed)
+        color === nothing && return automatic
+        color == :auto || color == automatic && return computed
+        return computed
+    end
+    elow = lift(extend_color, plot.extendlow, plot._computed_extendlow)
+    ehigh = lift(extend_color, plot.extendhigh, plot._computed_extendhigh)
+    return ColorMapping(levels[], levels,
+        ComputePipeline.get_observable!(plot._computed_colormap), limits,
+        ComputePipeline.get_observable!(plot.colorscale), Observable(1.0),
+        elow, ehigh, ComputePipeline.get_observable!(plot.nan_color)
+    )
 end
 
 function extract_colormap(plot::Voxels)


### PR DESCRIPTION
This is meant to not completely break things like:
```julia
c.attributes[:_computed_levels] = lift(c, zs, c.levels, c.mode) do zs, levels, mode
    return _get_isoband_levels(Val(mode), levels, vec(zs))
end
```

and maybe also

```julia
plot[:my_attr] = Observable(...)
```