### PR TITLE
Use `mixin_colormap_attributes` in `contourf `and `tricontourf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@
 - Added new `annotation` recipe which can be used for labeling many data points with automatically non-overlapping labels, or for more bespoke annotation with manually chosen positions and connecting arrows [#4891](https://github.com/MakieOrg/Makie.jl/pull/4891).
 - Fixed precompilation bug in julia dev 1.13 [#5018](https://github.com/MakieOrg/Makie.jl/pull/5018).
 - Fixed screen not open assertion and `Makie.isclosed(scene)` in WGLMakie [#5008](https://github.com/MakieOrg/Makie.jl/pull/5008).
+- Fixed `(tri)contourf` such that `colorrange` is a valid attribute. `colorscale` also starts to work with this fix [#5027](https://github.com/MakieOrg/Makie.jl/pull/5027).
 
 ## [0.22.7] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added docstrings for undocumented plot attributes. Also fixed some missing attribute passthrough and expanded on the available attributes for recipes [#5294](https://github.com/MakieOrg/Makie.jl/pull/5294)
 - Added support for plotting units with DynamicQuantities.jl [#5280](https://github.com/MakieOrg/Makie.jl/pull/5280)
 - Adjusted compute nodes to keep unspecialized types when transitioning from one graph to another [#5302](https://github.com/MakieOrg/Makie.jl/pull/5302)
+- Fixed `contourf` such that `colorrange` is a valid attribute. `colorscale` also starts to work with this fix [#5330](https://github.com/MakieOrg/Makie.jl/pull/5330).
 
 ## [0.24.6] - 2025-08-19
 
@@ -136,7 +137,6 @@
 - Added new `annotation` recipe which can be used for labeling many data points with automatically non-overlapping labels, or for more bespoke annotation with manually chosen positions and connecting arrows [#4891](https://github.com/MakieOrg/Makie.jl/pull/4891).
 - Fixed precompilation bug in julia dev 1.13 [#5018](https://github.com/MakieOrg/Makie.jl/pull/5018).
 - Fixed screen not open assertion and `Makie.isclosed(scene)` in WGLMakie [#5008](https://github.com/MakieOrg/Makie.jl/pull/5008).
-- Fixed `(tri)contourf` such that `colorrange` is a valid attribute. `colorscale` also starts to work with this fix [#5027](https://github.com/MakieOrg/Makie.jl/pull/5027).
 
 ## [0.22.7] - 2025-05-23
 

--- a/Makie/src/basic_recipes/contourf.jl
+++ b/Makie/src/basic_recipes/contourf.jl
@@ -41,7 +41,7 @@ similar to how [`surface`](@ref) works.
     extendhigh = nothing
     mixin_generic_plot_attributes()...
     # TODO, Isoband doesn't seem to support nans?
-    mixin_colormap_attributes(allow = (:alpha, :colormap, :colorscale, :nan_color))...
+    mixin_colormap_attributes(allow = (:alpha, :colormap, :colorrange, :colorscale, :nan_color))...
 end
 
 # these attributes are computed dynamically and needed for colorbar e.g.
@@ -204,7 +204,11 @@ function register_contourf_computations!(graph, argname)
         return _get_isoband_levels(Val(mode), levels, vec(zs))
     end
 
-    map!(extrema_nan, graph, :computed_levels, :computed_colorrange)
+    if graph[:colorrange] isa Automatic
+        map!(extrema_nan, graph, :computed_levels, :computed_colorrange)
+    else
+        map!(identity, graph, :colorrange, :computed_colorrange)
+    end
     map!(compute_contourf_colormap, graph, [:computed_levels, :colormap, :extendlow, :extendhigh], :computed_colormap)
     map!(compute_lowcolor, graph, [:extendlow, :colormap], :computed_lowcolor)
     map!(compute_highcolor, graph, [:extendhigh, :colormap], :computed_highcolor)
@@ -249,10 +253,10 @@ function Makie.plot!(c::Contourf{<:Union{<:Tuple{<:AbstractVector{<:Real}, <:Abs
     return poly!(
         c,
         c.polys,
+        alpha = c.alpha,
         colormap = c.computed_colormap,
         colorscale = c.colorscale,
         colorrange = c.computed_colorrange,
-        alpha = c.alpha,
         highclip = c.computed_highcolor,
         lowclip = c.computed_lowcolor,
         nan_color = c.nan_color,

--- a/Makie/src/basic_recipes/contourf.jl
+++ b/Makie/src/basic_recipes/contourf.jl
@@ -41,7 +41,7 @@ similar to how [`surface`](@ref) works.
     extendhigh = nothing
     mixin_generic_plot_attributes()...
     # TODO, Isoband doesn't seem to support nans?
-    mixin_colormap_attributes(allow = (:colormap, :colorscale, :nan_color))...
+    mixin_colormap_attributes(allow = (:alpha, :colormap, :colorscale, :nan_color))...
 end
 
 # these attributes are computed dynamically and needed for colorbar e.g.
@@ -250,7 +250,9 @@ function Makie.plot!(c::Contourf{<:Union{<:Tuple{<:AbstractVector{<:Real}, <:Abs
         c,
         c.polys,
         colormap = c.computed_colormap,
+        colorscale = c.colorscale,
         colorrange = c.computed_colorrange,
+        alpha = c.alpha,
         highclip = c.computed_highcolor,
         lowclip = c.computed_lowcolor,
         nan_color = c.nan_color,

--- a/Makie/src/basic_recipes/contourf.jl
+++ b/Makie/src/basic_recipes/contourf.jl
@@ -204,7 +204,7 @@ function register_contourf_computations!(graph, argname)
         return _get_isoband_levels(Val(mode), levels, vec(zs))
     end
 
-    if graph[:colorrange] isa Automatic
+    if graph[:colorrange][] isa Automatic
         map!(extrema_nan, graph, :computed_levels, :computed_colorrange)
     else
         map!(identity, graph, :colorrange, :computed_colorrange)

--- a/Makie/src/basic_recipes/tricontourf.jl
+++ b/Makie/src/basic_recipes/tricontourf.jl
@@ -22,12 +22,6 @@ for specifying the triangles, otherwise an unconstrained triangulation of `xs` a
     For example, `levels = 0.1:0.1:1.0` would exclude the lower 10% of data.
     """
     mode = :normal
-    "Sets the colormap from which the band colors are sampled."
-    colormap = @inherit colormap
-    "Color transform function"
-    colorscale = identity
-    "The alpha value of the colormap or color attribute."
-    alpha = 1.0
     """
     This sets the color of an optional additional band from
     `minimum(zs)` to the lowest value in `levels`.

--- a/Makie/src/basic_recipes/tricontourf.jl
+++ b/Makie/src/basic_recipes/tricontourf.jl
@@ -40,8 +40,6 @@ for specifying the triangles, otherwise an unconstrained triangulation of `xs` a
     If it's `nothing`, no band is added.
     """
     extendhigh = nothing
-    "Sets the color used for nan values in the generated contour."
-    nan_color = :transparent
     """
     The mode with which the points in `xs` and `ys` are triangulated.
     Passing `DelaunayTriangulation()` performs a Delaunay triangulation.
@@ -51,6 +49,7 @@ for specifying the triangles, otherwise an unconstrained triangulation of `xs` a
     """
     triangulation = DelaunayTriangulation()
     mixin_generic_plot_attributes()...
+    mixin_colormap_attributes(allow = (:alpha, :colormap, :colorrange, :colorscale, :nan_color))...
 end
 
 function Makie.used_attributes(::Type{<:Tricontourf}, ::AbstractVector{<:Real}, ::AbstractVector{<:Real}, ::AbstractVector{<:Real})


### PR DESCRIPTION
# Description

Pretty much the same as #5027, but this PR is based on the latest master.

Fixes #4016 (perhaps related to #4374 and #4980 as well) by updating `contourf` and `tricontourf` to use `mixin_colormap_attributes`. This PR should enable support for `colorrange`, `alpha`, and `colorscale` attributes in both `contourf` and `tricontourf`.

One reference test (Colorbar for recipes.png) is currently failing. However, based on manual inspection, the reference image may be incorrect. Specifically, the reference image was generated with `colorscale=sqrt` https://github.com/MakieOrg/Makie.jl/blob/10d65fd67bb269ea96c6748d754fd3544bb3051c/ReferenceTests/src/tests/figures_and_makielayout.jl#L624, but the resulting image was identical to one generated with `colorscale=identity`.

Current reference image (`colorscale=sqrt`):
<img width="758" height="254" alt="image" src="https://github.com/user-attachments/assets/6d6ed9d5-547c-4bb1-8883-103eae270c0f" />

With this PR (`colorscale=identity`):
<img width="758" height="254" alt="image" src="https://github.com/user-attachments/assets/d4eb6fa2-880d-47da-ae1a-edd4f03def57" />

With this PR (`colorscale=sqrt`):
<img width="758" height="254" alt="image" src="https://github.com/user-attachments/assets/d2a393f6-ed32-4462-8c9d-a853033ffead" />

It is not very clear to me why the `contourf` plot in the third screenshot only shows two colors while the colorbar has three. I would appreciate some hints if this is not an expected behavior

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Added an entry in CHANGELOG.md (for new features and breaking changes)
