### PR TITLE
Use map!() more for better performance

### DIFF
--- a/Makie/src/backend-functionality.jl
+++ b/Makie/src/backend-functionality.jl
@@ -6,9 +6,7 @@ add_computation!(attr::ComputeGraph, scene::Scene, symbols::Symbol...) =
 add_computation!(attr::ComputeGraph, symbols::Symbol...) = add_computation!(attr, Val.(symbols)...)
 
 function add_computation!(attr, ::Val{:gl_miter_limit})
-    return register_computation!(attr, [:miter_limit], [:gl_miter_limit]) do (miter,), changed, output
-        return (Float32(cos(pi - miter)),)
-    end
+    return map!(miter -> Float32(cos(pi - miter)), attr, :miter_limit, :gl_miter_limit)
 end
 
 function add_computation!(attr, ::Val{:uniform_pattern}, ::Val{:uniform_pattern_length})
@@ -39,11 +37,11 @@ _xy_convert(x::Makie.EndPoints, n) = [LinRange(extrema(x)..., n + 1);]
 
 function add_computation!(attr, scene, ::Val{:heatmap_transform})
     # TODO: consider just using a grid of points?
-    register_computation!(
+    map!(
         attr,
         [:x, :y, :image, :transform_func],
         [:x_transformed, :y_transformed]
-    ) do (x, y, img, func), changed, last
+    ) do x, y, img, func
 
         x1d = _xy_convert(x, size(img, 1))
         xps = apply_transform(func, Point2.(x1d, 0))
@@ -106,46 +104,46 @@ function add_computation!(attr, scene, ::Val{:surface_transform})
     # TODO: This is dropping fast paths for Range/Vector x, y w/o transform_func & f32c
     # TODO: If we're always creating a Matrix of Points GLMakie should just
     #       use that directly instead of going back to a x and y matrix representation
-    register_computation!(
+    map!(
         attr,
         [:x, :y, :z, :transform_func],
-        [:positions_transformed]
-    ) do (x, y, z, func), changed, last
-        return (apply_transform(func, _surf_xyz_convert(x, y, z)),)
+        :positions_transformed
+    ) do x, y, z, func
+        return apply_transform(func, _surf_xyz_convert(x, y, z))
     end
 
     register_positions_transformed_f32c!(attr)
 
-    return register_computation!(
+    return map!(
         attr,
-        [:positions_transformed_f32c],
+        :positions_transformed_f32c,
         [:x_transformed_f32c, :y_transformed_f32c, :z_transformed_f32c]
-    ) do (xyz,), changed, cached
+    ) do xyz
         return ntuple(i -> getindex.(xyz, i), Val(3))
     end
 end
 
 function add_computation!(attr, scene, ::Val{:voxel_model})
-    return register_computation!(attr, [:x, :y, :z, :chunk_u8, :model], [:voxel_model]) do (xs, ys, zs, chunk, model), changed, cached
+    return map!(attr, [:x, :y, :z, :chunk_u8, :model], :voxel_model) do xs, ys, zs, chunk, model
         mini = minimum.((xs, ys, zs))
         width = maximum.((xs, ys, zs)) .- mini
         m = Makie.transformationmatrix(Vec3f(mini), Vec3f(width ./ size(chunk)))
-        return (Mat4f(model * m),)
+        return Mat4f(model * m)
     end
 end
 
 function add_computation!(attr, scene, ::Val{:uniform_model})
-    return register_computation!(attr, [:data_limits, :model], [:uniform_model]) do (cube, model), changed, cached
+    return map!(attr, [:data_limits, :model], :uniform_model) do cube, model
         mini = minimum(cube)
         width = widths(cube)
         trans = Makie.transformationmatrix(Vec3f(mini), Vec3f(width))
-        return (Mat4f(model * trans),)
+        return Mat4f(model * trans)
     end
 end
 
 # repacks per-element uv_transform into Vec2's for wrapping in Texture/TextureBuffer for meshscatter
 function add_computation!(attr, scene, ::Val{:uv_transform_packing})
-    return register_computation!(attr, [:pattern_uv_transform], [:packed_uv_transform]) do (uvt,), changed, last
+    return map!(attr, :pattern_uv_transform, :packed_uv_transform) do uvt
         if uvt isa Vector
             # 3x Vec2 should match the element order of glsl mat3x2
             output = Vector{Vec2f}(undef, 3 * length(uvt))
