### PR TITLE
Special case `compute_identity` edges to forward ref types

### DIFF
--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -736,6 +736,30 @@ end
 
 compute_identity(inputs, changed, cached) = values(inputs)
 
+function TypedEdge(edge::ComputeEdge, f::typeof(compute_identity), inputs)
+    if length(inputs) != length(edge.outputs)
+        error("A `compute_identity` callback requires the length of inputs and outputs to match.")
+    end
+
+    # use input refs as output refs so we don't even need to evaluate the callback
+    for i in eachindex(values(inputs))
+        edge.outputs[i].value = inputs[i]
+        edge.outputs[i].dirty = true
+    end
+
+    return TypedEdge(f, inputs, edge.inputs_dirty, inputs, edge.outputs)
+end
+
+function resolve!(edge::TypedEdge{IT, OT, typeof(compute_identity)}) where {IT, OT}
+    # outputs are identical to inputs, so just copy the input state. To be safe
+    # don't overwrite any `dirty = true` state with false (maybe a problem if
+    # the input gets resolved?)
+    for i in eachindex(edge.inputs_dirty)
+        edge.output_nodes[i].dirty |= edge.inputs_dirty[i]
+    end
+    return
+end
+
 """
     add_input!([callback], compute_graph, name::Symbol, node::Computed)
 

--- a/ComputePipeline/test/unit_tests.jl
+++ b/ComputePipeline/test/unit_tests.jl
@@ -799,3 +799,47 @@ end
     e3 = graph2.merged3.parent
     @test e3.inputs == [graph1.a1, graph2.a2]
 end
+
+@testset "compute_identity" begin
+    graph1 = ComputeGraph()
+    add_input!(graph1, :a1, Ref{Any}(1))
+    map!(x -> Ref{Any}(x), graph1, :a1, :b1)
+
+    graph2 = ComputeGraph()
+    add_input!(graph2, :b1, graph1.b1)
+    graph2.b1[]
+    @test graph2.b1.value isa Ref{Any}
+
+    edge = graph2.b1.parent
+    @test edge.callback == ComputePipeline.compute_identity
+    @test length(edge.inputs) == length(edge.outputs)
+    for (in, out) in zip(edge.inputs, edge.outputs)
+        @test in.value === out.value
+        @test !ComputePipeline.isdirty(in)
+        @test !ComputePipeline.isdirty(out)
+    end
+
+    update!(graph1, a1 = 5.0)
+
+    for (in, out) in zip(edge.inputs, edge.outputs)
+        @test in.value === out.value
+        @test ComputePipeline.isdirty(in)
+        @test ComputePipeline.isdirty(out)
+    end
+
+    graph1.b1[]
+
+    for (in, out) in zip(edge.inputs, edge.outputs)
+        @test in.value === out.value
+        @test !ComputePipeline.isdirty(in)
+        @test ComputePipeline.isdirty(out)
+    end
+
+    graph2.b1[]
+
+    for (in, out) in zip(edge.inputs, edge.outputs)
+        @test in.value === out.value
+        @test !ComputePipeline.isdirty(in)
+        @test !ComputePipeline.isdirty(out)
+    end
+end


### PR DESCRIPTION
# Description

When passing a node of graph A as an input to graph B a new node is created in graph B which connects to the node in A with `compute_identity`. This was done to avoid sharing nodes between multiple graphs so that nodes are easier to manage. Since this was just using the normal machinery, the new node would pin whatever type it first gets.

This pr changes that behavior by special casing `compute_identity`. It now reuses the `Ref`s in input nodes directly, which preserves their potentially abstract eltypes and also allows us to skip a bunch of update code. So maybe this is also slightly faster.

This is in relation to https://github.com/JuliaDataCubes/PyramidScheme.jl/pull/78.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
