### PR TITLE
Recreate the CairoScreen if its pointer is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix an error in CairoMakie's screen management where corrupted (null-pointer) screens were not reconstructed on the next display []().
+
 ## [0.24.4] - 2025-07-17
 
 - Fixed rendering of volumes when the camera is inside the volume [#5164](https://github.com/MakieOrg/Makie.jl/pull/5164)

--- a/CairoMakie/src/screen.jl
+++ b/CairoMakie/src/screen.jl
@@ -291,7 +291,7 @@ function Makie.apply_screen_config!(
     # we need to re-create the screen if the rendertype changes, or for all vector backends
     # since they need to use the new IO, or if the resolution changed!
     new_resolution = scaled_scene_resolution(new_rendertype, config, scene)
-    if SCREEN_RT !== new_rendertype || is_vector_backend(new_rendertype) || size(screen) != new_resolution
+    if SCREEN_RT !== new_rendertype || is_vector_backend(new_rendertype) || size(screen) != new_resolution || screen.surface.ptr == C_NULL
         old_screen = screen
         surface = surface_from_output_type(new_rendertype, io, new_resolution...)
         screen = Screen(scene, config, surface)

--- a/CairoMakie/test/runtests.jl
+++ b/CairoMakie/test/runtests.jl
@@ -338,3 +338,17 @@ end
         end
     end
 end
+
+@testset "Screen is reconstructed if pointer is null" begin
+    fig = Figure()
+    ax = Axis(fig[1, 1])
+    lines!(ax, rand(10))
+
+    # First, show the main scene:
+    @test_nowarn colorbuffer(fig)
+    # Then, show a subscene
+    @test_nowarn colorbuffer(ax.scene)
+    # Then, show the main scene again
+    @test_nowarn colorbuffer(fig)
+    # If we have made it to here with no errors - profit!
+end


### PR DESCRIPTION
# Description

This allows
```julia
colorbuffer(fig)
colorbuffer(ax.scene)
colorbuffer(fig) # this used to fail because the screen pointer was C_NULL
```
in CairoMakie, by adding an additional condition that triggers screen reconstruction.

## Type of change

Delete options that do not apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [X] Added unit tests