### PR TITLE
clean up/rework text bounding boxes

### DIFF
--- a/.github/workflows/reference_tests.yml
+++ b/.github/workflows/reference_tests.yml
@@ -6,6 +6,7 @@ on:
       - '*.md'
     branches:
       - master
+      - sd/compute-graph
   push:
     tags:
       - '*'

--- a/src/basic_recipes/contours.jl
+++ b/src/basic_recipes/contours.jl
@@ -283,7 +283,7 @@ function plot!(plot::T) where T <: Union{Contour, Contour3d}
         return
     end
 
-    bboxes = per_string_boundingboxes_obs(texts)
+    bboxes = string_boundingboxes_obs(texts)
 
     masked_lines = lift(plot, labels, bboxes, points) do labels, bboxes, segments
         labels || return segments

--- a/src/camera/camera.jl
+++ b/src/camera/camera.jl
@@ -258,10 +258,18 @@ function get_view(graph::ComputeGraph, space::Symbol)
     return Mat4f(space === :data ? graph[Symbol(:world_to_eye)][] : Mat4d(I))
 end
 
-function get_preprojection(graph::ComputeGraph, space::Symbol, markerspace::Symbol)
-    key1 = ifelse(space === :data, :world, space)
-    key2 = ifelse(markerspace === :data, :world, markerspace)
+"""
+    get_space_to_space_matrix(scene_graph, input_space, output_space)
+
+Return a camera matrix that transforms from `input_space` to `output_space`.
+"""
+function get_space_to_space_matrix(graph::ComputeGraph, input_space::Symbol, output_space::Symbol)
+    key1 = ifelse(input_space === :data, :world, input_space)
+    key2 = ifelse(output_space === :data, :world, output_space)
     return Mat4f(graph[Symbol(key1, :_to_, key2)][])
+end
+function get_preprojection(graph::ComputeGraph, space::Symbol, markerspace::Symbol)
+    return get_space_to_space_matrix(graph, space, markerspace)
 end
 
 

--- a/src/camera/projection_math.jl
+++ b/src/camera/projection_math.jl
@@ -364,9 +364,19 @@ end
 
 function _project(matrix::Mat4{T1}, ps::AbstractArray{<: VecTypes{N, T2}}, dim4::Real = 1.0) where {N, T1 <: Real, T2 <: Real}
     T = promote_type(Float32, T1, T2)
+    matrix == Mat4{T1}(I) && return to_ndim.(Point3{T}, ps, 0)
     ps4 = to_ndim.(Point4{T}, to_ndim.(Point3{T}, ps, 0.0), dim4)
     ps4 = [matrix * p for p in ps4]
-    return [Point3{T}(p) / p[4] for p in ps4]
+    return Point3{T}[Point3{T}(p) / p[4] for p in ps4]
+end
+
+function _project(matrix::Mat4{T1}, r::Rect3{T2}, dim4::Real = 1.0) where {T1 <: Real, T2 <: Real}
+    T = promote_type(Float32, T1, T2)
+    if matrix == Mat4{T1}(I)
+        return Rect3{T}(r)
+    else
+        return Rect3{T}(_project(matrix, coordinates(r), dim4))
+    end
 end
 
 

--- a/src/layouting/data_limits.jl
+++ b/src/layouting/data_limits.jl
@@ -131,6 +131,10 @@ function update_boundingbox(a::Rect{N}, b::Rect{N}) where N
     return Rect{N}(mini, maxi - mini)
 end
 
+function maximum_widths(bounding_boxes::AbstractArray{<: Rect{N, T}}) where {N, T}
+    return mapreduce(widths, (a,b) -> max.(a, b), bounding_boxes, init = Vec{N, T}(0))
+end
+
 foreach_plot(f, s::Scene) = foreach_plot(f, s.plots)
 # foreach_plot(f, s::Figure) = foreach_plot(f, s.scene)
 # foreach_plot(f, s::FigureAxisPlot) = foreach_plot(f, s.figure)

--- a/src/layouting/text_boundingbox.jl
+++ b/src/layouting/text_boundingbox.jl
@@ -1,5 +1,3 @@
-@deprecate boundingbox(plot::Text) boundingbox(plot, plot.markerspace[])
-
 function boundingbox(plot::Text, target_space::Symbol)
     # TODO:
     # This is temporary prep work for the future. We should actually consider
@@ -8,94 +6,23 @@ function boundingbox(plot::Text, target_space::Symbol)
     # We may also want a cheap version that only considers forward
     # transformations (i.e. drops textsize etc when markerspace is not part of
     # the plot.space -> target_space conversion chain)
-    if Makie.is_data_space(target_space)
-        # This also transforms string boundingboxes if space == markerspace
-        return apply_transform_and_model(plot, data_limits(plot))
-    elseif target_space == plot.markerspace[]
-        return string_boundingbox(plot)
+    if target_space == plot.markerspace[]
+        return full_boundingbox(plot, target_space)
+    elseif Makie.is_data_space(target_space)
+        return _project(plot.model_f32c[]::Mat4f, Rect3d(plot.positions_transformed_f32c[])::Rect3d)
     else
         error("`target_space = :$target_space` must be either :data or markerspace = :$(plot.markerspace[])")
     end
 end
 
