### PR TITLE
implement a simple compression for value -> n_array_value -> value

### DIFF
--- a/Makie/src/basic_recipes/text.jl
+++ b/Makie/src/basic_recipes/text.jl
@@ -71,7 +71,6 @@ function register_arguments!(::Type{Text}, attr::ComputeGraph, user_kw, input_ar
     return
 end
 
-
 function per_glyph_getindex(x, text_blocks::Vector{UnitRange{Int}}, gi::Int, bi::Int)
     if isscalar(x)
         return x
@@ -331,28 +330,23 @@ function compute_glyph_collections!(attr::ComputeGraph)
         :linesegments, :linewidths, :linecolors, :lineindices,
     ]
     return register_computation!(attr, inputs, outputs) do (input_texts, _inputs...), changed, cached
-        if isnothing(cached)
-            _outputs = (
-                glyphcollections = GlyphCollection[],
-                glyphindices = UInt64[],
-                font_per_char = NativeFont[],
-                glyph_origins = Point3f[],
-                glyph_extents = GlyphExtent[],
-                text_blocks = UnitRange{Int64}[],
-                text_color = RGBAf[],
-                text_rotation = Quaternionf[],
-                text_scales = Vec2f[],
-                text_strokewidth = Float32[],
-                text_strokecolor = RGBAf[],
-                linesegments = Point3f[],
-                linewidths = Float32[],
-                linecolors = RGBAf[],
-                lineindices = Pair{Int, Int}[],
-            )
-        else
-            foreach(empty!, values(cached))
-            _outputs = cached
-        end
+        _outputs = (
+            glyphcollections = GlyphCollection[],
+            glyphindices = UInt64[],
+            font_per_char = NativeFont[],
+            glyph_origins = Point3f[],
+            glyph_extents = GlyphExtent[],
+            text_blocks = UnitRange{Int64}[],
+            text_color = RGBAf[],
+            text_rotation = Quaternionf[],
+            text_scales = Vec2f[],
+            text_strokewidth = Float32[],
+            text_strokecolor = RGBAf[],
+            linesegments = Point3f[],
+            linewidths = Float32[],
+            linecolors = RGBAf[],
+            lineindices = Pair{Int, Int}[],
+        )
         # strokewidth = Float32[] # TODO: Skipped?
 
         N = length(input_texts)

--- a/WGLMakie/src/javascript/Plots.js
+++ b/WGLMakie/src/javascript/Plots.js
@@ -169,6 +169,28 @@ export class Plot {
                 );
             }
         }
+
+        // Check if new_data is in compressed format
+        if (new_data && typeof new_data === 'object' && 'value' in new_data && 'length' in new_data) {
+            // Expand compressed format back to full array
+            const value = new_data.value;
+            if (value instanceof Float32Array || Array.isArray(value)) {
+                // Handle Vec3f case - value is an array/Float32Array that needs to be repeated
+                const element_size = value.length;
+                const total_size = new_data.length * element_size;
+                const expanded_array = new Float32Array(total_size);
+
+                for (let i = 0; i < new_data.length; i++) {
+                    expanded_array.set(value, i * element_size);
+                }
+                new_data = expanded_array;
+            } else {
+                // Handle scalar case - single value repeated
+                const expanded_array = new Float32Array(new_data.length).fill(value);
+                new_data = expanded_array;
+            }
+        }
+        console.log(new_data);
         const old_length = buffer.array.length;
         const is_interleaved =  buffer instanceof THREE.InstancedInterleavedBuffer;
         const attribute = is_interleaved ? find_interleaved_attribute(geometry, buffer) : buffer;

--- a/WGLMakie/src/javascript/WGLMakie.bundled.js
+++ b/WGLMakie/src/javascript/WGLMakie.bundled.js
@@ -23141,6 +23141,22 @@ class Plot {
                 throw new Error(`Buffer ${name} doesn't exist in Plot: ${this.name}`);
             }
         }
+        if (new_data && typeof new_data === 'object' && 'value' in new_data && 'length' in new_data) {
+            const value = new_data.value;
+            if (value instanceof Float32Array || Array.isArray(value)) {
+                const element_size = value.length;
+                const total_size = new_data.length * element_size;
+                const expanded_array = new Float32Array(total_size);
+                for(let i = 0; i < new_data.length; i++){
+                    expanded_array.set(value, i * element_size);
+                }
+                new_data = expanded_array;
+            } else {
+                const expanded_array = new Float32Array(new_data.length).fill(value);
+                new_data = expanded_array;
+            }
+        }
+        console.log(new_data);
         const old_length = buffer.array.length;
         const is_interleaved = buffer instanceof qh;
         const attribute = is_interleaved ? find_interleaved_attribute(geometry, buffer) : buffer;

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -99,7 +99,13 @@ function plot_updates(args, changed)
             _val = if value isa Sampler
                 [Int32[size(value.data)...], serialize_three(value.data)]
             else
-                serialize_three(value)
+                # Check if value is an array with all identical elements
+                if value isa AbstractArray && length(value) > 1 && all(x -> x == value[1], value)
+                    # Use compressed format for arrays with identical elements
+                    Dict("value" => serialize_three(value[1]), "length" => length(value))
+                else
+                    serialize_three(value)
+                end
             end
             push!(new_values, [name, _val])
         end


### PR DESCRIPTION
This mainly for text and WGLMakie, where we go from a single value (e.g. one color per text) to one color per glyph, which then is just one value repeated n times.
This is a "lazy" fix, since I'm just going from `n_values` -> `value` in WGLMakie specifically, where this has the biggest impact. Especially for text it has been difficult to not duplicate values per glyph, since a lot of the infrastructure expects arrays with value per glyph and we also can't easily switch between `T` and `Vector{T}`, which we allow for text specifically right now (other plots don't allow that).
The proper fix will require a rethink on how we handle attributes per X across plots, which we may tackle in https://github.com/MakieOrg/Makie.jl/issues/5162. 

This can be seen as a continuation of https://github.com/MakieOrg/Makie.jl/pull/4942, with the goal of making text more efficient for smoother axis updates in WGLMakie.

A quick benchmark of the improvements starting from before moving more of the text infrastructure to JS:

```julia
using WGLMakie, Bonito

rm(WGLMakie.WGL.bundle_file)
f, ax, pl = scatter(rand(Point2f, 10))
begin 
    limits!(ax, (0, 0.5), (0, 0.5))
    WGLMakie.poll_all_plots(f.scene)
    msgs, msg = Bonito.collect_messages() do 
        limits!(ax, (0, 2.2), (0, 2.2))
        WGLMakie.poll_all_plots(f.scene)
    end 
end
msg

# PR: 
"Send 8 messages with a total size of 3.197 KiB"
# 0.24.5:
"Send 10 messages with a total size of 4.223 KiB"
# 0.23 (with textureatlas in JS)
"Send 52 messages with a total size of 10.459 KiB"
# 0.22 (without js textureatlas) (WGLMakie v0.11.4 to be exact)
"Send 60 messages with a total size of 12.279 KiB"
```


