### PR TITLE
fix the error, that no screen is open

### DIFF
--- a/WGLMakie/src/events.jl
+++ b/WGLMakie/src/events.jl
@@ -121,20 +121,12 @@ function connect_scene_events!(screen::Screen, scene::Scene, comm::Observable)
     return
 end
 
-
 function connect_post_init_events(screen, scene)
-    for attempt in 1:10
-        isopen(screen) && break
-        sleep(0.1 * attempt)
-    end
-    @assert isopen(screen) "Window must be initialized first"
-
     e = events(scene)
     tick_callback = Makie.TickCallback(e.tick)
-
     # key = rand(UInt16) # Is the right clock closing?
     Makie.start!(screen.tick_clock) do timer
-        if isopen(screen)
+        if !Makie.isclosed(scene)
             tick_callback(Makie.RegularRenderTick)
             # @info "$key tick $(e.tick[].count) $(e.tick[].delta_time)"
         else
@@ -144,7 +136,5 @@ function connect_post_init_events(screen, scene)
         end
         return
     end
-
     return
 end
-


### PR DESCRIPTION
In some not yet determined circumstances, the screen doesn't seem to open, even though everything should be open at the point where `connect_post_init_events` is called.
We should debug those circumstances, but for now, this should also be the correct way to handle things, avoiding the screen open check.
