### PR TITLE
Execute using Pkg.Artifacts early to workaround REPLExt init time on Julia v1.12.0-rc3

### DIFF
--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -17,6 +17,7 @@ using Base64
 # It invalidates half of Makie. Simplest fix is to load it early on in Makie
 # So that the bulk of Makie gets compiled after FilePaths invalidadet Base code
 import FilePaths
+using Pkg.Artifacts # load early to cut down REPLExt init time
 using LaTeXStrings
 using MathTeXEngine
 using Random
@@ -85,7 +86,6 @@ export @L_str, @colorant_str
 export ConversionTrait, NoConversion, PointBased, GridBased, VertexGrid, CellGrid, ImageLike, VolumeLike
 export Pixel, px, Unit, plotkey, attributes, used_attributes
 export Linestyle
-using Pkg.Artifacts
 assetpath(files...) = normpath(joinpath(artifact"MakieAssets", files...))
 loadasset(files...) = FileIO.load(assetpath(files...))
 


### PR DESCRIPTION
<!--
* Any PR that is not ready for review should be created as a draft PR.
* Please don't force push to PRs, it removes the history, creates bad notifications, and we will squash and merge in the end anyways.
* Feel free to ping for a review when it passes all tests after a few days (@simondanisch, @ffreyer). We can't guarantee a review in a certain time frame, but we can guarantee to forget about PRs after a while.
* Allowing write access on the PR makes things more convenient, since we can make edits to the PR directly and update it if it gets out of sync with `master` (should be automatic if not disabled).
* Please understand, that some PRs will take very long to get merged. You can do a few things to optimize the time to get it merged:
    * The more tests you add, the easier it is to see that your change works without putting the work on us.
    * The clearer the problem being solved the easier. A PR best only addresses one bug fix or feature.
    * The more you explain the motivation or describe your feature (best with pictures), the easier it will be for us to priorize the PR.
    * Changes with more ambigious benefits are best discussed in a github [discussion](https://github.com/MakieOrg/Makie.jl/discussions) before a PR.
* What deserves a unit test or a reference image test isn't easy to decide, but here are a few pointers:
   * Makie unit tests are preferable, since they're fast to execute and easy to maintain, so if you can add tests to `Makie/src/test`
   * For new recipes or any changes that may get rendered differently by the backends, one should add a reference image test to the best fitting file in `Makie\ReferenceTests\src\tests\**` looking like this:
   ```julia 
   @reference_test "name of test" begin
        # code of test
        ...
        # make sure the last line is a Figure, FigureAxisPlot or Scene
    end
    ``` 
    Adding a reference image test will let your PR fail with the status "n reference images missing", which a maintainer will need to approve and fix. 
    Ideally, a comment with a screenshot of the expected output of the reference image test should be added to the PR.
    We prefer one reference image test with many subplots over multiple reference image tests.
-->
# Description

On Julia 1.12.0-rc3, `@time_import using Makie` shows that almost half a second is wasted initing REPLExt, which is an extension of Pkg.jl
```
               ┌ 451.5 ms REPLExt.__init__() 99.88% compilation time (100% recompilation)
    458.6 ms  Pkg → REPLExt 98.34% compilation time (100% recompilation)
```

A workaround is to load `Pkg.Artifacts` early.  This change of moving it up improves
```
@time using Makie
```
master as of 2025-9-29
```
2.827714 seconds (4.33 M allocations: 267.227 MiB, 7.06% gc time, 16.23% compilation time: 86% of which was recompilation)
```
this PR
```
2.567386 seconds (3.66 M allocations: 233.231 MiB, 9.50% gc time, 6.61% compilation time: 64% of which was recompilation)
```

Another way to see the problem on Julia v1.12.0-rc3 and Makie v0.24.6
```
@time using Makie
  2.950739 seconds (4.82 M allocations: 275.840 MiB, 10.45% gc time, 15.26% compilation time: 89% of which was recompilation)
```
```
@time using REPL, Pkg; @time using Makie
  0.317200 seconds (528.57 k allocations: 32.156 MiB, 9.29% gc time, 3.65% compilation time)
  2.282142 seconds (3.34 M allocations: 196.457 MiB, 10.36% gc time, 1.59% compilation time)
```



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