@@ -154,9 +152,9 @@ function add_computation!(attr, scene, ::Val{:uv_transform_packing})
                 output[3 * (i - 1) + 2] = uvt[i][Vec(3, 4)]
                 output[3 * (i - 1) + 3] = uvt[i][Vec(5, 6)]
             end
-            return (output,)
+            return output
         else
-            return (uvt,)
+            return uvt
         end
     end
 end
@@ -170,23 +168,23 @@ function add_computation!(attr, scene, ::Val{:meshscatter_f32c_scale})
     # transform them to world space (post float32convert) on the CPU. We then can't
     # do instancing anymore, so meshscatter becomes pointless.
     space = haskey(attr, :markerspace) ? :markerspace : :space
-    return register_computation!(
-        attr, [:f32c, :model, :model_f32c, :transform_marker, space], [:f32c_scale]
-    ) do (f32c, model, model_f32c, transform_marker, space), changed, cached
+    return map!(
+        attr, [:f32c, :model, :model_f32c, :transform_marker, space], :f32c_scale
+    ) do f32c, model, model_f32c, transform_marker, space
         if Makie.is_identity_transform(f32c)
-            return (Vec3f(1),)
+            return Vec3f(1)
         else
             # f32c_scale * model_f32c should reproduce f32c.scale * model if transform_marker is true
             if is_data_space(space)
                 if transform_marker
                     d3 = Vec(1, 6, 11)
                     scale = f32c.scale .* model[d3] ./ model_f32c[d3]
-                    return (Vec3f(scale),)
+                    return Vec3f(scale)
                 else
-                    return (Vec3f(f32c.scale),)
+                    return Vec3f(f32c.scale)
                 end
             else
-                return (Vec3f(1),)
+                return Vec3f(1)
             end
         end
     end
@@ -198,16 +196,16 @@ end
 
 function add_computation!(attr, scene, ::Val{:voxel_uv_transform})
     # TODO: Should this verify that color is a texture?
-    return register_computation!(attr, [:uvmap, :uv_transform], [:packed_uv_transform]) do (uvmap, uvt), changed, cached
+    return map!(attr, [:uvmap, :uv_transform], :packed_uv_transform) do uvmap, uvt
         if !isnothing(uvt)
-            return (Makie.pack_voxel_uv_transform(uvt),)
+            return pack_voxel_uv_transform(uvt)
         elseif !isnothing(uvmap)
             @warn "Voxel uvmap has been deprecated in favor of the more general `uv_transform`. Use `map(lrbt -> (Point2f(lrbt[1], lrbt[3]), Vec2f(lrbt[2] - lrbt[1], lrbt[4] - lrbt[3])), uvmap)`."
-            raw_uvt = Makie.uvmap_to_uv_transform(uvmap)
-            converted_uvt = Makie.convert_attribute(raw_uvt, Makie.key"uv_transform"())
-            return (Makie.pack_voxel_uv_transform(converted_uvt),)
+            raw_uvt = uvmap_to_uv_transform(uvmap)
+            converted_uvt = convert_attribute(raw_uvt, key"uv_transform"())
+            return pack_voxel_uv_transform(converted_uvt)
         else
-            return (nothing,)
+            return nothing
         end
     end
 end
@@ -318,10 +316,10 @@ end
 function add_computation!(attr, ::Val{:surface_as_mesh})
     # Generate mesh from surface data and add its data to the compute graph.
     # Use that to draw surface as a mesh
-    register_computation!(
+    map!(
         attr,
         [:x, :y, :z, :transform_func, :invert_normals], [:positions_transformed, :faces, :texturecoordinates, :normals]
-    ) do (x, y, z, transform_func, invert_normals), changed, cached
+    ) do x, y, z, transform_func, invert_normals
 
         # (x, y, z) are generated after convert_arguments and dim_converts,
         # before apply_transform and f32c

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -367,9 +367,7 @@ end
 function register_text_computations!(attr::ComputeGraph)
     add_constant!(attr, :atlas, get_texture_atlas())
 
-    register_computation!(attr, [:fonts, :font], [:selected_font]) do (fs, f), changed, cached
-        return (to_font(fs, f),)
-    end
+    map!(to_font, attr, [:fonts, :font], :selected_font)
 
     # Resolve colormapping to colors early. This allows rich text which returns
     # its own colors to be mixed with other text types which dont.
@@ -379,25 +377,25 @@ function register_text_computations!(attr::ComputeGraph)
     # And :glyphcollection if applicable
     compute_glyph_collections!(attr)
 
