### PR TITLE
`Annotation` quick fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.22.10] - 2025-06-03
+
+- Quick fix for the just released `annotation`, `textcolor` now follows `color` by default [#5034](https://github.com/MakieOrg/Makie.jl/pull/5034).
+
 ## [0.22.9] - 2025-06-03
 
 - Added conversion method for `annotation` to make it compatible with AlgebraOfGraphics [#5029](https://github.com/MakieOrg/Makie.jl/pull/5029).
@@ -819,7 +823,8 @@ All other changes are collected [in this PR](https://github.com/MakieOrg/Makie.j
 - Fixed rendering of `heatmap`s with one or more reversed ranges in CairoMakie, as in `heatmap(1:10, 10:-1:1, rand(10, 10))` [#1100](https://github.com/MakieOrg/Makie.jl/pull/1100).
 - Fixed volume slice recipe and added docs for it [#1123](https://github.com/MakieOrg/Makie.jl/pull/1123).
 
-[Unreleased]: https://github.com/MakieOrg/Makie.jl/compare/v0.22.9...HEAD
+[Unreleased]: https://github.com/MakieOrg/Makie.jl/compare/v0.22.10...HEAD
+[0.22.10]: https://github.com/MakieOrg/Makie.jl/compare/v0.22.9...v0.22.10
 [0.22.9]: https://github.com/MakieOrg/Makie.jl/compare/v0.22.8...v0.22.9
 [0.22.8]: https://github.com/MakieOrg/Makie.jl/compare/v0.22.7...v0.22.8
 [0.22.7]: https://github.com/MakieOrg/Makie.jl/compare/v0.22.6...v0.22.7

--- a/CairoMakie/Project.toml
+++ b/CairoMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "CairoMakie"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 author = ["Simon Danisch <sdanisch@gmail.com>"]
-version = "0.13.9"
+version = "0.13.10"
 
 [deps]
 CRC32c = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
@@ -24,7 +24,7 @@ FileIO = "1.1"
 FreeType = "3, 4.0"
 GeometryBasics = "0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.22.9"
+Makie = "=0.22.10"
 PrecompileTools = "1.0"
 julia = "1.3"
 

--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -1,6 +1,6 @@
 name = "GLMakie"
 uuid = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
-version = "0.11.10"
+version = "0.11.11"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
@@ -30,7 +30,7 @@ FreeTypeAbstraction = "0.10"
 GLFW = "3.4.3"
 GeometryBasics = "0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.22.9"
+Makie = "=0.22.10"
 Markdown = "1.0, 1.6"
 MeshIO = "0.5"
 ModernGL = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Makie"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 authors = ["Simon Danisch", "Julius Krumbiegel"]
-version = "0.22.9"
+version = "0.22.10"
 
 [deps]
 Animations = "27a7e980-b3e6-11e9-2bcd-0b925532e340"

--- a/RPRMakie/Project.toml
+++ b/RPRMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "RPRMakie"
 uuid = "22d9f318-5e34-4b44-b769-6e3734a732a6"
 authors = ["Simon Danisch"]
-version = "0.8.9"
+version = "0.8.10"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -17,7 +17,7 @@ Colors = "0.9, 0.10, 0.11, 0.12, 0.13"
 FileIO = "1.6"
 GeometryBasics = "0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.22.9"
+Makie = "=0.22.10"
 Printf = "1.0, 1.6"
 RadeonProRender = "0.3.2"
 julia = "1.3"

--- a/WGLMakie/Project.toml
+++ b/WGLMakie/Project.toml
@@ -1,7 +1,7 @@
 name = "WGLMakie"
 uuid = "276b4fcb-3e11-5398-bf8b-a0c2d153d008"
 authors = ["SimonDanisch <sdanisch@gmail.com>"]
-version = "0.11.9"
+version = "0.11.10"
 
 [deps]
 Bonito = "824d6782-a2ef-11e9-3a09-e5662e0c26f8"
@@ -27,7 +27,7 @@ FreeTypeAbstraction = "0.10"
 GeometryBasics = "0.5"
 Hyperscript = "0.0.3, 0.0.4, 0.0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.22.9"
+Makie = "=0.22.10"
 Observables = "0.5.1"
 PNGFiles = "0.3, 0.4"
 PrecompileTools = "1.0"

--- a/src/basic_recipes/annotation.jl
+++ b/src/basic_recipes/annotation.jl
@@ -166,8 +166,16 @@ function Makie.convert_arguments(::Type{<:Annotation}, x::Real, y::Real)
     return ([Vec4d(NaN, NaN, x, y)],)
 end
 
+function Makie.convert_arguments(::Type{<:Annotation}, p::VecTypes{2})
+    return ([Vec4d(NaN, NaN, p...)],)
+end
+
 function Makie.convert_arguments(::Type{<:Annotation}, x::Real, y::Real, x2::Real, y2::Real)
     return ([Vec4d(x, y, x2, y2)],)
+end
+
+function Makie.convert_arguments(::Type{<:Annotation}, p1::VecTypes{2}, p2::VecTypes{2})
+    return ([Vec4d(p1..., p2...)],)
 end
 
 function Makie.convert_arguments(::Type{<:Annotation}, v::AbstractVector{<:VecTypes{2}})

--- a/src/basic_recipes/annotation.jl
+++ b/src/basic_recipes/annotation.jl
@@ -67,13 +67,13 @@ be very close to their associated data points so connection plots are typically 
 """
 @recipe Annotation begin
     """
-    The color of the text labels.
+    The color of the text labels. If `automatic`, `textcolor` matches `color`.
     """
-    textcolor = :black
+    textcolor = automatic
     """
     The basic color of the connection object. For more fine-grained adjustments, modify the `style` object directly.
     """
-    color = :black
+    color = @inherit linecolor
     """
     One object or an array of objects that determine the textual content of the labels.
     """
@@ -201,13 +201,18 @@ function Makie.plot!(p::Annotation{<:Tuple{<:AbstractVector{<:Vec4}}})
         Point2d.(getindex.(vecs, 3), getindex.(vecs, 4))
     end
 
+    textcolor = Observable{Any}()
+    map!(textcolor, p.textcolor, p.color) do tc, c
+        tc === automatic ? c : tc
+    end
+
     txt = text!(
         p,
         textpositions;
         text = p.text,
         align = p.align,
         offset = zeros(Vec2d, length(textpositions[])),
-        color = p.textcolor,
+        color = textcolor,
         font = p.font,
         fonts = p.fonts,
         justification = p.justification,


### PR DESCRIPTION
- **add scalar vectypes conversions**
- **make `textcolor` follow `color` by default, and `color` theme-compatible**

Supersedes #5033 

I guess after the release two hours ago I got quickly convinced by @aplavin that it would be more user-friendly if `textcolor` followed `color` by default. I also found playing with AoG that it's more natural to try `color` first, and there are no lines in a typical ggrepel style plot, or they are very small, which is confusing as then `color` has no effect. So I'm pushing this as a "quick fix" and tagging patch, even though technically breaking, practically it has no impact as the feature was just released two hours ago. Better get ahead of it before more people start using this.