### PR TITLE
Allow `hist` with an empty list

### DIFF
--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -148,7 +148,8 @@ end
 
 function pick_hist_edges(vals, bins)
     if bins isa Int
-        mi, ma = float.(extrema(vals; init = (0.0, 0.0)))
+        isempty(vals) && return 0:10 # corresponds to what we do for empty `Axis`
+        mi, ma = float.(extrema(vals))
         if mi == ma
             return (mi - 0.5):(ma + 0.5)
         end

--- a/src/stats/hist.jl
+++ b/src/stats/hist.jl
@@ -148,7 +148,7 @@ end
 
 function pick_hist_edges(vals, bins)
     if bins isa Int
-        mi, ma = float.(extrema(vals))
+        mi, ma = float.(extrema(vals; init = (0.0, 0.0)))
         if mi == ma
             return (mi - 0.5):(ma + 0.5)
         end

--- a/test/plots/hist.jl
+++ b/test/plots/hist.jl
@@ -1,3 +1,6 @@
+using Test
+using Makie
+
 @testset "Histogram plotting" begin
     unequal_vec = [1; rand(2:9, rand(1:9))]
     allequal_vec = fill(rand(1:9), rand(1:9))
@@ -13,4 +16,14 @@
     @test_nowarn hist(v)
     # change to unequal vector
     @test_nowarn v[] = unequal_vec
+end
+
+@testset "Empty histogram" begin
+    arg = Observable(Float64[])
+    f, a, p = @test_nowarn hist(arg)
+    Makie.update_state_before_display!(f)
+    @test all(iszero, p.plots[1][1][])
+    push!(arg[], 0.1)
+    notify(arg)
+    @test !all(iszero, p.plots[1][1][])
 end


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Allows `hist(Float64[])` to work by special casing if in .  Defaults to 0 +- 0.5.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.
