### PR TITLE
WGLMakie: fix a DOM-mount race in three_display, add AwaitedNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Fixed a WGLMakie race where a slow/cold first page load (fresh browser tab, first
+  display in a process) could cause `three_display` to silently fail to initialize the
+  canvas: interpolating a DOM node into `js"..."` compiled to a one-shot
+  `document.querySelector(...)` with no retry, which could run before Bonito had actually
+  mounted the node. Added `AwaitedNode`, which retries until the node appears, mirroring
+  the existing `Scene` lookup retry logic [#PR_NUMBER](https://github.com/MakieOrg/Makie.jl/pull/PR_NUMBER).
 - Added an `absolute` attribute to `dendrogram` that keeps the input leaf positions instead of translating the root to `origin`, making it easy to align leaves to e.g. heatmap rows or columns [#5666](https://github.com/MakieOrg/Makie.jl/pull/5666).
 - `WGLMakie.ToolTip` can now be styled with `class` and `css` keyword arguments, and ships a
   `DATAINSPECTOR_CSS` preset that matches the GLMakie `DataInspector` look [#5664](https://github.com/MakieOrg/Makie.jl/pull/5664).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   canvas: interpolating a DOM node into `js"..."` compiled to a one-shot
   `document.querySelector(...)` with no retry, which could run before Bonito had actually
   mounted the node. Added `AwaitedNode`, which retries until the node appears, mirroring
-  the existing `Scene` lookup retry logic [#PR_NUMBER](https://github.com/MakieOrg/Makie.jl/pull/PR_NUMBER).
+  the existing `Scene` lookup retry logic [#5716](https://github.com/MakieOrg/Makie.jl/pull/5716).
 - Added an `absolute` attribute to `dendrogram` that keeps the input leaf positions instead of translating the root to `origin`, making it easy to align leaves to e.g. heatmap rows or columns [#5666](https://github.com/MakieOrg/Makie.jl/pull/5666).
 - `WGLMakie.ToolTip` can now be styled with `class` and `css` keyword arguments, and ships a
   `DATAINSPECTOR_CSS` preset that matches the GLMakie `DataInspector` look [#5664](https://github.com/MakieOrg/Makie.jl/pull/5664).

--- a/WGLMakie/src/three_plot.jl
+++ b/WGLMakie/src/three_plot.jl
@@ -53,6 +53,52 @@ function Bonito.print_js_code(io::IO, scene::Scene, context::Bonito.JSSourceCont
 end
 
 
+"""
+    AwaitedNode(node)
+
+Wraps a `Hyperscript.Node` (e.g. anything created via `DOM.div`, `DOM.m`, ...) so that
+interpolating it into a `js"..."` string waits for the node to actually be mounted in the
+DOM before resolving, instead of Bonito's default `Node` interpolation, which compiles to
+a plain, one-shot `document.querySelector(...)` with no retry. That default is only safe
+if the node is *guaranteed* to already be in the DOM by the time the interpolated code
+runs — which the JS module (`\$(WGL)`) finishing its own async load does not guarantee: on
+a slow/cold page load, the module can finish loading before Bonito has actually spliced
+this particular node into `document.body`, silently querying `null`. Mirrors the retry
+loop used for `Scene` lookups above, and shares its env var configuration.
+"""
+struct AwaitedNode
+    node::Hyperscript.Node
+end
+
+function Bonito.print_js_code(io::IO, awaited::AwaitedNode, context::Bonito.JSSourceContext)
+    id = Bonito.uuid(context.session, awaited.node)
+    retry_delay_ms = max(1, something(tryparse(Int, get(ENV, "WGLMAKIE_SCENE_RETRY_DELAY_MS", "100")), 100))
+    total_wait_ms = max(retry_delay_ms, something(tryparse(Int, get(ENV, "WGLMAKIE_SCENE_RETRY_TOTAL_MS", "60000")), 60000))
+    max_retries = max(100, cld(total_wait_ms, retry_delay_ms))
+
+    code = js"""(function() {
+        function try_find_node(_retries) {
+            let retries = _retries || 0;
+            const max_retries = $(max_retries);
+            const retry_delay = $(retry_delay_ms);
+            const node = document.querySelector('[data-jscall-id="' + $(id) + '"]');
+            if (node) {
+                return Promise.resolve(node);
+            } else if (retries < max_retries) {
+                return new Promise(resolve => {
+                    setTimeout(() => {
+                        try_find_node(retries + 1).then(resolve);
+                    }, retry_delay);
+                });
+            } else {
+                return Promise.reject(new Error("DOM node not found after retries: " + $(id)));
+            }
+        }
+        return try_find_node();
+    })()"""
+    return Bonito.print_js_code(io, code, context)
+end
+
 function get_order!(session::Session)
     order = Bonito.get_metadata(session, :wglmakie_scene_order, 1)
     Bonito.set_metadata!(session, :wglmakie_scene_order, order + 1)
@@ -122,13 +168,16 @@ function three_display(screen::Screen, session::Session, scene::Scene)
     comm = Observable(Dict{String, Any}())
 
     # Keep texture atlas in parent session, so we don't need to send it over and over again
+    # `wrapper`/`canvas` are awaited (not interpolated directly) since the JS module
+    # loading (`$(WGL)`) does not guarantee they've already been mounted in the DOM —
+    # see `AwaitedNode`.
     evaljs(
         session, js"""
-        $(WGL).then(WGL => {
+        Promise.all([$(WGL), $(AwaitedNode(wrapper)), $(AwaitedNode(canvas))]).then(([WGL, wrapper, canvas]) => {
             WGL.execute_in_order($order, ()=> {
                 WGL.setup_scene_init(
-                    $wrapper,
-                    $canvas,
+                    wrapper,
+                    canvas,
                     $width,
                     $height,
                     $(config.resize_to),

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -122,6 +122,51 @@ edisplay = Bonito.use_electron_display(devtools = true)
         end
     end
 
+    @testset "AwaitedNode retries until the DOM node is mounted" begin
+        # Regression test for a race where interpolating a DOM `Node` into `js"..."`
+        # (as `three_display` does for its `wrapper`/`canvas`) compiled to a bare,
+        # one-shot `document.querySelector(...)`. If the JS module finished loading
+        # before Bonito had actually mounted that specific node — most likely on a
+        # slow/cold first page load — the query silently returned `null` and
+        # `setup_scene_init` failed, without ever throwing on the Julia side.
+        # `AwaitedNode` fixes this by retrying until the node appears. We test the
+        # retry mechanism directly (rather than trying to reproduce the original
+        # cold-load timing, which isn't reliably reproducible in CI): start the
+        # lookup before the node exists in the DOM at all, then mount a matching
+        # node after a deliberate delay, and confirm the lookup still resolves.
+        local node_session = nothing
+        app = App() do session
+            node_session = session
+            return DOM.div("awaited node test container")
+        end
+        display(edisplay, app)
+        Bonito.wait_for(() -> !isnothing(node_session))
+        session = node_session
+
+        node = DOM.div("mounted late"; id = "awaited-node-test")
+        node_id = Bonito.uuid(session, node)
+
+        result = evaljs_value(
+            session, js"""
+                (async () => {
+                    // Start the retry loop *before* the node exists in the DOM —
+                    // this is the scenario the original bug hit.
+                    const lookup = $(WGLMakie.AwaitedNode(node));
+                    // Simulate the delayed DOM mount that caused the original race.
+                    setTimeout(() => {
+                        const el = document.createElement('div');
+                        el.setAttribute('data-jscall-id', $(node_id));
+                        el.textContent = 'mounted-late';
+                        document.body.appendChild(el);
+                    }, 300);
+                    const found = await lookup;
+                    return found.textContent;
+                })()
+            """
+        )
+        @test result == "mounted-late"
+    end
+
     @testset "small float passthrough" begin
         scene = Scene()
         p1 = volume!(scene, fill(N0f8(0.5), 4, 4, 4)::Array{N0f8, 3})


### PR DESCRIPTION
# Description

  - Interpolating a DOM `Node` into `js"..."` (used for `three_display`'s `wrapper`/`canvas`) compiled to a one-shot `document.querySelector(...)` with no retry — unlike `Scene` interpolation, which already retries via a configurable window (#5693). On a slow/cold first page load (fresh browser tab, first WGLMakie display in a process), the JS module could finish loading before Bonito had actually mounted that specific node, silently querying `null` and failing scene initialization inside `setup_scene_init`'s own `try/catch` — with no error surfacing on the Julia side.
  - Adds `AwaitedNode`, wrapping a node so its lookup retries until the node is mounted, reusing the same `WGLMAKIE_SCENE_RETRY_DELAY_MS`/`WGLMAKIE_SCENE_RETRY_TOTAL_MS` env vars already used for `Scene` lookups. `three_display` now awaits `wrapper`/`canvas` alongside the JS module, instead of interpolating them directly.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.
