### PR TITLE
Add additional scales based on `ReversibleScale`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+ - Added new scales based on `ReversibleScale` for use as `colorscale`, `xscale`, and `yscale` attributes. The new scales are `AsinhScale`, `SinhScale`, `LogScale`, `LuptonAsinhScale`, and `PowerScale`.
 
 ## [0.24.3] - 2025-07-04
 

--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -98,7 +98,7 @@ end
 - `colormap::Union{Symbol, Vector{<:Colorant}} = :viridis` sets the colormap that is sampled for numeric `color`s.
   `PlotUtils.cgrad(...)`, `Makie.Reverse(any_colormap)` can be used as well, or any symbol from ColorBrewer or PlotUtils.
   To see all available color gradients, you can call `Makie.available_gradients()`.
-- `colorscale::Function = identity` color transform function. Can be any function, but only works well together with `Colorbar` for `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10` and `Makie.Symlog10`.
+- `colorscale::Function = identity` color transform function. Can be any function, but only works well together with `Colorbar` for `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10`, `Makie.Symlog10`, `Makie.AsinhScale`, `Makie.SinhScale`, `Makie.LogScale`, `Makie.LuptonAsinhScale`, and `Makie.PowerScale`.
 - `colorrange::Tuple{<:Real, <:Real}` sets the values representing the start and end points of `colormap`.
 - `nan_color::Union{Symbol, <:Colorant} = RGBAf(0,0,0,0)` sets a replacement color for `color = NaN`.
 - `lowclip::Union{Nothing, Symbol, <:Colorant} = nothing` sets a color for any value below the colorrange.
@@ -137,7 +137,7 @@ function mixin_colormap_attributes()
         """
         colormap = @inherit colormap :viridis
         """
-        The color transform function. Can be any function, but only works well together with `Colorbar` for `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10` and `Makie.Symlog10`.
+        The color transform function. Can be any function, but only works well together with `Colorbar` for `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10`, `Makie.Symlog10`, `Makie.AsinhScale`, `Makie.SinhScale`, `Makie.LogScale`, `Makie.LuptonAsinhScale`, and `Makie.PowerScale`.
         """
         colorscale = identity
         "The values representing the start and end points of `colormap`."

--- a/Makie/src/layouting/transformation.jl
+++ b/Makie/src/layouting/transformation.jl
@@ -471,8 +471,6 @@ An asinh scaling defined as
 ```math
 y = \\frac{\\text{asinh} \\left(x/a\\right)}{\\text{asinh} \\left(1/a\\right)}
 ```
-
-This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
 """
 function AsinhScale(a=0.1)
     a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
@@ -487,8 +485,6 @@ A sinh scaling defined as
 ```math
 y = \\frac{\\text{sinh} \\left(x/a\\right)}{\\text{sinh} \\left(1/a\\right)}
 ```
-
-This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
 """
 function SinhScale(a=1/3)
     a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
@@ -504,8 +500,6 @@ A logarithmic scaling defined as
 ```math
 y = \\frac{\\text{log}_b \\left(ax + 1\right)}{\\text{log}_b \\left(a+1\\right)}
 ```
-
-This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
 """
 function LogScale(a=1000, base=ℯ)
     a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
