### PR TITLE
fix precompilation bug on `1.13`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-- Fixed precompilation bug in julia dev 1.13 [#5008](https://github.com/MakieOrg/Makie.jl/pull/5008).
+- Fixed precompilation bug in julia dev 1.13 [#5018](https://github.com/MakieOrg/Makie.jl/pull/5018).
 - Fixed screen not open assertion and `Makie.isclosed(scene)` in WGLMakie [#5008](https://github.com/MakieOrg/Makie.jl/pull/5008).
 
 ## [0.22.7] - 2025-05-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-
+- Fixed precompilation bug in julia dev 1.13 [#5008](https://github.com/MakieOrg/Makie.jl/pull/5008).
 - Fixed screen not open assertion and `Makie.isclosed(scene)` in WGLMakie [#5008](https://github.com/MakieOrg/Makie.jl/pull/5008).
 
 ## [0.22.7] - 2025-05-23

--- a/MakieCore/src/recipes.jl
+++ b/MakieCore/src/recipes.jl
@@ -5,9 +5,7 @@ to_func_name(x::Symbol) = Symbol(lowercase(string(x)))
 # Will get overloaded by recipe Macro
 plotsym(x) = :plot
 
-function func2string(func::F) where F <: Function
-    string(F.name.mt.name)
-end
+func2string(func::Function) = string(nameof(func))
 
 plotfunc(::Plot{F}) where F = F
 plotfunc(::Type{<: AbstractPlot{Func}}) where Func = Func

--- a/MakieCore/test/runtests.jl
+++ b/MakieCore/test/runtests.jl
@@ -38,3 +38,8 @@ used_attributes(::Any, x::Solution) = (:attribute,)
 function convert_arguments(p::MakieCore.PointBased, x::Solution; attribute = 1.0)
     return convert_arguments(p, x.data .* attribute)
 end
+
+@testset "func2string" begin
+    @test MakieCore.func2string(cos) == "cos"
+    @test startswith(MakieCore.func2string(x -> x), "#")
+end


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes https://github.com/MakieOrg/Makie.jl/issues/5018.
Tested `CairoMakie`, `GLMakie`, `WGLMakie` on `Julia Version 1.13.0-DEV.680`.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)