### PR TITLE
onchange propagation (compute)

### DIFF
--- a/ComputePipeline/Project.toml
+++ b/ComputePipeline/Project.toml
@@ -12,6 +12,7 @@ julia = "1.6.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Random"]

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -335,6 +335,7 @@ function resolve!(input::Input)
 end
 
 function mark_dirty!(input::Input, obs_to_update::Vector{Observable})
+    push!(input.graph.onchange.val, input.name)
     if !(input.graph.onchange in obs_to_update)
         push!(obs_to_update, input.graph.onchange)
     end

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -216,6 +216,7 @@ struct ComputeGraph
     onchange::Observable{Set{Symbol}}
     observables::Dict{Symbol,Observable}
     observerfunctions::Vector{Observables.ObserverFunction}
+    obs_to_update::Vector{Observable}
 end
 
 function get_observable!(attr::ComputeGraph, key::Symbol)
@@ -268,9 +269,11 @@ function ComputeEdge(f, graph::ComputeGraph, inputs::Vector{Computed})
 end
 
 function ComputeGraph()
+    onchange = Observable(Set{Symbol}())
+    on(empty!, onchange, priority = typemin(Int)) # clear changeset after processing observables
     return ComputeGraph(
-        Dict{Symbol,ComputeEdge}(), Dict{Symbol,Computed}(), Observable(Set{Symbol}()),
-        Dict{Symbol,Observable}(), Observables.ObserverFunction[])
+        Dict{Symbol,ComputeEdge}(), Dict{Symbol,Computed}(), onchange,
+        Dict{Symbol,Observable}(), Observables.ObserverFunction[], Observable[])
 end
 
 _first_arg(args, changed, last) = (args[1],)
@@ -294,20 +297,24 @@ function isdirty(edge::ComputeEdge)
     return any(edge.inputs_dirty)
 end
 
-function mark_dirty!(edge::ComputeEdge)
+function mark_dirty!(edge::ComputeEdge, obs_to_update::Vector{Observable})
+    # Assumes this is the same graph as edge.outputs (for parent -> child graph edges)
+    g = edge.graph
+    for output in edge.outputs
+        push!(g.onchange.val, output.name)
+        g.onchange in obs_to_update || push!(obs_to_update, g.onchange)
+    end
+
     edge.got_resolved[] = false
     for dep in edge.dependents
-        mark_dirty!(dep)
-    end
-    for output in edge.outputs
-        push!(edge.graph.onchange.val, output.name)
+        mark_dirty!(dep, obs_to_update)
     end
     return
 end
 
-function mark_dirty!(computed::Computed)
+function mark_dirty!(computed::Computed, obs_to_update::Vector{Observable})
     hasparent(computed) || return
-    return mark_dirty!(computed.parent)
+    return mark_dirty!(computed.parent, obs_to_update)
 end
 
 function resolve!(input::Input)
@@ -327,12 +334,29 @@ function resolve!(input::Input)
     return input.output.value[]
 end
 
-function mark_dirty!(input::Input)
+function mark_dirty!(input::Input, obs_to_update::Vector{Observable})
+    if !(input.graph.onchange in obs_to_update)
+        push!(obs_to_update, input.graph.onchange)
+    end
+
     input.dirty = true
     for edge in input.dependents
-        mark_dirty!(edge)
+        mark_dirty!(edge, obs_to_update)
     end
-    push!(input.graph.onchange.val, input.name)
+    return
+end
+
+function mark_dirty_and_notify!(node::Input)
+    obs_to_update = empty!(node.graph.obs_to_update)
+    mark_dirty!(node, obs_to_update)
+    foreach(notify, obs_to_update)
+    return
+end
+
+function mark_dirty_and_notify!(node::Computed)
+    obs_to_update = empty!(node.parent.graph.obs_to_update)
+    mark_dirty!(node, obs_to_update)
+    foreach(notify, obs_to_update)
     return
 end
 
@@ -341,23 +365,23 @@ function Base.setindex!(computed::Computed, value)
         return setindex!(computed.parent, value)
     else
         computed.value[] = value
-        return mark_dirty!(computed)
+        mark_dirty_and_notify!(computed)
+        return value
     end
 end
 
 function Base.setindex!(input::Input, value)
     input.value = value
-    return mark_dirty!(input)
+    mark_dirty_and_notify!(input)
+    return value
 end
 
 function _setproperty!(attr::ComputeGraph, key::Symbol, value)
-    empty!(attr.onchange.val)
     input = attr.inputs[key]
     # Skip if the value is the same as before
     is_same(input.value, value) && return value
     input.value = value
-    mark_dirty!(input)
-    notify(attr.onchange)
+    mark_dirty_and_notify!(input)
     return value
 end
 
