### PR TITLE
Fix meshscatter marker update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed incorrect variable name used for `voxels` in `Colorbar` [#5208](https://github.com/MakieOrg/Makie.jl/pull/5208)
 - Fixed `Time` ticks breaking when axis limits crossed over midnight [#5212](https://github.com/MakieOrg/Makie.jl/pull/5212).
+- Fixed `meshscatter` markers not updating correctly in GLMakie [#5217](https://github.com/MakieOrg/Makie.jl/pull/5217)
 
 ## Unreleased
 

--- a/GLMakie/src/glshaders/particles.jl
+++ b/GLMakie/src/glshaders/particles.jl
@@ -50,14 +50,17 @@ end
 """
 This is the main function to assemble particles with a GLNormalMesh as a primitive
 """
-function draw_mesh_particle(screen, p, data)
-    to_opengl_mesh!(screen.glscreen, data, p[1]) # TODO: new functions need something else
+function draw_mesh_particle(screen, data)
     @gen_defaults! data begin
-        position = p[2] => TextureBuffer
+        vertices = nothing => GLBuffer
+        faces = nothing => indexbuffer
+        normals = nothing => GLBuffer
+        texturecoordinates = nothing => GLBuffer
+
+        position = Point3f[] => TextureBuffer
         scale = Vec3f(1) => TextureBuffer
         rotation = Quaternionf(0, 0, 0, 1) => TextureBuffer
         f32c_scale = Vec3f(1) # drawing_primitives.jl
-        texturecoordinates = nothing
     end
 
     shading = pop!(data, :shading)::Makie.ShadingAlgorithm

--- a/GLMakie/src/plot-primitives.jl
+++ b/GLMakie/src/plot-primitives.jl
@@ -512,14 +512,13 @@ function assemble_meshscatter_robj!(data, screen::Screen, attr, args, input2glna
         input2glname[:scaled_color] = :color
     end
 
-    marker = attr[:marker][]
-    positions = data[:position]
-    return draw_mesh_particle(screen, (marker, positions), data)
+    return draw_mesh_particle(screen, data)
 end
 
 function draw_atomic(screen::Screen, scene::Scene, plot::MeshScatter)
     attr = generic_robj_setup(screen, scene, plot)
 
+    Makie.add_computation!(attr, Val(:disassemble_mesh), :marker)
     Makie.add_computation!(attr, Val(:uniform_clip_planes))
     Makie.add_computation!(attr, scene, Val(:uv_transform_packing))
     Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
@@ -539,6 +538,7 @@ function draw_atomic(screen::Screen, scene::Scene, plot::MeshScatter)
     ]
     uniforms = [
         :positions_transformed_f32c, :markersize, :rotation, :f32c_scale, :instances,
+        :vertex_position, :faces, :normal, :uv,
         :lowclip_color, :highclip_color, :nan_color, :matcap,
         :fetch_pixel, :model_f32c,
         :diffuse, :specular, :shininess, :backlight, :world_normalmatrix, :view_normalmatrix,
@@ -547,6 +547,7 @@ function draw_atomic(screen::Screen, scene::Scene, plot::MeshScatter)
 
     input2glname = Dict{Symbol, Symbol}(
         :positions_transformed_f32c => :position, :markersize => :scale,
+        :vertex_position => :vertices, :normal => :normals, :uv => :texturecoordinates,
         :packed_uv_transform => :uv_transform,
         :alpha_colormap => :color_map, :scaled_colorrange => :color_norm,
         :scaled_color => :color, :lowclip_color => :lowclip, :highclip_color => :highclip,

--- a/Makie/src/backend-functionality.jl
+++ b/Makie/src/backend-functionality.jl
@@ -190,6 +190,18 @@ function add_computation!(attr, scene, ::Val{:meshscatter_f32c_scale})
     end
 end
 
+
+function add_computation!(attr, ::Val{:disassemble_mesh}, name = :marker)
+    map!(attr, name, [:vertex_position, :faces, :normal, :uv]) do mesh
+        faces = decompose(GLTriangleFace, mesh)
+        normals = decompose_normals(mesh)
+        texturecoordinates = decompose_uv(mesh)
+        positions = decompose(Point3f, mesh)
+        return (positions, faces, normals, texturecoordinates)
+    end
+    return
+end
+
 function add_computation!(attr, scene, ::Val{:pattern_uv_transform}; kwargs...)
     return register_pattern_uv_transform!(attr; kwargs...)
 end

--- a/ReferenceTests/src/tests/updating.jl
+++ b/ReferenceTests/src/tests/updating.jl
@@ -294,3 +294,17 @@ end
     notify(Z)
     Makie.step!(st)
 end
+
+@reference_test "meshscatter update" begin
+    f,a,p = meshscatter([Point3f(0)])
+    st = Stepper(f)
+    Makie.step!(st)
+
+    p.marker = Rect3f(0, 0, 0, 1, 1, 1)
+    p.color = :red
+    p.markersize = Vec3f(0.2, 0.1, 0.05)
+    p.rotation = Vec3f(1, 1, -1)
+    p.alpha = 0.5
+    p.arg1 = [Point3f(-0.1, -0.05, 0), Point3f(0.1,0,0), Point3f(0,0.15,0)]
+    Makie.step!(st)
+end

--- a/WGLMakie/assets/particles.vert
+++ b/WGLMakie/assets/particles.vert
@@ -78,7 +78,7 @@ vec4 to_color(vec4 c) {
 void main(){
     // get_* gets the global inputs (uniform, sampler, position array)
     // those functions will get inserted by the shader creation pipeline
-    vec3 vertex_position = get_markersize() * to_vec3(get_position());
+    vec3 vertex_position = get_markersize() * to_vec3(get_vertex_position());
     vec3 N = get_normal() / get_markersize(); // see issue #3702
     rotate(get_converted_rotation(), vertex_position, N);
     vertex_position = get_f32c_scale() * vertex_position;

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -384,7 +384,7 @@ to_3x3(xs::Vector{Vec2f}) = Sampler(xs) # already has appropriate format
 
 function meshscatter_program(args)
     instance = Dict(
-        :position => args.position,
+        :vertex_position => args.vertex_position,
         :faces => args.faces,
         :normal => args.normal,
     )
@@ -416,20 +416,11 @@ function meshscatter_program(args)
 end
 
 
-function disassemble_mesh!(attr, mesh_sym = :marker)
-    return map!(attr, [mesh_sym], [:position, :faces, :normal, :uv]) do mesh
-        faces = decompose(GLTriangleFace, mesh)
-        normals = decompose_normals(mesh)
-        texturecoordinates = decompose_uv(mesh)
-        positions = decompose(Point3f, mesh)
-        return (positions, faces, normals, texturecoordinates)
-    end
-end
 
 function create_shader(scene::Scene, plot::MeshScatter)
     attr = plot.attributes
 
-    disassemble_mesh!(attr)
+    Makie.add_computation!(attr, Val(:disassemble_mesh), :marker)
     Makie.add_computation!(attr, scene, Val(:uv_transform_packing))
     map!(to_3x3, attr, :packed_uv_transform, :wgl_uv_transform)
     Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
@@ -440,7 +431,7 @@ function create_shader(scene::Scene, plot::MeshScatter)
     ComputePipeline.alias!(attr, :rotation, :converted_rotation)
 
     inputs = [
-        :position, :faces, :normal, :uv, # marker mesh
+        :vertex_position, :faces, :normal, :uv, # marker mesh
         :uniform_colormap, :uniform_color, :uniform_colorrange, :vertex_color,
         :wgl_uv_transform, :pattern,
         :positions_transformed_f32c, :markersize, :converted_rotation, :f32c_scale,


### PR DESCRIPTION
# Description

Fixes this not updating the mesh in GLMakie:
```julia
f, ax, plot = meshscatter([Point3f(0.0, 0.0, 0.0)], marker=Sphere(Point(0.0, 0.0, 0.0), 1.0))
display(f)
plot.marker = Rect3f(0, 0, 0, 1, 1, 1)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [x] Added reference image tests for new plotting functions, recipes, visual options, etc.
