### PR TITLE
Bug/(tri)contourf colorrange

### DIFF
--- a/src/basic_recipes/contourf.jl
+++ b/src/basic_recipes/contourf.jl
@@ -27,8 +27,6 @@ similar to how [`surface`](@ref) works.
     This can be used for example to draw bands for the upper 90% while excluding the lower 10% with `levels = 0.1:0.1:1.0, mode = :relative`.
     """
     mode = :normal
-    colormap = @inherit colormap
-    colorscale = identity
     """
     In `:normal` mode, if you want to show a band from `-Inf` to the low edge,
     set `extendlow` to `:auto` to give the extension the same color as the first level,
@@ -42,7 +40,7 @@ similar to how [`surface`](@ref) works.
     """
     extendhigh = nothing
     # TODO, Isoband doesn't seem to support nans?
-    nan_color = :transparent
+    MakieCore.mixin_colormap_attributes()...
     MakieCore.mixin_generic_plot_attributes()...
 end
 
@@ -171,21 +169,14 @@ function Makie.plot!(c::Contourf{<:Union{<: Tuple{<:AbstractVector{<:Real}, <:Ab
         _get_isoband_levels(Val(mode), levels, vec(zs))
     end
 
-    colorrange = lift(c, c._computed_levels) do levels
-        minimum(levels), maximum(levels)
-    end
     computed_colormap = lift(compute_contourf_colormap, c, c._computed_levels, c.colormap, c.extendlow,
                              c.extendhigh)
     c.attributes[:_computed_colormap] = computed_colormap
 
-    lowcolor = Observable{RGBAf}()
-    lift!(compute_lowcolor, c, lowcolor, c.extendlow, c.colormap)
-    c.attributes[:_computed_extendlow] = lowcolor
+    c.attributes[:_computed_extendlow] = c.lowclip
     is_extended_low = lift(!isnothing, c, c.extendlow)
 
-    highcolor = Observable{RGBAf}()
-    lift!(compute_highcolor, c, highcolor, c.extendhigh, c.colormap)
-    c.attributes[:_computed_extendhigh] = highcolor
+    c.attributes[:_computed_extendhigh] = c.highclip
     is_extended_high = lift(!isnothing, c, c.extendhigh)
     PolyType = typeof(Polygon(Point2f[], [Point2f[]]))
 
@@ -213,9 +204,11 @@ function Makie.plot!(c::Contourf{<:Union{<: Tuple{<:AbstractVector{<:Real}, <:Ab
     poly!(c,
         polys,
         colormap = c._computed_colormap,
-        colorrange = colorrange,
-        highclip = highcolor,
-        lowclip = lowcolor,
+        colorscale = c.colorscale,
+        colorrange = c.colorrange,
+        alpha = c.alpha,
+        lowclip = c.lowclip,
+        highclip = c.highclip,
         nan_color = c.nan_color,
         color = colors,
         strokewidth = 0,

--- a/src/basic_recipes/tricontourf.jl
+++ b/src/basic_recipes/tricontourf.jl
@@ -95,26 +95,6 @@ function compute_contourf_colormap(levels, cmap, elow, ehigh)
     return cm
 end
 
-function compute_lowcolor(el, cmap)
-    if isnothing(el)
-        return RGBAf(0, 0, 0, 0)
-    elseif el === automatic || el === :auto
-        return RGBAf(to_colormap(cmap)[begin])
-    else
-        return to_color(el)::RGBAf
-    end
-end
-
-function compute_highcolor(eh, cmap)
-    if isnothing(eh)
-        return RGBAf(0, 0, 0, 0)
-    elseif eh === automatic || eh === :auto
-        return RGBAf(to_colormap(cmap)[end])
-    else
-        return to_color(eh)::RGBAf
-    end
-end
-
 function Makie.plot!(c::Tricontourf{<:Tuple{<:DelTri.Triangulation, <:AbstractVector{<:Real}}})
     tri, zs = c[1:2]
 


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #4016 by using `MakieCore.mixin_colormap_attributes` for both `contourf` and `tricontourf`. Setting `colorrange`, `colorscale`, `lowclip`, `highclip`, and `alpha` all seem to work. Please let me know if anything needs to change. :smiley: 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)