-
-# TODO: Naming: not px, it's whatever markerspace is...
-# function string_boundingbox(plot::Text)
-#     bb = Rect3d()
-#     for p in plot.plots
-#         _bb = string_boundingbox(p)
-#         if !isfinite_rect(bb)
-#             bb = _bb
-#         elseif isfinite_rect(_bb)
-#             bb = union(bb, _bb)
-#         end
-#     end
-#     return bb
-# end
-
-# Text can contain linesegments. Use data_limits to avoid transformations as
-# they are already in markerspace
-string_boundingbox(x::LineSegments) = data_limits(x)
-
-function string_boundingbox(x::Text{<:Tuple{<:GlyphCollection}})
-    if x.space[] == x.markerspace[]
-        pos = to_ndim(Point3d, x.position[], 0)
-    else
-        cam = parent_scene(x).camera
-        transformed = apply_transform_and_model(x, x.position[])
-        pos = Makie.project(cam, x.space[], x.markerspace[], transformed)
-    end
-    return string_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
-end
-
-function string_boundingbox(x::Text{<:Tuple{<:AbstractArray{<:GlyphCollection}}})
-    if x.space[] == x.markerspace[]
-        pos = to_ndim.(Point3d, x.position[], 0)
-    else
-        cam = (parent_scene(x).camera,)
-        transformed = apply_transform_and_model(x, x.position[])
-        pos = Makie.project.(cam, x.space[], x.markerspace[], transformed) # TODO: vectorized project
-    end
-    return string_boundingbox(x[1][], pos, to_rotation(x.rotation[]))
-end
-
-function string_boundingbox(x::Union{GlyphCollection,AbstractArray{<:GlyphCollection}}, args...)
-    bb = unchecked_boundingbox(x, args...)
-    # isfinite_rect(bb) || error("Invalid text boundingbox $bb")
-    return bb
-end
+@deprecate string_boundingbox(plot::Text) full_boundingbox(plot::Text)
+# @deprecate unchecked_boundingbox string_boundingboxes
 
 # Utility
 function text_bb(str, font, size)
     rot = Quaternionf(0,0,0,1)
     layout = glyph_collection(str, font, size, 0f0, 0f0, 0f0, 0f0, -1, rot)
     return unchecked_boundingbox(layout.glyphindices, layout.char_origins, size, layout.glyph_extents, rot)
-end
-
-
-################################################################################
-
-function unchecked_boundingbox(glyphcollection::GlyphCollection, position::Point3, rotation::Quaternion)
-    return unchecked_boundingbox(glyphcollection, rotation) + position
-end
-
-function unchecked_boundingbox(glyphcollection::GlyphCollection, rotation::Quaternion)
-    isempty(glyphcollection.glyphs) && return Rect3d(Point3d(0), Vec3d(0))
-
-    glyphorigins = glyphcollection.origins
-    glyphbbs = gl_bboxes(glyphcollection)
-
-    bb = Rect3d()
-    for (charo, glyphbb) in zip(glyphorigins, glyphbbs)
-        glyphbb3 = Rect3d(to_ndim(Point3d, origin(glyphbb), 0), to_ndim(Point3d, widths(glyphbb), 0))
-        charbb = rotate_bbox(glyphbb3, rotation) + charo
-        if !isfinite_rect(bb)
-            bb = charbb
-        else
-            bb = union(bb, charbb)
-        end
-    end
-    return bb
 end
 
 function unchecked_boundingbox(glyphs, origins, scales, extents, rotation)
@@ -114,51 +41,12 @@ function unchecked_boundingbox(glyphs, origins, scales, extents, rotation)
     return bb
 end
 
-function unchecked_boundingbox(glyphbbs, origins, rotation)
-    isempty(glyphbbs) && return Rect3d(Point3d(0), Vec3d(0))
-    bb = Rect3d()
-    broadcast_foreach(origins, glyphbbs, rotation) do charo, glyphbb, rotation
-        glyphbb3 = Rect3d(to_ndim(Point3d, origin(glyphbb), 0), to_ndim(Point3d, widths(glyphbb), 0))
-        charbb = rotate_bbox(glyphbb3, rotation) + charo
-        if !isfinite_rect(bb)
-            bb = charbb
-        else
-            bb = union(bb, charbb)
-        end
-    end
-    return bb
-end
-
-function unchecked_boundingbox(layouts::AbstractArray{<:GlyphCollection}, positions, rotations)
-    isempty(layouts) && return Rect3d((0, 0, 0), (0, 0, 0))
-
-    bb = Rect3d()
-    broadcast_foreach(layouts, positions, rotations) do layout, pos, rot
-        if !isfinite_rect(bb)
-            bb = string_boundingbox(layout, pos, rot)
-        else
-            bb = union(bb, string_boundingbox(layout, pos, rot))
-        end
-    end
-    return bb
-end
-
-
-################################################################################
-
-# used
-
 function gl_bboxes(glyphs, scales, extents)
     broadcast(glyphs, extents, scales) do c, ext, scale
         hi_bb = height_insensitive_boundingbox_with_advance(ext)
         # TODO c != 0 filters out all non renderables, which is not always desired
         return Rect2d(origin(hi_bb) * scale, (c != 0) * widths(hi_bb) * scale)
     end
