### PR TITLE
specapi fixes

### DIFF
--- a/GLMakie/test/Project.toml
+++ b/GLMakie/test/Project.toml
@@ -2,7 +2,6 @@
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/ReferenceUpdater/Project.toml
+++ b/ReferenceUpdater/Project.toml
@@ -22,7 +22,7 @@ ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 
 [compat]
 Bonito = "3, 4"
-Colors = "0.13.0"
+Colors = "0.12, 0.13.0"
 DelimitedFiles = "1.9.1"
 FFMPEG_jll = "6.1.2"
 FileIO = "1.16.6"


### PR DESCRIPTION
I noticed that changing the plot type in an axis creates a new axis:
```julia
function to_spec(Typ, cmap=:viridis, ms=20, f=sin)
    ms = Typ == S.Scatter ? (; markersize = ms) : (; linewidth = ms)
    pl = Typ(
        xrange, f.(yrange);
        colormap = cmap,
        color=yrange,
        ms...
    )
    cb = S.Colorbar(pl)
    S.GridLayout(
        [S.Axis(plots = [pl]) cb]
    )
end
begin 
    f = sin
    xrange = 0:0.3:10
    yrange = f.(xrange)
    typ = Observable{Any}(S.Scatter)
    obs = map(to_spec, typ)
    f, ax, pl = plot(obs)
    display(f)
end
typ[] = S.Lines

```

The reason is, that `distance_score(ax1, ax2) == 100` for different plot types in the axis, which is way over the threshold so we dont match the axes, and need to create new ones.
I took out typ comparison in the PlotSpec distance score, and instead do the check if types match in `find_minimum_score` which should be a nice shortcuircit condition for performance, and means the comparison between plots of the same type come out much smaller. 