@@ -419,6 +443,7 @@ function Base.getproperty(attr::ComputeGraph, key::Symbol)
     key === :onchange && return getfield(attr, :onchange)
     key === :observables && return getfield(attr, :observables)
     key === :observerfunctions && return getfield(attr, :observerfunctions)
+    key === :obs_to_update && return getfield(attr, :obs_to_update)
     return attr.outputs[key]
 end
 

--- a/ComputePipeline/test/runtests.jl
+++ b/ComputePipeline/test/runtests.jl
@@ -2,6 +2,7 @@ using ComputePipeline
 using Test
 
 using ComputePipeline: InputFunctionWrapper, isdirty, ResolveException
+using ComputePipeline: Observables
 
 @testset "ComputePipeline.jl" begin
     include("unit_tests.jl")

--- a/ComputePipeline/test/runtests.jl
+++ b/ComputePipeline/test/runtests.jl
@@ -1,5 +1,6 @@
 using ComputePipeline
 using Test
+using Random
 
 using ComputePipeline: InputFunctionWrapper, isdirty, ResolveException
 using ComputePipeline.Observables

--- a/ComputePipeline/test/runtests.jl
+++ b/ComputePipeline/test/runtests.jl
@@ -2,7 +2,7 @@ using ComputePipeline
 using Test
 
 using ComputePipeline: InputFunctionWrapper, isdirty, ResolveException
-using ComputePipeline: Observables
+using ComputePipeline.Observables
 
 @testset "ComputePipeline.jl" begin
     include("unit_tests.jl")

--- a/ComputePipeline/test/unit_tests.jl
+++ b/ComputePipeline/test/unit_tests.jl
@@ -416,7 +416,7 @@ end
 
     @testset "map and on" begin
         g = ComputeGraph()
-        add_input!((k, x) -> Float64.(x), g, :input1, 1)
+        add_input!((k, x) -> Float64.(x), g, :input1, 0)
         add_input!((k, x) -> Float64.(x), g, :input2, 4)
         register_computation!(g, [:input1, :input2], [:xy, :yx]) do (x,y), changed, cached
             return (x-y, y-x)
@@ -432,6 +432,7 @@ end
         @test_throws UndefRefError obs[]
         @test haskey(g.observables, :mult)
         @test length(g.observables) == 1
+        update!(g, input1 = 1)
 
         obs2 = map(x -> 2 .* x, g.out2)
         @test obs2[] == 8.0
@@ -450,7 +451,7 @@ end
             counter[] += 1
             return
         end
-        ComputePipeline.update!(g, input1 = 2, input2 = 5)
+        ComputePipeline.update!(g, input1 = 2, input2 = 8)
         @test counter[] == 4
 
     end

--- a/src/basic_recipes/buffers.jl
+++ b/src/basic_recipes/buffers.jl
@@ -36,9 +36,9 @@ end
 
 function finish!(lsb::LineSegments)
     # update the signal!
-    ComputePipeline.mark_dirty!(lsb[:arg1])
-    ComputePipeline.mark_dirty!(lsb[:color])
-    ComputePipeline.mark_dirty!(lsb[:linewidth])
+    ComputePipeline.mark_dirty_and_notify!(lsb[:arg1])
+    ComputePipeline.mark_dirty_and_notify!(lsb[:color])
+    ComputePipeline.mark_dirty_and_notify!(lsb[:linewidth])
     notify(lsb.attributes.onchange)
     return
 end
@@ -76,7 +76,7 @@ function finish!(tb::Text)
     # now update all callbacks
     attr = tb.attributes
     for key in (:arg1, :text, :color, :rotation, :fontsize, :font, :align)
-        ComputePipeline.mark_dirty!(attr.inputs[key])
+        ComputePipeline.mark_dirty_and_notify!(attr.inputs[key])
     end
     if length(tb[1][]) != length(tb.fontsize[])
         error("Inconsistent buffer state for $(tb[1][])")

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -183,7 +183,7 @@ function handle_transformation!(plot, parent)
     # TODO: Consider removing Transformation() and handling this in compute graph
     # connect updates
     # TODO: These should not be added as inputs. But how do we update them otherwise?
-    if haskey(plot, :model)
+    if haskey(plot, :model) && haskey(plot.attributes.inputs, :model)
         on(model -> update!(plot, model = model), plot, transformationmatrix(plot), update = true)
     else
         add_input!(plot.attributes, :model, transformationmatrix(plot))


### PR DESCRIPTION
This changes how `onchange` is triggered and cleared so that multiple onchange observables can be triggered when multiple graphs are connected. This fixes issues where a child graph does not trigger obseravbles when the parent graph is updated.

The way this works is that it collects every unique `edge.graph.onchange` it comes across in `mark_dirty!(edge)` in a vector. After marking is done, every observable gets notified, which triggers all the registered observable updates. To make sure the the changeset in onchange gets cleared for child graphs, it now clears `on(onchange)` with minimal priority (i.e. at the end of a trigger)