### PR TITLE
fix arrow metrics not triggering arrow position updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed arrow marker attributes in `arrows3d` not triggering repositioning of arrows. [#5134](https://github.com/MakieOrg/Makie.jl/pull/5134)
+
 ## [0.24.2] - 2025-06-27
 
 - Bring back some default attributes for recipes [#5130](https://github.com/MakieOrg/Makie.jl/pull/5130).

--- a/Makie/src/basic_recipes/arrows.jl
+++ b/Makie/src/basic_recipes/arrows.jl
@@ -694,16 +694,16 @@ function Makie.plot!(plot::Arrows3D)
     tail_visible = map((l, v) -> !iszero(l) && v, plot, plot.taillength, visible)
 
     # Skip startpoints, directions inputs to avoid double update (let arrow metrics trigger)
-    shaft_pos = map(plot, normalized_dir) do dirs
-        map(arrow_metrics[], startpoints_directions[][1], dirs) do metric, pos, dir
+    shaft_pos = map(plot, normalized_dir, arrow_metrics) do dirs, metrics
+        map(metrics, startpoints_directions[][1], dirs) do metric, pos, dir
             taillength, tailradius, shaftlength, shaftradius, tiplength, tipradius = metric
             return pos + taillength * dir
         end
     end
     shaft_scale = map(metrics -> [Vec3f(2r, 2r, l) for (_, _, l, r, _, _) in metrics], plot, arrow_metrics)
 
-    tip_pos = map(plot, normalized_dir) do dirs
-        map(arrow_metrics[], startpoints_directions[][1], dirs) do metric, pos, dir
+    tip_pos = map(plot, normalized_dir, arrow_metrics) do dirs, metrics
+        map(metrics, startpoints_directions[][1], dirs) do metric, pos, dir
             taillength, tailradius, shaftlength, shaftradius, tiplength, tipradius = metric
             return pos + (taillength + shaftlength) * dir
         end


### PR DESCRIPTION
# Description

Fixes things like `arrow_plot.tiplength = ...` not triggering an update of component positions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
