### PR TITLE
Some more fixes for patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [0.24.1] - 2025-06-24
 
+- Don't pull plots from invisible scenes and hide Blocks during construction [#5119](https://github.com/MakieOrg/Makie.jl/pull/5119).
 - Fixed `dendrogram` docstring and added `x, y, merges` conversion [#5118](https://github.com/MakieOrg/Makie.jl/pull/5118).
 - Make sure there's only one inspector per root scene [#5113](https://github.com/MakieOrg/Makie.jl/pull/5113).
 - Bring back lowres background for heatmap(Resampler(...)) [#5110](https://github.com/MakieOrg/Makie.jl/pull/5110).

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -752,23 +752,21 @@ The Observable listener is set up with `priority = typemax(Int)-1` and
 `Consume(false)`. This means it will take precedence over all but `typemax(Int)`
 priority and not block later updates.
 """
-function add_input!(attr::ComputeGraph, k::Symbol, obs::Observable)
+function add_input!(attr::ComputeGraph, k::Symbol, @nospecialize(obs::Observable))
     add_input!(attr, k, obs[])
-    # typemax-1 so it doesn't get disturbed by other listeners but can still be
-    # blocked by a typamax obs
-    of = on(obs, priority = typemax(Int) - 1) do new_val
+    of = on(obs) do new_val
         setproperty!(attr, k, new_val)
-        return Consume(false)
+        return nothing
     end
     push!(attr.observerfunctions, of)
     return attr
 end
 
-function add_input!(f, attr::ComputeGraph, k::Symbol, obs::Observable)
+function add_input!(f, attr::ComputeGraph, k::Symbol, @nospecialize(obs::Observable))
     add_input!(f, attr, k, obs[])
-    of = on(obs, priority = typemax(Int) - 1) do new_val
+    of = on(obs) do new_val
         setproperty!(attr, k, new_val)
-        return Consume(false)
+        return nothing
     end
     push!(attr.observerfunctions, of)
     return attr

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -752,21 +752,21 @@ The Observable listener is set up with `priority = typemax(Int)-1` and
 `Consume(false)`. This means it will take precedence over all but `typemax(Int)`
 priority and not block later updates.
 """
-function add_input!(attr::ComputeGraph, k::Symbol, @nospecialize(obs::Observable))
+function add_input!(attr::ComputeGraph, k::Symbol, obs::Observable)
     add_input!(attr, k, obs[])
-    of = on(obs) do new_val
+    of = on(obs; priority = typemax(Int) - 1) do new_val
         setproperty!(attr, k, new_val)
-        return nothing
+        return Consume(false)
     end
     push!(attr.observerfunctions, of)
     return attr
 end
 
-function add_input!(f, attr::ComputeGraph, k::Symbol, @nospecialize(obs::Observable))
+function add_input!(f, attr::ComputeGraph, k::Symbol, obs::Observable)
     add_input!(f, attr, k, obs[])
-    of = on(obs) do new_val
+    of = on(obs, priority = typemax(Int) - 1) do new_val
         setproperty!(attr, k, new_val)
-        return nothing
+        return Consume(false)
     end
     push!(attr.observerfunctions, of)
     return attr

--- a/GLMakie/src/screen.jl
+++ b/GLMakie/src/screen.jl
@@ -1056,12 +1056,13 @@ function requires_update(screen::Screen)
     return false
 end
 
-
 # const time_record = sizehint!(Float64[], 100_000)
 function poll_updates(screen)
     Base.invokelatest() do
         with_context(screen.glscreen) do
             for plot in values(screen.cache2plot)
+                scene = Makie.parent_scene(plot)
+                scene.visible[] || continue # skip invisible scenes
                 # Skip updating invisible renderobjects
                 # This is basically `if is_visible || was_visible`, which makes
                 # sure the robj updates on state change. (i.e. hides and redisplays)

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -8,9 +8,9 @@ module Aggregation
     """
         Canvas(bounds::Rect2; resolution::Tuple{Int,Int}=(800, 800), op=AggCount())
         Canvas(xmin::Number, xmax::Number, ymin::Number, ymax::Number; args...)
-    
+
     # Example
-    
+
     ```Julia
     using Makie
     canvas = Canvas(-1, 1, -1, 1; op=AggCount(), resolution=(800, 800))
@@ -33,7 +33,7 @@ module Aggregation
 
     """
         get_aggregation(canvas::Canvas; operation=equalize_histogram, local_operation=identity, result=similar(canvas.pixelbuffer, canvas.resolution))
-    
+
     Basically does `operation(map!(local_operation, result, canvas.pixelbuffer))`, but does the correct reshaping of the flat pixelbuffer and
     simplifies passing a local or global operation.
     Allocates the result buffer every time and can be made non allocating by passing the correct result buffer.
@@ -129,7 +129,7 @@ module Aggregation
 
     """
         aggregate!(c::Canvas, points; point_transform=identity, method::AggMethod=AggSerial())
-    
+
     Aggregate points into a canvas. The points are transformed by `point_transform` before aggregation.
     Method can be `AggSerial()` or `AggThreads()`.
     """

--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -152,7 +152,6 @@ function compute_protrusions(
 end
 
 function initialize_block!(ax::Axis; palette = nothing)
-
     blockscene = ax.blockscene
     elements = Dict{Symbol, Any}()
     ax.elements = elements
@@ -176,7 +175,9 @@ function initialize_block!(ax::Axis; palette = nothing)
 
     scenearea = sceneareanode!(ax.layoutobservables.computedbbox, finallimits, ax.aspect)
 
-    scene = Scene(blockscene, viewport = scenearea)
+    scene = Scene(blockscene, viewport = scenearea, visible = false)
+    # Hide to block updates, will be unhidden! in constructor who calls this!
+    @assert !scene.visible[]
     ax.scene = scene
     # transfer conversions from axis to scene if there are any
     # or the other way around

--- a/Makie/src/makielayout/blocks/scene.jl
+++ b/Makie/src/makielayout/blocks/scene.jl
@@ -9,7 +9,7 @@ function initialize_block!(ls::LScene; scenekw = NamedTuple())
     blockscene = ls.blockscene
     # pick a camera and draw axis.
     scenekw = merge((clear = false, camera = cam3d!), scenekw)
-    ls.scene = Scene(blockscene, lift(round_to_IRect2D, blockscene, ls.layoutobservables.computedbbox); scenekw...)
+    ls.scene = Scene(blockscene, lift(round_to_IRect2D, blockscene, ls.layoutobservables.computedbbox); visible = false, scenekw...)
 
     on(blockscene, ls.show_axis) do show_axis
         ax = ls.scene[OldAxis]


### PR DESCRIPTION
-  fix for cycle in event handling. Somehow the priority set for adding an observable to a compute graph managed to trigger an event loop for e.g. `events.keyboardbutton`
- Not polling plots from invisible scenes anymore, skipping costly computations and updates.
- Hiding Blocks during constructions. With the above, this actually fixes a bug where creating a new Axis in an already displayed scene would get a text size missmatch error. This is the poor mans version of actually porting Axis to the new compute-graph (which would fix the error as well), but this is a good thing even after the compute-graph refactor.
- Fix a bug with `heatmap(Resampler(...))`, where it could get into a state where the limits where nothing.