### PR TITLE
support RichText concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- Added support for RichText concatenation using the `*` operator, e.g., `"text" * rich("bold", font=:bold)` [#5221](https://github.com/MakieOrg/Makie.jl/pull/5221)
 - Fixed incorrect variable name used for `voxels` in `Colorbar` [#5208](https://github.com/MakieOrg/Makie.jl/pull/5208)
 - Fixed `Time` ticks breaking when axis limits crossed over midnight [#5212](https://github.com/MakieOrg/Makie.jl/pull/5212).
 - Fixed `meshscatter` markers not updating correctly in GLMakie [#5217](https://github.com/MakieOrg/Makie.jl/pull/5217)

--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -845,6 +845,10 @@ where both scripts are right-aligned against the following text.
 """
 left_subsup(args...; kwargs...) = RichText(:leftsubsup, args...; kwargs...)
 
+Base.:*(x::RichText, y::AbstractString) = rich(x, y)
+Base.:*(x::AbstractString, y::RichText) = rich(x, y)
+Base.:*(x::RichText, y::RichText) = rich(x, y)
+
 export rich, subscript, superscript, subsup, left_subsup
 
 struct GlyphState

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -700,7 +700,7 @@ end
     )
     gl = GridLayout(f[1, 2], tellheight = false)
     Label(gl[1, 1], rich("Hi", rich("Hi", offset = (0.2, 0.2), color = :blue)))
-    Label(gl[2, 1], rich("X", superscript("super"), subscript("sub")))
+    Label(gl[2, 1], "X" * superscript("super") * subscript("sub"))
     Label(gl[3, 1], rich(left_subsup("92", "238"), "U"))
     Label(gl[4, 1], rich("SO", subsup("4", "2−")))
     Label(gl[5, 1], rich("x", subsup("f", "g")))

--- a/ReferenceTests/src/tests/figures_and_makielayout.jl
+++ b/ReferenceTests/src/tests/figures_and_makielayout.jl
@@ -695,8 +695,8 @@ end
         xscale = log10,
         yscale = log2,
         title = rich("A ", rich("title", color = :red, font = :bold_italic)),
-        xlabel = rich("X", subscript("label", fontsize = 25)),
-        ylabel = rich("Y", superscript("label")),
+        xlabel = "X" * subscript("label", fontsize = 25),
+        ylabel = "Y" * superscript("label"),
     )
     gl = GridLayout(f[1, 2], tellheight = false)
     Label(gl[1, 1], rich("Hi", rich("Hi", offset = (0.2, 0.2), color = :blue)))


### PR DESCRIPTION
Fixes https://github.com/MakieOrg/Makie.jl/issues/4393.

# Description

Fixes #4393.
Support `*` for `RichText`, to make creating rich text labels cleaner.

## Type of change

Delete options that do not apply:

- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
