### PR TITLE
Enable axis scaling for Resampler

### DIFF
--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -526,6 +526,7 @@ If the array doesn't support this, it will be converted to an interpolation obje
 * `method` is the interpolation method used, defaulting to `Interpolations.Linear()`.
 * `update_while_button_pressed` will update the heatmap while a mouse button is pressed, useful for zooming/panning. Set it to false for e.g. WGLMakie to avoid updating while dragging.
 * `lowres_background` will always show a low resolution background while the high resolution image is being calculated.
+When plotting, `x` and `y` are typically omitted. To control the absolute coordinates, these must be provided as 2-tuples or `EndPoints`, i.e. heatmap((xmin, xmax), (ymin, ymax), Resampler(data)). 
 """
 struct Resampler{T <: AbstractMatrix{<:Union{Real, Colorant}}}
     data::T
@@ -617,7 +618,7 @@ end
 extract_colormap_recursive(plot::HeatmapShader) = extract_colormap_recursive(plot.plots[1])
 
 
-function resample_image(x, y, image, max_resolution, limits)
+function resample_image(x, y, image, max_resolution, limits, transform_func)
     # extent of the image in data coordinates (same as limits)
     xmin, xmax = x
     ymin, ymax = y
@@ -641,7 +642,16 @@ function resample_image(x, y, image, max_resolution, limits)
         indices = ((nrange .- data_min[i]) ./ data_width[i]) .* (si .- 1) .+ 1
         resolution = max(2, round(Int, indices[2] - indices[1]))
         len = min(resolution, max_resolution[i])
-        return LinRange(max(1, indices[1]), min(indices[2], si), len)
+        transformed_inds = apply_transform(
+                inverse_transform(transform_func[i]), 
+                LinRange(
+                    apply_transform(transform_func[i], max(1, indices[1])),
+                    apply_transform(transform_func[i], min(indices[2], si)), 
+                    len
+                )
+            )
+        # prevent oob due to rounding
+        return clamp.(transformed_inds, 1, si)
     end
     if isempty(x_index_range) || isempty(y_index_range)
         return nothing
@@ -713,8 +723,11 @@ function Makie.plot!(p::HeatmapShader)
 
 
     T = eltype(p.image[].data) <: Colors.Colorant ? RGB{Float32} : Float32
-    map!(p.attributes, [:image, :x, :y, :max_resolution, :data_limits, :colorrange], [:x_endpoints, :y_endpoints, :overview_image, :computed_colorrange]) do image, x, y, max_resolution, image_area, crange
-        x, y, img = resample_image(x, y, image.data, max_resolution, image_area)
+    map!(p.attributes, 
+        [:image, :x, :y, :max_resolution, :data_limits, :colorrange, :transform_func], 
+        [:x_endpoints, :y_endpoints, :overview_image, :computed_colorrange]
+    ) do image, x, y, max_resolution, image_area, crange, transform_func
+        x, y, img = resample_image(x, y, image.data, max_resolution, image_area, transform_func)
         cr = calculate_colorrange(img, crange)
         if image.lowres_background
             val = cr isa Vec2 ? mean(cr) : 0.0f0 # TODO color mean?
@@ -727,11 +740,11 @@ function Makie.plot!(p::HeatmapShader)
 
     ComputePipeline.map!(
         p.attributes,
-        [:image, :x, :y, :max_resolution, :slow_limits],
+        [:image, :x, :y, :max_resolution, :slow_limits, :transform_func],
         [:lx_endpoints, :ly_endpoints, :limit_image, :l_visible],
-        init = (p.x[], p.x[], fill(zero(T), 2, 2), false)
-    ) do image, x, y, max_resolution, limits
-        xe_ye_oimg = resample_image(x, y, image.data, max_resolution, limits)
+        init = (p.x[], p.y[], fill(zero(T), 2, 2), false)
+    ) do image, x, y, max_resolution, limits, transform_func
+        xe_ye_oimg = resample_image(x, y, image.data, max_resolution, limits, transform_func)
         isnothing(xe_ye_oimg) && return nothing
         return (xe_ye_oimg..., true)
     end

--- a/Makie/test/conversions/conversions.jl
+++ b/Makie/test/conversions/conversions.jl
@@ -23,6 +23,59 @@ end
     @test hm.converted[][3].data == Resampler(zeros(4, 4)).data
 end
 
+@testset "resample_image" begin
+    matrix = permutedims(1:5) .* (1:5)
+    rs = Resampler(matrix)
+
+    # These tests are designed to catch regressions, not be an 
+    # undisputable correct answer. They are added when adding
+    # support for axis scalings of the resampler, such that
+    # the behavior when scale = :identity is unaffected, which
+    # means that some suspicious off-by-one behavior is carried on. 
+    # This should not have any effect on the overall appearance of 
+    # an image, but it means we need to deal with non-integer numbers
+    # for unit tests and cannot test for simple properties of the result. 
+
+    image_area = Rect2f(0, 0, 4, 4) 
+    _, _, resampled = resample_image((0,4), (0, 4), rs.data, (100, 100), image_area, (identity, identity))
+    @test resampled ≈ Float32[
+        1.0 2.3333333 3.6666667 5.0; 
+        2.3333333 5.444444 8.555555 11.666666; 
+        3.6666667 8.555555 13.444446 18.333334; 
+        5.0 11.666666 18.333334 25.0
+    ]
+
+    image_area = Rect2f(0,0,2,4)
+    _, _, resampled = resample_image((0,4), (0, 4), rs.data, (100, 100), image_area, (identity, identity))
+    @test resampled ≈ Float32[
+        1.0 2.3333333 3.6666667 5.0; 
+        3.0 7.0 11.0 15.0
+    ]
+
+    image_area = Rect2f(0,0,4, 2)
+    _, _, resampled = resample_image((0,4), (0, 4), rs.data, (100, 100), image_area, (identity, identity))
+    @test resampled ≈ Float32[
+        1.0 3.0; 
+        2.3333333 7.0; 
+        3.6666667 11.0;
+        5.0 15.0
+    ]
+
+    # X-axis sqrt-scaled. The resampled matrix has the same values in the "corners"
+    # as without rescaling. The first row is still uniform (identity) but the 
+    # first column is non-uniform. 
+    image_area = Rect2f(0, 0, 4, 4) 
+    x, y, resampled = resample_image((0,4), (0, 4), rs.data, (100, 100), image_area, (sqrt, identity))
+    @test x == [0,4]
+    @test y == [0,4]
+    @test resampled ≈ Float32[
+        1.0 2.3333333 3.6666667 5.0; 
+        1.9938082 4.652219 7.3106303 9.969041; 
+        3.3271413 7.7633295 12.199518 16.635706; 
+        5.0 11.666666 18.333334 25.0
+    ]
+end
+
 @testset "changing input types" begin
     input = Observable{Any}(decompose(Point2f, Circle(Point2f(0), 2.0f0)))
     f, ax, pl = mesh(input)


### PR DESCRIPTION
# Description

Made `Resampler` not ignore axis scaling settings. 

Its a follow-up on https://github.com/MakieOrg/Makie.jl/pull/5526 that got stuck on my computer for some time, sorry about the delay. 

The implementation should not change anything when identity scaling (default) is used. I made some quick tests to catch any regression in the future. When I tried to write better tests, I also found that I wanted to change some of the computations, which would make everything much more complicated. So I'm keeping it simple. Let me know if you need something more rigorous. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