-    register_computation!(attr, [:text_blocks, :positions], [:text_positions]) do (blocks, pos), changed, cached
+    map!(attr, [:text_blocks, :positions], :text_positions) do blocks, pos
         if length(blocks) != length(pos)
             error("Text blocks and positions have different lengths: $(length(blocks)) != $(length(pos)). Please use `update!(plot_object; arg1/arg2/text/position/color/etc...) to update multiple attributes together.")
         end
-        return ([p for (b, p) in zip(blocks, pos) for i in b],)
+        return [p for (b, p) in zip(blocks, pos) for i in b]
     end
 
-    register_computation!(attr, [:atlas, :glyphindices, :font_per_char], [:sdf_uv]) do (atlas, gi, fonts), changed, cached
-        return (glyph_uv_width!.((atlas,), gi, fonts),)
+    map!(attr, [:atlas, :glyphindices, :font_per_char], :sdf_uv) do atlas, gi, fonts
+        return glyph_uv_width!.((atlas,), gi, fonts)
     end
 
-    register_computation!(attr, [:glyph_origins, :offset, :text_blocks], [:marker_offset]) do (origins, offset, blocks), changed, cached
-        return (Point3f[origins[gi] + sv_getindex(offset, i) for (i, r) in enumerate(blocks) for gi in r],)
+    map!(attr, [:glyph_origins, :offset, :text_blocks], :marker_offset) do origins, offset, blocks
+        return Point3f[origins[gi] + sv_getindex(offset, i) for (i, r) in enumerate(blocks) for gi in r]
     end
 
-    register_computation!(
+    map!(
         attr, [:atlas, :glyphindices, :text_blocks, :font_per_char, :text_scales],
         [:quad_offset, :quad_scale]
-    ) do (atlas, gi, text_blocks, fonts, fontsize), changed, cached
+    ) do atlas, gi, text_blocks, fonts, fontsize
 
         quad_offsets = Vec2f[]
         quad_scales = Vec2f[]

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -213,11 +213,11 @@ end
 function register_colormapping!(attr::ComputeGraph, colorname = :color)
     register_colormapping_without_color!(attr)
 
-    register_computation!(
+    map!(
         attr,
         [colorname, :colorscale, :alpha],
         [:raw_color, :scaled_color, :fetch_pixel]
-    ) do (color, colorscale, alpha), changed, last
+    ) do color, colorscale, alpha
         val = if color isa Union{AbstractArray{<:Real}, Real}
             clamp.(el32convert(apply_scale(colorscale, color)), -floatmax(Float32), floatmax(Float32))
         elseif color isa AbstractPattern
@@ -232,15 +232,15 @@ function register_colormapping!(attr::ComputeGraph, colorname = :color)
         return (color, val, color isa AbstractPattern)
     end
 
-    return register_computation!(
+    return map!(
         attr,
-        [:colorrange, :colorscale, :scaled_color], [:scaled_colorrange]
-    ) do (colorrange, colorscale, color), changed, last
-        (color isa AbstractArray{<:Real} || color isa Real) || return (nothing,)
+        [:colorrange, :colorscale, :scaled_color], :scaled_colorrange
+    ) do colorrange, colorscale, color
+        (color isa AbstractArray{<:Real} || color isa Real) || return nothing
         if colorrange === automatic
-            return (isempty(color) ? Vec2f(0, 10) : Vec2f(distinct_extrema_nan(color)),)
+            return isempty(color) ? Vec2f(0, 10) : Vec2f(distinct_extrema_nan(color))
         else
-            return (Vec2f(apply_scale(colorscale, colorrange)),)
+            return Vec2f(apply_scale(colorscale, colorrange))
         end
     end
 end
@@ -323,14 +323,14 @@ function _register_expand_arguments!(::Type{P}, attr, inputs, is_merged = false)
         conversion_trait(P, map(k -> attr[k][], inputs)...)
     end
     # call it args for backwards compatibility (plot.args)
-    register_computation!(attr, inputs, [:args]) do input_args, changed, last
+    map!(attr, inputs, :args) do input_args...
         args = values(is_merged ? input_args[1] : input_args)
         args_exp = expand_dimensions(PTrait, args...)
         if isnothing(args_exp)
             # This can change types, so force Any type in Compute node
-            return (Ref{Any}(args),)
+            return Ref{Any}(args)
         else
-            return (Ref{Any}(args_exp),)
+            return Ref{Any}(args_exp)
         end
     end
     return
@@ -363,8 +363,8 @@ end
 function add_dim_converts!(attr::ComputeGraph, dim_converts, args, input = :args)
     if !(length(args) in (2, 3))
         # We only support plots with 2 or 3 dimensions right now
