### PR TITLE
dont convert dicts to attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [0.24.1] - 2025-06-24
 
+- Make sure there's only one inspector per root scene [#5113](https://github.com/MakieOrg/Makie.jl/pull/5113).
+- Bring back lowres background for heatmap(Resampler(...)) [#5110](https://github.com/MakieOrg/Makie.jl/pull/5110).
+- Fixed forwarding attributes in recipes [#5109](https://github.com/MakieOrg/Makie.jl/pull/5109).
+
 ## [0.24.0] - 2025-06-20
 
 - **Breaking** Refactored plots to rely on the newly introduced `ComputeGraph` instead of `Observables`. [#4630](https://github.com/MakieOrg/Makie.jl/pull/4630)

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -495,7 +495,7 @@ end
 
 to_recipe_attribute(_, x) = Ref{Any}(x) # Make sure it can change type
 to_recipe_attribute(_, attr::Attributes) = attr
-function to_recipe_attribute(_, value::Union{NamedTuple, Dict})
+function to_recipe_attribute(_, value::NamedTuple)
     return Attributes(value)
 end
 


### PR DESCRIPTION
I think dicts are too general and are used for other attributes (E.g. in OSMMakie).