-end
-
-function gl_bboxes(gl::GlyphCollection)
-    scales = gl.scales.sv isa Vec2 ? (gl.scales.sv for _ in gl.extents) : gl.scales.sv
-    gl_bboxes(gl.glyphs, scales, gl.extents)
 end
 
 # tested but not used?

--- a/src/makielayout/blocks/menu.jl
+++ b/src/makielayout/blocks/menu.jl
@@ -118,9 +118,8 @@ function initialize_block!(m::Menu; default = 1)
 
     # listheight needs to be up to date before showing the menuscene so that its
     # direction is correct
-    gc_heights = map(blockscene, optiontexts.attributes.onchange, m.textpadding) do gcs, pad
-        widths = string_widths(optiontexts)
-        heights = map(size -> size[2] + pad[3] + pad[4], widths)
+    gc_heights = map(blockscene, fast_string_boundingboxes_obs(optiontexts), m.textpadding) do bbs, pad
+        heights = map(size -> size[2] + pad[3] + pad[4], widths.(bbs))
         h = sum(heights)
         listheight[] = h
         return (heights, h)

--- a/src/makielayout/blocks/polaraxis.jl
+++ b/src/makielayout/blocks/polaraxis.jl
@@ -44,24 +44,24 @@ function initialize_block!(po::PolarAxis; palette=nothing)
     # OPT: only update on relevant text attributes rather than glyphcollection
     onany(
             po.blockscene,
-            thetaticklabelplot.per_string_bb, thetaticklabelplot.visible,
-            rticklabelplot.per_string_bb, rticklabelplot.visible,
+            fast_string_boundingboxes_obs(thetaticklabelplot), thetaticklabelplot.visible,
+            fast_string_boundingboxes_obs(rticklabelplot), rticklabelplot.visible,
             po.rticklabelpad,
             po.rticksvisible, po.rticksize, po.rtickalign,
             po.thetaticklabelpad,
             po.thetaticksvisible, po.thetaticksize, po.thetatickalign,
             po.overlay.viewport
-        ) do _, tpvis, __, rpvis, rpad, rtvis, rtsize, rtalign, tpad, ttvis, ttsize, ttalign, area
+        ) do tbbs, tpvis, rbbs, rpvis, rpad, rtvis, rtsize, rtalign, tpad, ttvis, ttsize, ttalign, area
 
         # get maximum size of tick label
         # (each boundingbox represents a string without text.position applied)
         max_widths = Vec2f(0)
         if tpvis
-            plot_widths = Vec2f(maximum_string_widths(thetaticklabelplot))
+            plot_widths = Vec2f(maximum_widths(tbbs))
             max_widths = max.(max_widths, plot_widths)
         end
         if rpvis
-            plot_widths = Vec2f(maximum_string_widths(rticklabelplot))
+            plot_widths = Vec2f(maximum_widths(rbbs))
             max_widths = max.(max_widths, plot_widths)
         end
 

--- a/src/makielayout/blocks/textbox.jl
+++ b/src/makielayout/blocks/textbox.jl
@@ -69,9 +69,11 @@ function initialize_block!(tbox::Textbox)
         fontsize = tbox.fontsize, padding = tbox.textpadding)
 
     textplot = t.blockscene.plots[1]
-    _tight_character_boundingboxes(textplot) # create computation
-    # generate obs and throw away equal values to not trigger stackoverflow from translate!()
-    displayed_charbbs = map(identity, textplot.tight_character_boundingboxes, ignore_equal_values = true)
+    # Manually add positions without considering transformations to prevent
+    # infinite loop from translate!() in on(cursorpoints)
+    displayed_charbbs = map(textplot.positions, fast_glyph_boundingboxes_obs(textplot)) do pos, bbs
+        return [Rect2f(bb) + Point2f(pos[1]) for bb in bbs]
+    end
 
     cursorsize = Observable(Vec2f(1, tbox.fontsize[]))
     cursorpoints = lift(topscene, cursorindex, displayed_charbbs) do ci, bbs


### PR DESCRIPTION
Cleans up the mess of text bounding boxes that build up trying to fix PolarAxis, Menu, Textbox and general bounding boxes.

Adds a bunch of new, optional text bounding boxes which are hopefully more useful, performant and easier to understand than the old "do it yourself, good luck". (TODO: overview)

Removes a bunch of old Code that relied on GlyphCollections. While they could still be used, any Code that was using them will now error because `plot.plots[1][1]` is no longer a glyph colleciton. So you might as well correct to the new methods.