-        register_computation!(attr, [:args], [:dim_converted]) do args, changed, last
-            return (Ref{Any}(args.args),)
+        map!(attr, :args, :dim_converted) do args
+            return Ref{Any}(args)
         end
         return
     end
@@ -399,8 +399,8 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
     elseif (status === true || status === SpecApi)
         # Nothing needs to be done, since we can just use convert_arguments without dim_converts
         # And just pass the arguments through
-        register_computation!(attr, [:args], [:dim_converted]) do args, changed, last
-            return (Ref{Any}(args.args),)
+        map!(attr, :args, :dim_converted) do args
+            return Ref{Any}(args)
         end
     elseif isnothing(status) || status == true # we don't know (e.g. recipes)
         add_dim_converts!(attr, dim_converts, args)
@@ -408,8 +408,8 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
         if args_converted !== args
             # Not at target conversion, but something got converted
             # This means we need to convert the args before doing a dim conversion
-            register_computation!(attr, [:args], [:recursive_convert]) do args, changed, last
-                return (convert_arguments(P, args.args...),)
+            map!(attr, :args, :recursive_convert) do args
+                return convert_arguments(P, args...)
             end
             add_dim_converts!(attr, dim_converts, args_converted, :recursive_convert)
         else
@@ -418,20 +418,20 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
     end
     #  backwards compatibility for plot.converted (and not only compatibility, but it's just convenient to have)
 
-    register_computation!(attr, [:dim_converted, :convert_kwargs], [:converted]) do args, changed, last
-        x = convert_arguments(P, args.dim_converted...; args.convert_kwargs...)
+    map!(attr, [:dim_converted, :convert_kwargs], :converted) do dim_converted, convert_kwargs
+        x = convert_arguments(P, dim_converted...; convert_kwargs...)
         if x isa Tuple
-            return (x,)
+            return x
         elseif x isa Union{PlotSpec, AbstractVector{PlotSpec}, GridLayoutSpec}
-            return ((x,),)
+            return (x,)
         else
             error("Result needs to be Tuple or SpecApi")
         end
     end
     converted = attr[:converted][]
     n_args = length(converted)
-    register_computation!(attr, [:converted], [argument_names(P, n_args)...]) do args, changed, last
-        return args.converted # destructure
+    map!(attr, :converted, [argument_names(P, n_args)...]) do converted
+        return converted # destructure
     end
 
     add_input!((k, v) -> Ref{Any}(v), attr, :transform_func, identity)
@@ -445,10 +445,10 @@ function register_marker_computations!(attr::ComputeGraph)
 
     # TODO: allowing user supplied atlas for e.g. sprite animations would be nice...
 
-    return register_computation!(
+    return map!(
         attr, [:marker, :markersize, :font],
         [:quad_offset, :quad_scale]
-    ) do (marker, markersize, font), changed, last
+    ) do marker, markersize, font
         atlas = get_texture_atlas()
         quad_scale = rescale_marker(atlas, marker, font, markersize)
         quad_offset = offset_marker(atlas, marker, font, markersize)
@@ -770,7 +770,7 @@ end
 
 function register_mesh_decomposition!(attr)
     # :arg1 is user input, :mesh is after convert_arguments and dim converts (?)
-    register_computation!(attr, [:mesh], [:positions, :faces, :normals, :texturecoordinates]) do (merged,), changed, cached
+    map!(attr, :mesh, [:positions, :faces, :normals, :texturecoordinates]) do merged
         pos = coordinates(merged)
         faces = decompose(GLTriangleFace, merged)
         normies = normals(merged)
@@ -778,7 +778,10 @@ function register_mesh_decomposition!(attr)
         return (pos, faces, normies, texturecoords)
     end
 
-    return register_computation!(attr, [:arg1, :mesh, :color], [:mesh_color, :interpolate_in_fragment_shader]) do (meshes, merged, color), changed, cached
+    return map!(
+        attr, [:arg1, :mesh, :color], [:mesh_color, :interpolate_in_fragment_shader]
+    ) do meshes, merged, color
+
         if hasproperty(merged, :color)
             return (merged.color, true)
         elseif meshes isa Vector{<:AbstractGeometry} && color isa Vector && length(color) == length(meshes)


### PR DESCRIPTION
# Description

Replaces a bunch of `register_computation!()` calls with `map!()`. Probably improves compile times

## Type of change

- [x] internal cleanup
