### PR TITLE
Improve dim converts recipe compatibility, usability

### DIFF
--- a/Makie/ext/MakieDynamicQuantitiesExt.jl
+++ b/Makie/ext/MakieDynamicQuantitiesExt.jl
@@ -36,6 +36,8 @@ function M.get_ticks(conversion::M.DQConversion, ticks, scale, formatter, vmin, 
     return tick_vals, labels
 end
 
+M.get_label_suffix(conversion::M.DQConversion) = unit_string(conversion.quantity[])
+
 function M.convert_dim_value(conversion::M.DQConversion, attr, values, last_values)
     if conversion.quantity[] isa M.Automatic
         conversion.quantity[] = oneunit(first(values))

--- a/Makie/ext/MakieDynamicQuantitiesExt.jl
+++ b/Makie/ext/MakieDynamicQuantitiesExt.jl
@@ -24,13 +24,14 @@ function unit_convert(quantity::DQ.UnionAbstractQuantity, value)
 end
 
 needs_tick_update_observable(conversion::M.DQConversion) = conversion.quantity
+show_dim_convert_in_ticklabel(::M.DQConversion, ::Automatic) = true
 
-function M.get_ticks(conversion::M.DQConversion, ticks, scale, formatter, vmin, vmax)
+function M.get_ticks(conversion::M.DQConversion, ticks, scale, formatter, vmin, vmax, show_in_label)
     quantity = conversion.quantity[]
     quantity isa M.Automatic && return [], []
     unit_str = unit_string(quantity)
     tick_vals, labels = M.get_ticks(ticks, scale, formatter, vmin, vmax)
-    if conversion.units_in_label[]
+    if show_in_label
         labels = labels .* unit_str
     end
     return tick_vals, labels

--- a/Makie/ext/MakieDynamicQuantitiesExt.jl
+++ b/Makie/ext/MakieDynamicQuantitiesExt.jl
@@ -24,7 +24,7 @@ function unit_convert(quantity::DQ.UnionAbstractQuantity, value)
 end
 
 needs_tick_update_observable(conversion::M.DQConversion) = conversion.quantity
-show_dim_convert_in_ticklabel(::M.DQConversion, ::Automatic) = true
+show_dim_convert_in_ticklabel(::M.DQConversion, ::M.Automatic) = true
 
 function M.get_ticks(conversion::M.DQConversion, ticks, scale, formatter, vmin, vmax, show_in_label)
     quantity = conversion.quantity[]

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -131,6 +131,7 @@ include("dim-converts/unitful-integration.jl")
 include("dim-converts/dynamic-quantities-integration.jl")
 include("dim-converts/categorical-integration.jl")
 include("dim-converts/dates-integration.jl")
+include("dim-converts/argument_dims.jl")
 
 include("scenes.jl")
 include("float32-scaling.jl")

--- a/Makie/src/basic_recipes/barplot.jl
+++ b/Makie/src/basic_recipes/barplot.jl
@@ -129,6 +129,7 @@ Plots bars of the given `heights` at the given (scalar) `positions`.
 end
 
 conversion_trait(::Type{<:BarPlot}) = PointBased()
+argument_dim_kwargs(::Type{<:BarPlot}) = (:direction,)
 
 function bar_rectangle(x, y, width, fillto, in_y_direction)
     # y could be smaller than fillto...

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -429,9 +429,11 @@ function add_convert_kwargs!(attr, user_kw, P, args)
     intrinsics = default_theme(nothing)
     conv_attr_input = Symbol[]
     for key in conv_attributes
-        if !haskey(attr.inputs, key) && !haskey(intrinsics, key) # can be added from plot attributes
-            default = key === :space ? :data : nothing
-            add_input!(attr, key, pop!(user_kw, key, default))
+        if !haskey(intrinsics, key) # can be added from plot attributes
+            if !haskey(attr.inputs, key)
+                default = key === :space ? :data : nothing
+                add_input!(attr, key, pop!(user_kw, key, default))
+            end
             push!(conv_attr_input, key)
         end
     end
@@ -783,6 +785,8 @@ function Plot{Func}(user_args::Tuple, user_attributes::Dict) where {Func}
 
     attr = ComputeGraph()
 
+    add_attributes!(P, attr, user_attributes)
+
     register_arguments!(P, attr, user_attributes, user_args)
     converted = attr.converted[]
     PTrait = conversion_trait(P, attr.args[]...)
@@ -791,7 +795,6 @@ function Plot{Func}(user_args::Tuple, user_attributes::Dict) where {Func}
     end
     ArgTyp = typeof(converted)
     FinalPlotFunc = plotfunc(plottype(P, converted...))
-    add_attributes!(Plot{FinalPlotFunc}, attr, user_attributes)
     return Plot{FinalPlotFunc, ArgTyp}(user_attributes, attr)
 end
 

--- a/Makie/src/dim-converts/argument_dims.jl
+++ b/Makie/src/dim-converts/argument_dims.jl
@@ -8,19 +8,19 @@ end
 # Loses dispatch to specific traits, e.g.
 # argument_dims(trait::PointBased, args...; kwargs...)
 function argument_dims(trait::ConversionTrait, args...; kwargs...)
-    return _argument_dims(args...; kwargs...)
+    return _argument_dims(args; kwargs...)
 end
 
 # Default handling
-function _argument_dims(arg1, args...; direction::Symbol = :y, orientation::Symbol = :vertrical)
-    dims = ntuple(identity, 1 + length(args))
+function _argument_dims(args; direction::Symbol = :y, orientation::Symbol = :vertrical)
+    # Block any one argument case by default, e.g. VecTypes, GeometryPrimitive
+    length(args) in (2, 3) || return nothing
+
+    dims = ntuple(identity, length(args))
     dims = ifelse(direction === :y, dims, (dims[2], dims[1]))
     dims = ifelse(orientation === :vertical, dims, (dims[2], dims[1]))
     return dims
 end
-
-# Block any one argument case by default, e.g. VecTypes, GeometryPrimitive
-_argument_dims(::Any; kwargs...) = nothing
 
 # attributes that are needed to map args to dims, e.g. direction/orientation
 # TODO: This is completely unrelated to args, right?

--- a/Makie/src/dim-converts/argument_dims.jl
+++ b/Makie/src/dim-converts/argument_dims.jl
@@ -1,0 +1,27 @@
+# loses dispatch to type calls, e.g.
+# argument_dims(::Type{<:Scatter}, args...; kwargs...)
+function argument_dims(PT, args...; kwargs...)
+    CT = conversion_trait(PT, args...)
+    return argument_dims(CT, args...; kwargs...)
+end
+
+# Loses dispatch to specific traits, e.g.
+# argument_dims(trait::PointBased, args...; kwargs...)
+function argument_dims(trait::ConversionTrait, args...; kwargs...)
+    return _argument_dims(args...; kwargs...)
+end
+
+# Default handling
+function _argument_dims(arg1, args...; direction::Symbol = :y, orientation::Symbol = :vertrical)
+    dims = ntuple(identity, 1 + length(args))
+    dims = ifelse(direction === :y, dims, (dims[2], dims[1]))
+    dims = ifelse(orientation === :vertical, dims, (dims[2], dims[1]))
+    return dims
+end
+
+# Block any one argument case by default, e.g. VecTypes, GeometryPrimitive
+_argument_dims(::Any; kwargs...) = nothing
+
+# attributes that are needed to map args to dims, e.g. direction/orientation
+# TODO: This is completely unrelated to args, right?
+argument_dim_kwargs(::Type{<:Plot}) = tuple()

--- a/Makie/src/dim-converts/argument_dims.jl
+++ b/Makie/src/dim-converts/argument_dims.jl
@@ -12,7 +12,7 @@ function argument_dims(trait::ConversionTrait, args...; kwargs...)
 end
 
 # Default handling
-function _argument_dims(args; direction::Symbol = :y, orientation::Symbol = :vertrical)
+function _argument_dims(args; direction::Symbol = :y, orientation::Symbol = :vertical)
     # Block any one argument case by default, e.g. VecTypes, GeometryPrimitive
     length(args) in (2, 3) || return nothing
 

--- a/Makie/src/dim-converts/categorical-integration.jl
+++ b/Makie/src/dim-converts/categorical-integration.jl
@@ -168,6 +168,8 @@ function get_ticks(conversion::CategoricalConversion, ticks, scale, formatter, v
     end
 end
 
+show_dim_convert_in_axis_label(::CategoricalConversion, ::Automatic) = false
+
 # TODO:
 # Allow this to succeed so x/ylabel_suffix can be used?
 # Or just error and force people to use x/ylabel instead?

--- a/Makie/src/dim-converts/categorical-integration.jl
+++ b/Makie/src/dim-converts/categorical-integration.jl
@@ -144,8 +144,11 @@ function convert_dim_value(conversion::CategoricalConversion, attr, values, prev
     return convert_categorical.(Ref(conversion), unwrapped_values)
 end
 
+# TODO: Does it make sense to allow discarding all the categorical information
+# and go back to default tick finding?
+show_dim_convert_in_ticklabel(::CategoricalConversion, ::Automatic) = true
 
-function get_ticks(conversion::CategoricalConversion, ticks, scale, formatter, vmin, vmax)
+function get_ticks(conversion::CategoricalConversion, ticks, scale, formatter, vmin, vmax, show_in_label)
     scale != identity && error("Scale $(scale) not supported for categorical conversion")
     if ticks isa Automatic
         # TODO, do we want to support leaving out conversion? Right now, every category will become a tick
@@ -156,8 +159,13 @@ function get_ticks(conversion::CategoricalConversion, ticks, scale, formatter, v
     end
     # TODO filter out ticks greater vmin vmax?
     numbers = convert_dim_value.(Ref(conversion), categories)
-    labels_str = formatter isa Automatic ? string.(categories) : get_ticklabels(formatter, categories)
-    return numbers, labels_str
+    if show_in_label
+        labels_str = formatter isa Automatic ? string.(categories) : get_ticklabels(formatter, categories)
+        return numbers, labels_str
+    else
+        vmin, vmax = extrema(numbers)
+        return get_ticks(ticks, scale, formatter, vmin, vmax)
+    end
 end
 
 # TODO:

--- a/Makie/src/dim-converts/categorical-integration.jl
+++ b/Makie/src/dim-converts/categorical-integration.jl
@@ -159,3 +159,8 @@ function get_ticks(conversion::CategoricalConversion, ticks, scale, formatter, v
     labels_str = formatter isa Automatic ? string.(categories) : get_ticklabels(formatter, categories)
     return numbers, labels_str
 end
+
+# TODO:
+# Allow this to succeed so x/ylabel_suffix can be used?
+# Or just error and force people to use x/ylabel instead?
+get_label_suffix(dc::CategoricalConversion) = ""

--- a/Makie/src/dim-converts/dates-integration.jl
+++ b/Makie/src/dim-converts/dates-integration.jl
@@ -512,3 +512,10 @@ function datetime_range_ticklabels(tickobj::DateTimeTicks, datetimes::Vector{<:D
         error("invalid kind $kind")
     end
 end
+
+# TODO: Consider reworking offset ticks so that the origin time stamp is in the label?
+# show_dim_convert_in_ticklabel(::DateTimeConversion, ::Automatic) = true
+# get_label_suffix(dc::DateTimeConversion, format) = get_formatted_timestamp(dc)
+
+# This only makes sense for Time which goes through units, not Dates or DateTime
+get_label_suffix(::DateTimeConversion) = error("Cannot produce a label suffix for Dates.")

--- a/Makie/src/dim-converts/dates-integration.jl
+++ b/Makie/src/dim-converts/dates-integration.jl
@@ -523,4 +523,6 @@ end
 # get_label_suffix(dc::DateTimeConversion, format) = get_formatted_timestamp(dc)
 
 # This only makes sense for Time which goes through units, not Dates or DateTime
+show_dim_convert_in_axis_label(::DateTimeConversion, ::Automatic) = false
+show_dim_convert_in_axis_label(::DateTimeConversion, ::Symbol) = false
 get_label_suffix(::DateTimeConversion) = error("Cannot produce a label suffix for Dates.")

--- a/Makie/src/dim-converts/dates-integration.jl
+++ b/Makie/src/dim-converts/dates-integration.jl
@@ -85,7 +85,12 @@ function convert_dim_value(conversion::DateTimeConversion, attr, values, previou
     return date_to_number.(conversion.type[], values)
 end
 
-function get_ticks(conversion::DateTimeConversion, ticks, scale, formatter, vmin, vmax)
+# TODO: Is there a point in allowing Date ticks to not be displayed?
+# What would be shown instead?
+show_dim_convert_in_ticklabel(::DateTimeConversion, ::Automatic) = true
+show_dim_convert_in_ticklabel(::DateTimeConversion, ::Symbol) = true
+
+function get_ticks(conversion::DateTimeConversion, ticks, scale, formatter, vmin, vmax, show_in_label)
     T = conversion.type[]
 
     # When automatic, we haven't actually plotted anything yet, so no unit chosen

--- a/Makie/src/dim-converts/dim-converts.jl
+++ b/Makie/src/dim-converts/dim-converts.jl
@@ -77,6 +77,11 @@ function get_ticks(::Union{Nothing, NoDimConversion}, ticks, scale, formatter, v
     return get_ticks(ticks, scale, formatter, vmin, vmax)
 end
 
+# TODO: temporary
+function get_ticks(c::Union{Nothing, AbstractDimConversion}, ticks, scale, formatter, vmin, vmax)
+    return get_ticks(c, ticks, scale, formatter, vmin, vmax, true)
+end
+
 show_dim_convert_in_ticklabel(::Union{AbstractDimConversion, Nothing}, ::Automatic) = false
 function show_dim_convert_in_ticklabel(::Union{AbstractDimConversion, Nothing}, option::Symbol)
     return option in (:ticklabel, :both)

--- a/Makie/src/dim-converts/dim-converts.jl
+++ b/Makie/src/dim-converts/dim-converts.jl
@@ -77,6 +77,20 @@ function get_ticks(::Union{Nothing, NoDimConversion}, ticks, scale, formatter, v
     return get_ticks(ticks, scale, formatter, vmin, vmax)
 end
 
+# Should this trigger an error or just return ""?
+get_label_suffix(dc, format) = apply_format(get_label_suffix(dc), format)
+get_label_suffix(dc) = error("No axis label suffix defined for conversion $dc.")
+get_label_suffix(dc::Union{Nothing, NoDimConversion}) = ""
+
+# Don't default to generating a suffix for no dim conversion.
+# TODO: Maybe allow option cases to go through though so `suffix` can be used w/o dimconverts?
+show_dim_convert_in_axis_label(::Union{Nothing, NoDimConversion}, ::Automatic) = false
+
+show_dim_convert_in_axis_label(::AbstractDimConversion, ::Automatic) = true
+function show_dim_convert_in_axis_label(::Union{AbstractDimConversion, Nothing}, option::Symbol)
+    return option in (:label, :both)
+end
+
 # Recursively gets the dim convert from the plot
 # This needs to be recursive to allow recipes to use dim convert
 # TODO, should a recipe always set the dim convert to it's parent?

--- a/Makie/src/dim-converts/dim-converts.jl
+++ b/Makie/src/dim-converts/dim-converts.jl
@@ -184,11 +184,11 @@ convert_dim_value(conv, attr, value, last_value) = value
 
 function update_dim_conversion!(conversions::DimConversions, dim, value)
     conversion = conversions[dim]
-    if !(conversion isa Union{Nothing, NoDimConversion})
-        return
+    if conversion isa Union{Nothing, NoDimConversion}
+        c = dim_conversion_from_args(value)
+        return conversions[dim] = c
     end
-    c = dim_conversion_from_args(value)
-    return conversions[dim] = c
+    return
 end
 
 function try_dim_convert(P::Type{<:Plot}, PTrait::ConversionTrait, user_attributes, args_obs::Tuple, deregister)

--- a/Makie/src/dim-converts/dim-converts.jl
+++ b/Makie/src/dim-converts/dim-converts.jl
@@ -73,8 +73,13 @@ end
 
 # get_ticks needs overloading for Dim Conversion
 # Which gets ignored for no conversion/nothing
-function get_ticks(::Union{Nothing, NoDimConversion}, ticks, scale, formatter, vmin, vmax)
+function get_ticks(::Union{Nothing, NoDimConversion}, ticks, scale, formatter, vmin, vmax, show_in_label)
     return get_ticks(ticks, scale, formatter, vmin, vmax)
+end
+
+show_dim_convert_in_ticklabel(::Union{AbstractDimConversion, Nothing}, ::Automatic) = false
+function show_dim_convert_in_ticklabel(::Union{AbstractDimConversion, Nothing}, option::Symbol)
+    return option in (:ticklabel, :both)
 end
 
 # Should this trigger an error or just return ""?

--- a/Makie/src/dim-converts/dynamic-quantities-integration.jl
+++ b/Makie/src/dim-converts/dynamic-quantities-integration.jl
@@ -24,9 +24,6 @@ scatter(1:4, [0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"]; axis=(dim2_conversion
 """
 struct DQConversion <: AbstractDimConversion
     quantity::Observable{Any}
-    units_in_label::Observable{Bool}
 end
 
-function DQConversion(quantity = automatic; units_in_label = true)
-    return DQConversion(quantity, units_in_label)
-end
+DQConversion() = DQConversion(automatic)

--- a/Makie/src/dim-converts/unitful-integration.jl
+++ b/Makie/src/dim-converts/unitful-integration.jl
@@ -228,6 +228,12 @@ function get_ticks(conversion::UnitfulConversion, ticks, scale, formatter, vmin,
     return tick_vals, labels
 end
 
+function get_label_suffix(conversion::UnitfulConversion, format)
+    str = unit_string(conversion.unit[])
+    formatted = apply_format(str, format)
+    return unit_string_to_rich(formatted)
+end
+
 function convert_dim_value(conversion::UnitfulConversion, attr, values, last_values)
     unit = conversion.unit[]
     if !isempty(values)

--- a/Makie/src/dim-converts/unitful-integration.jl
+++ b/Makie/src/dim-converts/unitful-integration.jl
@@ -156,13 +156,12 @@ scatter(1:4, [0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"]; axis=(dim2_conversion
 struct UnitfulConversion <: AbstractDimConversion
     unit::Observable{Any}
     automatic_units::Bool
-    units_in_label::Observable{Bool}
     extrema::Dict{String, Tuple{Any, Any}}
 end
 
-function UnitfulConversion(unit = automatic; units_in_label = true)
+function UnitfulConversion(unit = automatic)
     extrema = Dict{String, Tuple{Any, Any}}()
-    return UnitfulConversion(unit, unit isa Automatic, units_in_label, extrema)
+    return UnitfulConversion(unit, unit isa Automatic, extrema)
 end
 
 function update_extrema!(conversion::UnitfulConversion, id::String, vals)
@@ -215,14 +214,16 @@ function unit_string_to_rich(str::String)
     return rich(output...)
 end
 
-function get_ticks(conversion::UnitfulConversion, ticks, scale, formatter, vmin, vmax)
+show_dim_convert_in_ticklabel(::UnitfulConversion, ::Automatic) = true
+
+function get_ticks(conversion::UnitfulConversion, ticks, scale, formatter, vmin, vmax, show_in_label)
     unit = conversion.unit[]
     unit isa Automatic && return [], []
     unit_str = unit_string(unit)
     rich_unit_str = unit_string_to_rich(unit_str)
     tick_vals = get_tickvalues(ticks, scale, vmin, vmax)
     labels = get_ticklabels(formatter, tick_vals)
-    if conversion.units_in_label[]
+    if show_in_label
         labels = map(lbl -> rich(lbl, rich_unit_str), labels)
     end
     return tick_vals, labels

--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -355,6 +355,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         reversed = ax.xreversed, tickwidth = ax.xtickwidth, tickcolor = ax.xtickcolor,
         minorticksvisible = ax.xminorticksvisible, minortickalign = ax.xminortickalign, minorticksize = ax.xminorticksize, minortickwidth = ax.xminortickwidth, minortickcolor = ax.xminortickcolor, minorticks = ax.xminorticks, scale = ax.xscale,
         minorticksused = ax.xminorgridvisible,
+        label_suffix = ax.xlabel_suffix, dim_convert_in = ax.show_x_dim_convert_in
     )
 
     ax.xaxis = xaxis
@@ -371,6 +372,7 @@ function initialize_block!(ax::Axis; palette = nothing)
         tickcolor = ax.ytickcolor,
         minorticksvisible = ax.yminorticksvisible, minortickalign = ax.yminortickalign, minorticksize = ax.yminorticksize, minortickwidth = ax.yminortickwidth, minortickcolor = ax.yminortickcolor, minorticks = ax.yminorticks, scale = ax.yscale,
         minorticksused = ax.yminorgridvisible,
+        label_suffix = ax.ylabel_suffix, dim_convert_in = ax.show_y_dim_convert_in
     )
 
     ax.yaxis = yaxis

--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -355,7 +355,8 @@ function initialize_block!(ax::Axis; palette = nothing)
         reversed = ax.xreversed, tickwidth = ax.xtickwidth, tickcolor = ax.xtickcolor,
         minorticksvisible = ax.xminorticksvisible, minortickalign = ax.xminortickalign, minorticksize = ax.xminorticksize, minortickwidth = ax.xminortickwidth, minortickcolor = ax.xminortickcolor, minorticks = ax.xminorticks, scale = ax.xscale,
         minorticksused = ax.xminorgridvisible,
-        label_suffix = ax.xlabel_suffix, dim_convert_in = ax.show_x_dim_convert_in
+        label_suffix = ax.xlabel_suffix, unit_in_label = ax.show_x_dim_convert_in,
+        use_short_units = ax.use_short_x_units
     )
 
     ax.xaxis = xaxis
@@ -372,7 +373,8 @@ function initialize_block!(ax::Axis; palette = nothing)
         tickcolor = ax.ytickcolor,
         minorticksvisible = ax.yminorticksvisible, minortickalign = ax.yminortickalign, minorticksize = ax.yminorticksize, minortickwidth = ax.yminortickwidth, minortickcolor = ax.yminortickcolor, minorticks = ax.yminorticks, scale = ax.yscale,
         minorticksused = ax.yminorgridvisible,
-        label_suffix = ax.ylabel_suffix, dim_convert_in = ax.show_y_dim_convert_in
+        label_suffix = ax.ylabel_suffix, dim_convert_in = ax.show_y_dim_convert_in,
+        use_short_units = ax.use_short_y_units
     )
 
     ax.yaxis = yaxis

--- a/Makie/src/makielayout/lineaxis.jl
+++ b/Makie/src/makielayout/lineaxis.jl
@@ -464,9 +464,11 @@ function LineAxis(parent::Scene, attrs::Attributes)
     obs = needs_tick_update_observable(dim_convert) # make sure we update tick calculation when needed
     map!(
         parent, tickvalues_labels_unfiltered, pos_extents_horizontal, obs, limits, ticks, tickformat,
-        attrs.scale
-    ) do (position, extents, horizontal), _, limits, ticks, tickformat, scale
-        return get_ticks(dim_convert[], ticks, scale, tickformat, limits...)
+        attrs.scale, dim_convert_in
+    ) do (position, extents, horizontal), _, limits, ticks, tickformat, scale, show_option
+        dc = dim_convert[]
+        should_show = show_dim_convert_in_ticklabel(dc, show_option)
+        return get_ticks(dim_convert[], ticks, scale, tickformat, limits..., should_show)
     end
 
     tickpositions = Observable(Point2f[]; ignore_equal_values = true)

--- a/Makie/src/makielayout/types.jl
+++ b/Makie/src/makielayout/types.jl
@@ -298,6 +298,23 @@ Axis(fig_or_scene; palette = nothing, kwargs...)
         dim2_conversion = nothing
 
         """
+        Controls where x dim_converts are shown. Can be `:label`, `:ticklabel`,
+        `:both` or `:none`.
+
+        The label produced by dim_converts is affected by `use_short_x_units`.
+        If `:label` is selected the `xlabel_suffix` attribute is used as a
+        formatter for the produced label.
+        """
+        show_x_dim_convert_in::Union{Symbol, Automatic} = automatic
+        show_y_dim_convert_in::Union{Symbol, Automatic} = automatic
+        "Format.jl compatible format string or `string -> string` format function"
+        xlabel_suffix = "[{}]"
+        ylabel_suffix = "[{}]"
+        "Does anyone care about long labels?"
+        use_short_x_units::Bool = true
+        use_short_y_units::Bool = true
+
+        """
         The content of the x axis label.
         The value can be any non-vector-valued object that the `text` primitive supports.
         """

--- a/Makie/src/stats/boxplot.jl
+++ b/Makie/src/stats/boxplot.jl
@@ -64,6 +64,7 @@ the 75% percentile) with a midline marking the median
 end
 
 conversion_trait(x::Type{<:BoxPlot}) = SampleBased()
+argument_dim_kwargs(::Type{<:BoxPlot}) = (:orientation,)
 
 _cycle(v::AbstractVector, idx::Integer) = v[mod1(idx, length(v))]
 _cycle(v, idx::Integer) = v

--- a/Makie/src/stats/crossbar.jl
+++ b/Makie/src/stats/crossbar.jl
@@ -78,6 +78,8 @@ It is most commonly used as part of the `boxplot`.
     mixin_generic_plot_attributes()...
 end
 
+argument_dim_kwargs(::Type{<:CrossBar}) = (:orientation,)
+
 function Makie.plot!(plot::CrossBar)
     map!(
         plot, [

--- a/Makie/src/stats/density.jl
+++ b/Makie/src/stats/density.jl
@@ -62,6 +62,8 @@ Plot a kernel density estimate of `values`.
     cycle = [:color => :patchcolor]
 end
 
+argument_dim_kwargs(::Type{<:Density}) = (:direction,)
+
 function plot!(plot::Density{<:Tuple{<:AbstractVector}})
     map!(
         plot, [:converted_1, :direction, :boundary, :offset, :npoints, :bandwidth, :weights],

--- a/Makie/src/stats/hist.jl
+++ b/Makie/src/stats/hist.jl
@@ -124,6 +124,8 @@ Plot a histogram of `values`.
     over_bar_color = automatic
 end
 
+argument_dim_kwargs(::Type{<:Hist}) = (:direction,)
+
 function pick_hist_edges(vals, bins)
     if bins isa Int
         mi, ma = float.(extrema(vals))

--- a/Makie/src/stats/violin.jl
+++ b/Makie/src/stats/violin.jl
@@ -81,6 +81,7 @@ The density pairs can be sourced from the same or from different data.
 end
 
 conversion_trait(::Type{<:Violin}) = SampleBased()
+argument_dim_kwargs(::Type{<:Violin}) = (:orientation,)
 
 getuniquevalue(v, idxs) = v
 


### PR DESCRIPTION
# Description

This pr adds `argument_dims()`  as an overloadable function similar to `convert_arguments()` to allow recipes to define how their arguments map to plot dimensions. With that you can specify which dim_convert applies to first, second, ... argument by returning the index of the appropriate dimension/dim convert. This aims to fix:
- #3889
- #3896
- #3897, #4176
- #3932, closing #4797
- some of #3947
- #3973
- #4069, #4412, #5187
- #4409

This pr also aims to make some usability improvements:
- simplify units in axis labels by allowing dim_converts to generate label suffixes, fixing #3890
- add more dim convert related attributes to blocks to avoid needing to create dim converts manually

## Type of change

Likely breaking for dim_convert implementations since moving options to blocks means they need to be passed to `get_ticks`.

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
