### PR TITLE
Restore input safety check for compute edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed arrow marker attributes in `arrows3d` not triggering repositioning of arrows. [#5134](https://github.com/MakieOrg/Makie.jl/pull/5134)
+- Moved some compute edge checks out of debug mode to error more consistently on edge overwrite [#5125](https://github.com/MakieOrg/Makie.jl/pull/5125)
 
 ## [0.24.2] - 2025-06-27
 


### PR DESCRIPTION
# Description

While optimizing we moved a lot of checks for `register_computation!()/map!()` behind a debug flag. This pr restores the `given_inputs == existing_inputs` check, which makes sure this errors:

```julia
graph = ComputeGraph()
add_input!(graph, :a, 1)
add_input!(graph, :b, 1)
map!(identity, graph, :a, :output)
map!(identity, graph, :b, :output)
```

Without this check the second `map!()` thinks the edge already exists and exits early. `graph.output` then continues to be reliant on `graph.a`.

Should we run ComputePipeline tests without extended error checking so we can test this?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
