### PR TITLE
Fix changing text types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed `p.text = "..."` erroring with `p = text(..., text = rich(...))` [#5173](https://github.com/MakieOrg/Makie.jl/pull/5173)
+
 ## [0.24.3] - 2025-07-04
 
 - Fix empty plotlist [#5150](https://github.com/MakieOrg/Makie.jl/pull/5150).

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -25,7 +25,8 @@ convert_attribute(align, ::key"align", ::key"text") = Ref{Any}(align)
 
 # Positions are always vectors so text should be too
 convert_attribute(str::AbstractString, ::key"text", ::key"text") = Ref{Any}([str]) # don't fix string type
-convert_attribute(x::AbstractVector, ::key"text", ::key"text") = vec(x)
+convert_attribute(rt::RichText, ::key"text", ::key"text") = Ref{Any}([rt])
+convert_attribute(x::AbstractVector, ::key"text", ::key"text") = Ref{Any}(vec(x))
 
 to_string_arr(text::AbstractVector) = text
 to_string_arr(text) = [text]
@@ -854,8 +855,6 @@ where both scripts are right-aligned against the following text.
 left_subsup(args...; kwargs...) = RichText(:leftsubsup, args...; kwargs...)
 
 export rich, subscript, superscript, subsup, left_subsup
-
-convert_attribute(rt::RichText, ::key"text", ::key"text") = [rt]
 
 struct GlyphState
     x::Float32

--- a/Makie/test/plots/text.jl
+++ b/Makie/test/plots/text.jl
@@ -107,7 +107,6 @@ end
     @test scales == fta_scales
 end
 
-
 @testset "old text syntax" begin
     text("text", position = Point2f(0, 0))
     text(["text"], position = [Point2f(0, 0)])
@@ -121,4 +120,28 @@ end
     err = ArgumentError("`textsize` has been renamed to `fontsize` in Makie v0.19. Please change all occurrences of `textsize` to `fontsize` or revert back to an earlier version.")
     @test_throws err Label(Figure()[1, 1], "hi", textsize = 30)
     # @test_throws err text(1, 2, text = "hi", textsize = 30)
+end
+
+@testset "Text type changes" begin
+    scene = Scene()
+    for initial_text in ["test", rich("test"), L"test"]
+        p = text!(scene, 0, 0, text = initial_text)
+        @test begin
+            for changed in ["test", rich("test"), L"test"]
+                p.text = changed
+                p.glyphindices[]
+            end
+            true
+        end
+
+        p = text!(scene, 0, 0, text = [initial_text])
+        @test begin
+            for changed in ["test", rich("test"), L"test"]
+                p.text = [changed]
+                p.glyphindices[]
+            end
+            true
+        end
+    end
+
 end

--- a/Makie/test/plots/text.jl
+++ b/Makie/test/plots/text.jl
@@ -143,5 +143,4 @@ end
             true
         end
     end
-
 end


### PR DESCRIPTION
# Description

Fixes #5168. 

If a computation returns a `Ref`, that Ref is used directly in the compute node. That allows you to prevent the type getting fixed to what it is at initialization. Here we missed a convert_attribute() for rich text (and maybe the vector one too?)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
