### PR TITLE
only run runic on merge and commit formatting changes

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,22 +1,59 @@
-name: Formatting
+name: Auto-format on Master Merge
+
 on:
   push:
     branches:
-      - 'master'
-      - 'release-'
-    tags:
-      - '*'
-  pull_request:
+      - master
+      - main
+
 jobs:
-  runic:
-    name: Runic formatting
+  auto-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          version: '1'
-      - uses: julia-actions/cache@v2
-      - uses: fredrikekre/runic-action@v1
+          # Use a PAT or the default token with write permissions
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Fetch full history to avoid shallow clone issues
+          fetch-depth: 0
+
+      - name: Set up Julia (if needed for runic)
+        uses: julia-actions/setup-julia@v2
         with:
-          version: '1.4'
+          version: '1.10'
+
+      - name: Install runic formatter
+        run: |
+          julia -e 'using Pkg; Pkg.add("Runic")'
+
+      - name: Run formatter
+        run: |
+          julia -e 'using Runic; exit(Runic.main(ARGS))' -- --inplace .
+
+      - name: Check for changes
+        id: verify-changed-files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "Files were changed by formatter"
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "No files were changed by formatter"
+          fi
+
+      - name: Commit formatting changes
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Auto-format code with runic [skip ci]"
+          git push
+
+      - name: Cancel previous workflow runs
+        if: steps.verify-changed-files.outputs.changed == 'true'
+        uses: styfle/cancel-workflow-action@0.12.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow_id: ${{ github.run_id }}


### PR DESCRIPTION
I'm already tired of runic formatting churn :D 
Also, we either need to force outside contributors to run runic formatting, or we need to do that work, which is even more annoying since we need to check out their branch.
Even worse, we're running into CI usage queuing quite quickly, and with every third commit being runic fixes this makes the waiting for CI much worse.
This is directly committing when fixes are found, minimizing the time of people branching off from an unfixed master branch, and therefore reducing merge conflicts.
We considered letting the gh action make a PR, but that would need to run for an hour until we can merge it, eating up more CI resources and increasing merge conflict potential.

This means though, that before tagging we should wait for the master merge CI to turn green, since in theory runic could introduce errors. 
I can't really think of a better trade off, but happy to hear better ideas.
Github hook also isn't a viable solution, since this would not solve the outside contributor issue.
