### PR TITLE
glyphs need to be inserted across figures in the correct order

### DIFF
--- a/WGLMakie/src/javascript/WGLMakie.bundled.js
+++ b/WGLMakie/src/javascript/WGLMakie.bundled.js
@@ -24547,6 +24547,31 @@ const mod1 = {
     Scatter: Scatter
 };
 window.THREE = mod;
+const orderedExecutor = {
+    tasks: new Map(),
+    nextExpected: 1,
+    insert (f, order) {
+        if (this.tasks.has(order)) {
+            throw new Error(`Duplicate task for order ${order}`);
+        }
+        this.tasks.set(order, f);
+        this.flush();
+    },
+    flush () {
+        while(this.tasks.has(this.nextExpected)){
+            const f = this.tasks.get(this.nextExpected);
+            f();
+            this.tasks.delete(this.nextExpected);
+            this.nextExpected += 1;
+        }
+    }
+};
+function execute_in_order(order, f) {
+    if (order < 1 || !Number.isInteger(order)) {
+        throw new Error(`Invalid order: ${order}`);
+    }
+    orderedExecutor.insert(f, order);
+}
 function dispose_screen(screen) {
     if (Object.keys(screen).length === 0) {
         return;
@@ -25212,6 +25237,7 @@ window.WGL = {
     get_texture_atlas
 };
 export { deserialize_scene as deserialize_scene, threejs_module as threejs_module, start_renderloop as start_renderloop, delete_plots as delete_plots, insert_plot as insert_plot, find_plots as find_plots, delete_scene as delete_scene, find_scene as find_scene, scene_cache as scene_cache, plot_cache as plot_cache, delete_scenes as delete_scenes, create_scene as create_scene, events2unitless as events2unitless, on_next_insert as on_next_insert, get_texture_atlas as get_texture_atlas };
+export { execute_in_order as execute_in_order };
 export { render_scene as render_scene };
 export { wglerror as wglerror };
 export { pick_native as pick_native };

--- a/WGLMakie/src/javascript/WGLMakie.js
+++ b/WGLMakie/src/javascript/WGLMakie.js
@@ -19,6 +19,35 @@ import {get_texture_atlas} from "./TextureAtlas.js";
 
 window.THREE = THREE;
 
+const orderedExecutor = {
+    tasks: new Map(),
+    nextExpected: 1,
+
+    insert(f, order) {
+        if (this.tasks.has(order)) {
+            throw new Error(`Duplicate task for order ${order}`);
+        }
+        this.tasks.set(order, f);
+        this.flush();
+    },
+
+    flush() {
+        while (this.tasks.has(this.nextExpected)) {
+            const f = this.tasks.get(this.nextExpected);
+            f();
+            this.tasks.delete(this.nextExpected);
+            this.nextExpected += 1;
+        }
+    },
+};
+
+export function execute_in_order(order, f) {
+    if (order < 1 || !Number.isInteger(order)) {
+        throw new Error(`Invalid order: ${order}`);
+    }
+    orderedExecutor.insert(f, order);
+}
+
 function dispose_screen(screen) {
     if (Object.keys(screen).length === 0) {
         return;

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -297,7 +297,7 @@ function get_atlas_tracker(f, scene::Scene)
             Bonito.isclosed(s) && delete!(SCENE_ATLASES, s)
         end
         screen = Makie.getscreen(scene, WGLMakie)
-        if isnothing(screen.session)
+        if isnothing(screen) || isnothing(screen.session)
             @warn "No session found, returning empty atlas tracker"
             # TODO, it's not entirely clear in which case this can happen,
             # which is why we don't just error, but just assume there isn't anything tracked


### PR DESCRIPTION
@bradcarman reported this for Bonito apps with multiple figures loosing glyphs on refresh.

The reason is, that if you're doing something like this:
```julia
app = App() do
    figs = map(1:10) do i 
        scatter(1:4; figure=(; size=(100, 100)))
    end
    DOM.div(figs...)
end
```
Will lead to a mismatch in serialization order compared to deserialization in the browser, since the canvas and JS payload loading order is not necessarily the same.

To fix this, this PR introduces a serialization order for root scenes, which is matched in JS by deserializing scenes via `execute_in_order` .