@@ -526,9 +520,7 @@ defined as
 y = \\text{asinh} \\left( \\frac{Q * x}{a} \\right) \\times \\frac{a}{\\text{asinh} \\left(Q*a\\right)}
 ```
 
-The argument `a` is the linear scaling parameter and `Q` is the asinh softening parameter. To find an effective scaling, the authors recommend setting `Q` to near zero and adjusting the linear scaling `a` to a reasonable level, then increasing `Q` to accentuate faint features.
-
-This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+This scaling is typically used to adjust the intensity scaling of astronomical images. The argument `a` is the linear scaling parameter and `Q` is the asinh softening parameter. To find an effective scaling, the authors recommend setting `Q` to near zero and adjusting the linear scaling `a` to a reasonable level, then increasing `Q` to accentuate faint features.
 """
 function LuptonAsinhScale(a=0.1, Q=0.01, frac=0.1)
     a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
@@ -541,7 +533,7 @@ end
 """
     PowerScale(a=1)
 
-A power-law scaling derived as ``y = x^a``. This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+A power-law scaling derived as ``y = x^a``.
 """
 function PowerScale(a=1)
     a < 0 && throw(ArgumentError("Argument `a` must be > 0."))

--- a/Makie/src/layouting/transformation.jl
+++ b/Makie/src/layouting/transformation.jl
@@ -464,6 +464,92 @@ function Symlog10(lo, hi)
     return ReversibleScale(forward, inverse; limits = (0.0f0, 3.0f0), name = :Symlog10)
 end
 
+"""
+    AsinhScale(a=0.1)
+
+An asinh scaling defined as
+```math
+y = \\frac{\\text{asinh} \\left(x/a\\right)}{\\text{asinh} \\left(1/a\\right)}
+```
+
+This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+"""
+function AsinhScale(a=0.1)
+    a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
+    forward(x) = asinh(x/a) / asinh(1/a)
+    inverse(x) = a * sinh(asinh(1/a) * x)
+    return ReversibleScale(forward, inverse; name = :AsinhScale)
+end
+
+"""
+    SinhScale(a=1/3)
+A sinh scaling defined as
+```math
+y = \\frac{\\text{sinh} \\left(x/a\\right)}{\\text{sinh} \\left(1/a\\right)}
+```
+
+This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+"""
+function SinhScale(a=1/3)
+    a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
+    forward(x) = sinh(x/a) / sinh(1/a)
+    inverse(x) = a * asinh(sinh(1/a) * x)
+    return ReversibleScale(forward, inverse; name = :SinhScale)
+end
+
+"""
+    LogScale(a=1000, base=ℯ)
+
+A logarithmic scaling defined as
+```math
+y = \\frac{\\text{log}_b \\left(ax + 1\right)}{\\text{log}_b \\left(a+1\\right)}
+```
+
+This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+"""
+function LogScale(a=1000, base=ℯ)
+    a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
+    base < 0 && throw(ArgumentError("Argument `base` must be > 0."))
+    forward(x) = log(base, a*x + 1) / log(base, a + 1)
+    inverse(x) = ((1 + a)^x - 1) / a
+    return ReversibleScale(forward, inverse; limits=(0.0f0, 3.0f0), name = :LogScale)
+end
+
+"""
+    LuptonAsinhScale(a=0.1, Q=0.01, frac=0.1)
+
+A modified asinh scaling based on
+[Lupton et al. 2004](https://ui.adsabs.harvard.edu/abs/2004PASP..116..133L)
+defined as
+
+```math
+y = \\text{asinh} \\left( \\frac{Q * x}{a} \\right) \\times \\frac{a}{\\text{asinh} \\left(Q*a\\right)}
+```
+
+The argument `a` is the linear scaling parameter and `Q` is the asinh softening parameter. To find an effective scaling, the authors recommend setting `Q` to near zero and adjusting the linear scaling `a` to a reasonable level, then increasing `Q` to accentuate faint features.
+
+This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+"""
+function LuptonAsinhScale(a=0.1, Q=0.01, frac=0.1)
+    a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
+    Q < 0 && throw(ArgumentError("Argument `Q` must be > 0."))
+    forward(x) = asinh(Q*x/a) * frac / asinh(frac*Q)
+    inverse(x) = a * sinh(asinh(frac*Q) * x / frac) / Q
+    return ReversibleScale(forward, inverse; name = :LuptonAsinhScale)
+end
+
+"""
+    PowerScale(a=1)
+
+A power-law scaling derived as ``y = x^a``. This can be used as the `colorscale` keyword argument to [`heatmap`](@ref).
+"""
+function PowerScale(a=1)
+    a < 0 && throw(ArgumentError("Argument `a` must be > 0."))
+    forward(x) = x^a
+    inverse(x) = x^(inv(a))
+    return ReversibleScale(forward, inverse; name = :PowerScale)
+end
+
 function inverse_transform(f)
     f⁻¹ = InverseFunctions.inverse(f)
     return f⁻¹ isa InverseFunctions.NoInverse ? nothing : f⁻¹  # nothing is for backwards compatibility

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -679,7 +679,7 @@ Axis(fig_or_scene; palette = nothing, kwargs...)
         The scaling function for the x axis.
 
         Can be any invertible function, some predefined options are
-        `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10` and `Makie.Symlog10`.
+        `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10`, `Makie.Symlog10`, `Makie.AsinhScale`, `Makie.SinhScale`, `Makie.LogScale`, `Makie.LuptonAsinhScale`, and `Makie.PowerScale`.
         To use a custom function, you have to define appropriate methods for `Makie.inverse_transform`,
         `Makie.defaultlimits` and `Makie.defined_interval`.
 
@@ -698,7 +698,7 @@ Axis(fig_or_scene; palette = nothing, kwargs...)
         The scaling function for the y axis.
 
         Can be any invertible function, some predefined options are
-        `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10` and `Makie.Symlog10`.
+        `identity`, `log`, `log2`, `log10`, `sqrt`, `logit`, `Makie.pseudolog10`, `Makie.Symlog10`, `Makie.AsinhScale`, `Makie.SinhScale`, `Makie.LogScale`, `Makie.LuptonAsinhScale`, and `Makie.PowerScale`.
         To use a custom function, you have to define appropriate methods for `Makie.inverse_transform`,
         `Makie.defaultlimits` and `Makie.defined_interval`.
 

--- a/Makie/test/SceneLike/makielayout.jl
+++ b/Makie/test/SceneLike/makielayout.jl
@@ -552,13 +552,16 @@ end
     y = 1.0:0.1:5.0
     z = broadcast((x, y) -> x, x, y')
 
-    scale = Makie.Symlog10(2)
-    fig, ax, hm = heatmap(x, y, z; colorscale = scale, axis = (; xscale = scale))
-    Colorbar(fig[1, 2], hm)
-
-    scale = Makie.pseudolog10
-    fig, ax, hm = heatmap(x, y, z; colorscale = scale, axis = (; xscale = scale))
-    Colorbar(fig[1, 2], hm)
+    for scale in (Makie.Symlog10(2), 
+        Makie.pseudolog10, 
+        Makie.AsinhScale(0.1), 
+        Makie.SinhScale(1/3), 
+        Makie.LogScale(1000, ℯ), 
+        Makie.LuptonAsinhScale(0.1, 0.01, 0.1), 
+        Makie.PowerScale(1))
+        fig, ax, hm = heatmap(x, y, z; colorscale = scale, axis = (; xscale = scale))
+        Colorbar(fig[1, 2], hm)
+    end
 end
 
 @testset "Axis scale" begin


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Implements additional scales based on `ReversibleScale`. These are mostly inspired by color scales implemented in the astronomy-focused astropy project. I am using these as `colorscale` keyword arguments to methods like `heatmap`, but other uses may also be possible. Based on the tests that I added, they seem to work as `xscale` and `yscale` parameters, though `LogScale` will not work for negative `x` values. I could add a symmetric implementation for negative `x` values like is used for `Symlog10` if you think it's important the `LogScale` support all real `x`.

## Type of change
New feature (non-breaking change which adds functionality)

## Checklist

- [ x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ x] Added or changed relevant sections in the documentation
- [x ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
Not sure what the last point is asking me to do.
