### PR TITLE
Proof of concept/Prototype for rendering opaque objects in transparent volume plots

### DIFF
--- a/GLMakie/src/glshaders/image_like.jl
+++ b/GLMakie/src/glshaders/image_like.jl
@@ -59,6 +59,7 @@ function draw_volume(screen, data::Dict)
         enable_depth = true
         transparency = false
         px_per_unit = 1.0f0
+        depth_buffer = screen.framebuffer[:depth][2]
         shader = GLVisualizeShader(
             screen,
             "volume.vert",


### PR DESCRIPTION
# Description

Adds/Fixes #5290

Usually depth sorting works by comparing the depth of the currently drawn pixel with the recorded depth value in the depth buffer. If the new pixel is less deep it gets saved and the depth buffer updated, otherwise it gets discarded.

Volume plots render by sampling volume data on a ray. These samples then accumulate to generate the drawn color. Since there are multiple samples at multiple positions, there is no single depth value to output. So the normal depth testing does not work.

What we can do instead is have all the opaque geometry render first and then explicitly depth test each sample. If the sample position is less deep than the drawn geometry it contributes, otherwise sampling stops. This pr is a quick test for this.

```julia
using FileIO, GLMakie, NIfTI
brain = niread(Makie.assetpath("brain.nii.gz")).raw
mini, maxi = extrema(brain)
normed = Float32.((brain .- mini) ./ (maxi - mini))

begin
    # Necessary to get a valid depth buffer in volume
    # (likely wont render anything without)
    GLMakie.closeall()

    fig = Figure(size=(1000, 450))
    ax = Axis3(fig[1, 1])

    meshscatter!(
        Point3f.(50:50:300, 50:50:300, 0),
        marker = Rect3f(0, 0, 0, 1, 100, 400),
        markersize = 1,
        color = :green,
        shading = NoShading,
    )

    # volume must render after opaque geometry
    colormap = to_colormap(:plasma)
    colormap[1] = RGBAf(0, 0, 0, 0)
    vp = volume!(ax, normed, algorithm=:absorption, absorption=2f0, colormap=colormap)

    fig
end
```

<img width="686" height="420" alt="Screenshot from 2025-09-09 02-44-08" src="https://github.com/user-attachments/assets/b5873121-717e-4c88-bad9-dffd72942dfc" />
<img width="465" height="420" alt="Screenshot from 2025-09-09 02-44-28" src="https://github.com/user-attachments/assets/a20d5664-919e-4e00-a998-0854884df5a3" />

TODO:
- [ ] adjust render order to draw volume plots after opaque plots
- [ ] figure out how to safely include the depth buffer in volume plots
- [ ] extend updates to other volume algorithms + WGLMakie
- [ ] maybe also try adding an order independent transparency version

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
