### PR TITLE
Custom types rum dim conversion on the convert_arguments

### DIFF
--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -474,7 +474,7 @@ function _register_argument_conversions!(::Type{P}, attr::ComputeGraph, user_kw)
     args_converted = convert_arguments(P, args...; kw...)
     status = got_converted(P, conversion_trait(P, args...), args_converted)
     force_dimconverts = needs_dimconvert(dim_converts)
-    if force_dimconverts
+    if force_dimconverts && status == true
         add_dim_converts!(attr, dim_converts, args)
     elseif (status === true || status === SpecApi)
         # Nothing needs to be done, since we can just use convert_arguments without dim_converts


### PR DESCRIPTION
# Description

In some cases, type recipes do not work correctly with Dim Conversions (e.g. https://github.com/rafaqz/DimensionalData.jl/issues/1103). A minimal example of this:
```julia 
struct B{T} end
function Makie.convert_arguments(::Makie.PointBased, data::B{T}) where {T}
    return (rand(T,10), rand(T, 10))
end
lines(B{Float64)}()) # Works fine
lines!(B{Float64)}()) # Works fine

lines(B{typeof(1.0u"m")}()) # Works fine
lines!(B{typeof(1.0u"m")}()) # Error
#= ERROR: ArgumentError: 
    Conversion failed for Lines (With conversion trait PointBased()) with args:
        Tuple{B{Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}} 
    Got converted to: Tuple{Vector{Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}, Vector{Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}}
    Lines requires to convert to argument types Tuple{AbstractVector{<:Union{Point2, Point3}}}, which convert_arguments didn't succeed in.
  To fix this overload convert_arguments(P, args...) for Lines or PointBased() and return an object of type Tuple{AbstractVector{<:Union{Point2, Point3}}}.`=#

```

I looked into this and the issue seems that the Dim Conversion in `_register_argument_conversions` is done on the struct `B` instead of the output from `convert_arguments`. I did some testing and it seems that adding a new condition to the `if` statement fixes this.  

## Type of change

Delete options that do not apply:

- [ x] Bug fix (non-breaking change which fixes an issue)
