### PR TITLE
sync `limits` attribute across linked axis when using `xlims!`/`ylims!`

### DIFF
--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -1256,6 +1256,13 @@ function Makie.xlims!(ax::Axis, xlims)
 
     mlims = convert_limit_attribute(ax.limits[])
     ax.limits.val = (xlims, mlims[2])
+
+    # update xlims for linked axes
+    for xlink in ax.xaxislinks
+        xlink_mlims = convert_limit_attribute(xlink.limits[])
+        xlink.limits.val = (xlims, xlink_mlims[2])
+    end
+
     reset_limits!(ax, yauto = false)
     return nothing
 end
@@ -1274,6 +1281,13 @@ function Makie.ylims!(ax::Axis, ylims)
     end
     mlims = convert_limit_attribute(ax.limits[])
     ax.limits.val = (mlims[1], ylims)
+
+    # update ylims for linked axes
+    for ylink in ax.yaxislinks
+        ylink_mlims = convert_limit_attribute(ylink.limits[])
+        ylink.limits.val = (ylink_mlims[1], ylims)
+    end
+
     reset_limits!(ax, xauto = false)
     return nothing
 end


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

Fixes #4837

Currently, calling `xlims!`/`ylims!` on an axis does not change the `ax.limits` of the other linked axes, only their `ax.targetlimits`. This works well in most cases, but if `reset_limits!` is called on one of the other axes (for example directly through ctrl + left click or indirectly through `display(fig)`), they will reset to their original `ax.limits`, not the one set by `xlims!`/`ylims!`.

Example from the issue #4837:
```julia
using GLMakie

x = 1:10
y = rand(10)

f = Figure()
ax1 = Axis(f[1, 1])
sc1 = scatter!(ax1, x, y)
ax2 = Axis(f[2, 1])
sc2 = scatter!(ax2, x, y)
linkaxes!(ax1, ax2)
xlims!(ax1, 4, 8)
display(f) # this triggers a reset_limits!(ax) on all the figure elements
```
<img width="400" height="432" alt="image" src="https://github.com/user-attachments/assets/330fdb68-e219-4222-bb1e-f52ea4585d7a" />

Here the `display(fig)` triggered a `reset_limits!` on the content of `fig`, first on `ax1` and then on `ax2`. As such, the "final" limits are the one contained in `ax2.limits`, which were not updated by the `xlims!` call.

The same behavior occurs if one does
```julia
display(f) 
xlims!(ax1, 4, 8)
reset_limits!(ax2) # same as interactively doing a ctrl + left click
```

<br></br>
With this PR, calling `xlims!`/`ylims!` on an axis will also update the `ax.limits` of the linked axis, and the above example gives

<img width="400" height="432" alt="image" src="https://github.com/user-attachments/assets/bfd8c324-774d-4a8d-aac1-0f9a2af5e177" />


I think this is more the expected behavior of linking axis together.



## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
