### PR TITLE
Add `select!` to ComputePipeline for resolving just one selected input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
   - **minor breaking** This may lead to duplicate call signatures, attribute and argument information, and examples as those are now added automatically.
 - Updated CairoMakie to allow LinePatterns to be vectorized [#5534](https://github.com/MakieOrg/Makie.jl/pull/5534)
 - **minor breaking** Reworked cycling internals for improved performance when adding many plots. This changes cycling behavior in some edge cases, e.g. when adding plot specs to a `plotlist`, after removing plots from a scene/axis or when leaving cycled attributes unset in recipes. Also allows `:cycle` to be themed via `theme[:PlotName][:cycle]` and cycled attributes to be overwritten by `theme[:Plot][...]`. [#5636](https://github.com/MakieOrg/Makie.jl/pull/5636)
+- Added `select!(graph, selector, choices, output)` as a way to resolve just one of `choices` based on the index given by `selector` and write it to `output`. This allows you to exclude expensive branches of the compute graph with an adjustable index. [#5749](https://github.com/MakieOrg/Makie.jl/pull/5749)
 
 ## Unreleased
 

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -973,14 +973,39 @@ end
 
 function locked_resolve!(edge::ComputeEdge)
     edge.got_resolved[] && return
-    foreach(locked_resolve!, edge.inputs)
-    if !isassigned(edge.typed_edge)
-        edge.typed_edge[] = TypedEdge(edge)
+
+    # special case to avoid resolving both options of an ifelse
+    # Note: dispatching on callback type is much slower than this
+    if edge.callback === ifelse
+        # resolve condition
+        locked_resolve!(edge.inputs[1])
+        edge.inputs_dirty[1] = false
+
+        # resolve and forward picked choice
+        idx = 1 + Int(edge.inputs[1][]::Bool)
+        locked_resolve!(edge.inputs[idx])
+        edge.inputs_dirty[idx] = false
+        new_value = edge.inputs[idx].value[]
+
+        output = edge.outputs[1]
+        if isdefined(output, :value) && isassigned(output.value)
+            output.dirty = is_same(output.value[], new_value)
+            output.value[] = new_value
+        else
+            output.dirty = true
+            output.value = RefValue(new_value)
+        end
     else
-        locked_resolve!(edge.typed_edge[])
+        foreach(locked_resolve!, edge.inputs)
+        if !isassigned(edge.typed_edge)
+            edge.typed_edge[] = TypedEdge(edge)
+        else
+            locked_resolve!(edge.typed_edge[])
+        end
+        fill!(edge.inputs_dirty, false)
     end
+
     edge.got_resolved[] = true
-    fill!(edge.inputs_dirty, false)
     for dep in edge.dependents
         mark_input_dirty!(edge, dep)
     end
@@ -1555,6 +1580,7 @@ struct MapFunctionWrapper{pack, FT} <: Function
 end
 
 MapFunctionWrapper(::typeof(compute_identity), pack = true) = compute_identity
+MapFunctionWrapper(::typeof(ifelse), pack = true) = ifelse
 
 function (x::MapFunctionWrapper{true})(inputs, @nospecialize(changed), @nospecialize(cached))
     result = x.user_func(values(inputs)...)

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -982,7 +982,7 @@ function locked_resolve!(edge::ComputeEdge)
         edge.inputs_dirty[1] = false
 
         # resolve and forward picked choice
-        idx = 1 + Int(edge.inputs[1][]::Bool)
+        idx = 2 + Int(!edge.inputs[1][]::Bool)
         locked_resolve!(edge.inputs[idx])
         edge.inputs_dirty[idx] = false
         new_value = edge.inputs[idx].value[]

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -1011,10 +1011,12 @@ function locked_resolve!(edge::ComputeEdge)
         # resolve and forward picked choice
         idx = 1 + edge.inputs[1].value[]::Int
         if !(2 <= idx <= length(edge.inputs))
-            throw(SelectException(
-                "Selection index $(idx - 1) is out of bounds for indexing $(length(edge.inputs) - 1) inputs.",
-                edge
-            ))
+            throw(
+                SelectException(
+                    "Selection index $(idx - 1) is out of bounds for indexing $(length(edge.inputs) - 1) inputs.",
+                    edge
+                )
+            )
         end
         locked_resolve!(edge.inputs[idx])
         edge.inputs_dirty[idx] = false

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -144,11 +144,6 @@ function Base.eltype(computed::Computed)
     return eltype(computed.value)
 end
 
-struct ResolveException{E <: Exception} <: Exception
-    start::Computed
-    error::E
-end
-
 struct TypedEdge{InputTuple, OutputTuple, F}
     callback::F
     inputs::InputTuple
@@ -177,6 +172,16 @@ struct ComputeEdge{T} <: AbstractEdge
     # Mainly needed for mark_dirty!(edge) to propagate to all dependents
     dependents::Vector{ComputeEdge{T}}
     typed_edge::RefValue{TypedEdge}
+end
+
+struct ResolveException{E <: Exception} <: Exception
+    start::Computed
+    error::E
+end
+
+struct SelectException <: Exception
+    msg::String
+    edge::ComputeEdge
 end
 
 function ComputeEdge(f, graph::T, input::Computed, output::Computed) where {T}
@@ -1005,6 +1010,12 @@ function locked_resolve!(edge::ComputeEdge)
 
         # resolve and forward picked choice
         idx = 1 + edge.inputs[1].value[]::Int
+        if !(2 <= idx <= length(edge.inputs))
+            throw(SelectException(
+                "Selection index $(idx - 1) is out of bounds for indexing $(length(edge.inputs) - 1) inputs.",
+                edge
+            ))
+        end
         locked_resolve!(edge.inputs[idx])
         edge.inputs_dirty[idx] = false
         new_value = edge.inputs[idx].value[]

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -1004,7 +1004,7 @@ function locked_resolve!(edge::ComputeEdge)
         edge.inputs_dirty[1] = false
 
         # resolve and forward picked choice
-        idx = edge.inputs[1].value[]::Int
+        idx = 1 + edge.inputs[1].value[]::Int
         locked_resolve!(edge.inputs[idx])
         edge.inputs_dirty[idx] = false
         new_value = edge.inputs[idx].value[]

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -2000,7 +2000,7 @@ returned by the parent edge callback.
 function unsafe_init!(node::Computed, value)
     if !isdefined(node, :value)
         node.value = value isa RefValue ? value : RefValue(value)
-    elseif !isassigned(node, :value)
+    elseif !isassigned(node.value)
         # Maybe set_type! happened, but resolve definitely didn't since it has
         # no value. So we don't need mark_dirty! here...
         node.value[] = deref(value)

--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -979,18 +979,32 @@ function locked_resolve!(computed::Computed)
     return
 end
 
+# Not actually called, but maybe useful for understanding what it does?
+"""
+    select(idx::Int, choices...)
+
+Returns `choices[idx]`.
+
+This function is not directly called when used as the callback in `map` or
+`register_computation!`. It is instead replaced by resolving the node which
+supplies `idx` and node which supplies `choices[idx]`, leaving all other nodes
+unresolved/dirty. The edge output gets the result as if `select` was called
+directly, but doesn't pay the cost of resolving unused inputs.
+"""
+select(i::Int, choices...) = choices[i]
+
 function locked_resolve!(edge::ComputeEdge)
     edge.got_resolved[] && return
 
-    # special case to avoid resolving both options of an ifelse
-    # Note: dispatching on callback type is much slower than this
-    if edge.callback === ifelse
-        # resolve condition
+    # special case to resolve just one of many options
+    # Note: dispatching on callback type is much slower than ===
+    if edge.callback === select
+        # resolve selected index
         locked_resolve!(edge.inputs[1])
         edge.inputs_dirty[1] = false
 
         # resolve and forward picked choice
-        idx = 2 + Int(!edge.inputs[1][]::Bool)
+        idx = edge.inputs[1].value[]::Int
         locked_resolve!(edge.inputs[idx])
         edge.inputs_dirty[idx] = false
         new_value = edge.inputs[idx].value[]
@@ -1588,7 +1602,7 @@ struct MapFunctionWrapper{pack, FT} <: Function
 end
 
 MapFunctionWrapper(::typeof(compute_identity), pack = true) = compute_identity
-MapFunctionWrapper(::typeof(ifelse), pack = true) = ifelse
+MapFunctionWrapper(::typeof(select), pack = true) = select
 
 function (x::MapFunctionWrapper{true})(inputs, @nospecialize(changed), @nospecialize(cached))
     result = x.user_func(values(inputs)...)
@@ -1984,10 +1998,14 @@ This function makes no checks to confirm that the given value matches the type
 returned by the parent edge callback.
 """
 function unsafe_init!(node::Computed, value)
-    if isdefined(node, :value)
-        error("Node already initialized.")
-    else
+    if !isdefined(node, :value)
         node.value = value isa RefValue ? value : RefValue(value)
+    elseif !isassigned(node, :value)
+        # Maybe set_type! happened, but resolve definitely didn't since it has
+        # no value. So we don't need mark_dirty! here...
+        node.value[] = deref(value)
+    else
+        error("Node already initialized.")
     end
 
     return unsafe_init!(node.parent)
@@ -2051,6 +2069,9 @@ set_type!(graph.output, Union{Int, Float64, String})
 ```
 """
 function set_type!(node::Computed, T::Type)
+    # Should be the same as is_initialized(node) in practice, but it's a little
+    # safer to only work with not-yet-defined node.value's because otherwise
+    # there is a ref that could be used somewhere already.
     if isdefined(node, :value)
         error("Node already initialized.")
     else

--- a/ComputePipeline/src/io.jl
+++ b/ComputePipeline/src/io.jl
@@ -247,6 +247,15 @@ function Base.show(io::IO, ::MIME"text/plain", graph::ComputeGraph)
 end
 
 
+function Base.showerror(io::IO, re::ResolveException{SelectException})
+    trace_error(io, re.start, re.error.edge)
+    print(io, "Due to ")
+    printstyled(io, "ERROR: ", color = :light_red, bold = true)
+    Base.showerror(io, re.error)
+end
+
+Base.showerror(io::IO, se::SelectException) = print(io, se.msg)
+
 function Base.showerror(io::IO, re::ResolveException)
     trace_error(io, re.start)
     print(io, "Due to ")
@@ -271,24 +280,27 @@ function collect_dirty(edge::Input, marked = Set{Symbol}())
 end
 
 # Error handling tools
-function trace_error(io::IO, computed::Computed)
+function trace_error(io::IO, computed::Computed, stop_at = nothing)
     print(io, "Failed to resolve ")
     printstyled(io, "$(computed.name):\n", color = :red)
     if hasparent(computed)
         marked = collect_dirty(computed)
         push!(marked, computed.name)
-        trace_error(io, computed.parent, marked)
+        trace_error(io, computed.parent, marked, stop_at)
     end
     return
 end
-trace_error(io::IO, edge::ComputeEdge) = trace_error(io, edge, collect_dirty(edge))
 
-function trace_error(io::IO, computed::Computed, marked)
-    hasparent(computed) && trace_error(io, computed.parent, marked)
+function trace_error(io::IO, edge::ComputeEdge, stop_at = nothing)
+    return trace_error(io, edge, collect_dirty(edge), stop_at)
+end
+
+function trace_error(io::IO, computed::Computed, marked::Set, stop_at = nothing)
+    hasparent(computed) && trace_error(io, computed.parent, marked, stop_at)
     return
 end
 
-function trace_error(io::IO, edge::ComputeEdge, marked)
+function trace_error(io::IO, edge::ComputeEdge, marked::Set, stop_at = nothing)
     if isdirty(edge)
         print(io, "[ComputeEdge] ")
 
@@ -312,18 +324,23 @@ function trace_error(io::IO, edge::ComputeEdge, marked)
         printstyled(io, "  @ $(edge_callback_location(edge))\n", color = :light_black)
 
         idx = findfirst(computed -> computed.name in marked, edge.inputs)
-        if idx === nothing # All resolved
+        if isnothing(idx) || stop_at === edge # All resolved or marked as stopping point
             print(io, "  with edge inputs:")
             ioc = IOContext(io, :limit => true)
             for (input, dirty) in zip(edge.inputs, edge.inputs_dirty)
                 c = ifelse(dirty, :normal, :light_black)
                 printstyled(io, "\n    ", input.name, " = ", color = c)
-                show(ioc, input.value[])
+                if isdirty(input)
+                    val = is_initialized(input) ? input.value[] : "#undef"
+                    printstyled(ioc, val * " (outdated)", color = :light_black)
+                else
+                    show(ioc, input.value[])
+                end
             end
             println(io)
-            print_root_inputs(io, edge)
+            isnothing(idx) && print_root_inputs(io, edge)
         else # idx is first dirty
-            trace_error(io, edge.inputs[idx], marked)
+            trace_error(io, edge.inputs[idx], marked, stop_at)
         end
     end
     return
@@ -349,7 +366,7 @@ function trace_inputs!(input::Input, root_inputs)
     return
 end
 
-function trace_error(io::IO, edge::Input, marked = nothing)
+function trace_error(io::IO, edge::Input, marked = nothing, stop_at = nothing)
     print(io, "[Input] ")
     if edge.dirty
         printstyled(io, edge.name, color = :red)

--- a/ComputePipeline/src/utils.jl
+++ b/ComputePipeline/src/utils.jl
@@ -47,3 +47,33 @@ unwrap_explicit_update(x) = x
 unwrap_explicit_update(x::ComputePipeline.ExplicitUpdate) = x.data
 
 export ExplicitUpdate, unwrap_explicit_update
+
+"""
+    pick_ifelse(graph, condition, choice1, choice2, output)
+
+Calls `map!(ifelse, graph, [condition, choice1, choice2], output)` which sets
+`output` to `choice1` or `choice2` based on `condition` when resolved.
+
+This uses a special path in `resolve!` to only evaluate one of the two branches.
+"""
+function pick_ifelse(graph, condition, choice1, choice2, output::Symbol)
+    map!(ifelse, graph, [condition, choice1, choice2], output)
+    return
+end
+
+"""
+    pick_ifelse(callback, graph, condition_inputs, choice1, choice2, output)
+
+Adds `map!(callback, graph, condition_inputs, anon_node)` to map the
+`condition_inputs` to a boolean node using `callback` and
+`map!(ifelse, graph, [anon_node, choice1, choice2], output)` to pick `choice1`
+or `choice2` based on the result.
+
+This uses a special path in `resolve!` to only evaluate one of the two branches.
+"""
+function pick_ifelse(callback, graph, condition_inputs, choice1, choice2, output::Symbol)
+    condition = Symbol(output, :_picker)
+    map!(callback, graph, condition_inputs, condition)
+    map!(ifelse, graph, [condition, choice1, choice2], output)
+    return
+end

--- a/ComputePipeline/src/utils.jl
+++ b/ComputePipeline/src/utils.jl
@@ -48,11 +48,9 @@ unwrap_explicit_update(x::ComputePipeline.ExplicitUpdate) = x.data
 
 export ExplicitUpdate, unwrap_explicit_update
 
-
-
 """
-    select(graph, selector, choices, output)
-    select(callback, graph, selection_inputs, choices, output)
+    select!(graph, selector, choices, output)
+    select!(callback, graph, selection_inputs, choices, output)
 
 Selects one of the `choices` nodes based on the index given in the `selector`
 node and forwards it to the `output` node without resolving the other `choices`.
@@ -63,7 +61,7 @@ define the selected index based on the result of `callback(selection_inputs...)`
 This calls `map!(select, graph, [selector, choices...], output)` internally. If
 a callback is given, it will generate a `selector` node beforehand.
 """
-function select(graph, selector::InputNodeTypes, choices::Vector, output::OutputNodeTypes)
+function select!(graph::AbstractComputeGraph, selector::InputNodeTypes, choices::Vector, output::OutputNodeTypes)
     map!(select, graph, [selector, choices...], output)
     node = get_node(graph, selector)
     if is_initialized(node)
@@ -74,10 +72,11 @@ function select(graph, selector::InputNodeTypes, choices::Vector, output::Output
     return
 end
 
-
-function select(callback, graph, selection_inputs, choices::Vector, output::OutputNodeTypes)
+function select!(callback, graph::AbstractComputeGraph, selection_inputs, choices::Vector, output::OutputNodeTypes)
     selector = Symbol(output, :_selector)
     map!(callback, graph, selection_inputs, selector)
     map!(select, graph, [selector, choices...], output)
     return
 end
+
+export select!

--- a/ComputePipeline/src/utils.jl
+++ b/ComputePipeline/src/utils.jl
@@ -48,32 +48,36 @@ unwrap_explicit_update(x::ComputePipeline.ExplicitUpdate) = x.data
 
 export ExplicitUpdate, unwrap_explicit_update
 
-"""
-    pick_ifelse(graph, condition, choice1, choice2, output)
 
-Calls `map!(ifelse, graph, [condition, choice1, choice2], output)` which sets
-`output` to `choice1` or `choice2` based on `condition` when resolved.
 
-This uses a special path in `resolve!` to only evaluate one of the two branches.
 """
-function pick_ifelse(graph, condition, choice1, choice2, output::Symbol)
-    map!(ifelse, graph, [condition, choice1, choice2], output)
+    select(graph, selector, choices, output)
+    select(callback, graph, selection_inputs, choices, output)
+
+Selects one of the `choices` nodes based on the index given in the `selector`
+node and forwards it to the `output` node without resolving the other `choices`.
+
+Alternatively, a `callback` and one or more `selection_inputs` can be given to
+define the selected index based on the result of `callback(selection_inputs...)`.
+
+This calls `map!(select, graph, [selector, choices...], output)` internally. If
+a callback is given, it will generate a `selector` node beforehand.
+"""
+function select(graph, selector::InputNodeTypes, choices::Vector, output::OutputNodeTypes)
+    map!(select, graph, [selector, choices...], output)
+    node = get_node(graph, selector)
+    if is_initialized(node)
+        node.value[] isa Int || error("Selector node $(node.name) must contain an $Int, but is initialized to $(node.value[])")
+    else
+        ComputePipeline.set_type!(node, Int)
+    end
     return
 end
 
-"""
-    pick_ifelse(callback, graph, condition_inputs, choice1, choice2, output)
 
-Adds `map!(callback, graph, condition_inputs, anon_node)` to map the
-`condition_inputs` to a boolean node using `callback` and
-`map!(ifelse, graph, [anon_node, choice1, choice2], output)` to pick `choice1`
-or `choice2` based on the result.
-
-This uses a special path in `resolve!` to only evaluate one of the two branches.
-"""
-function pick_ifelse(callback, graph, condition_inputs, choice1, choice2, output::Symbol)
-    condition = Symbol(output, :_picker)
-    map!(callback, graph, condition_inputs, condition)
-    map!(ifelse, graph, [condition, choice1, choice2], output)
+function select(callback, graph, selection_inputs, choices::Vector, output::OutputNodeTypes)
+    selector = Symbol(output, :_selector)
+    map!(callback, graph, selection_inputs, selector)
+    map!(select, graph, [selector, choices...], output)
     return
 end

--- a/ComputePipeline/src/utils.jl
+++ b/ComputePipeline/src/utils.jl
@@ -75,7 +75,7 @@ end
 function select!(callback, graph::AbstractComputeGraph, selection_inputs, choices::Vector, output::OutputNodeTypes)
     selector = Symbol(output, :_selector)
     map!(callback, graph, selection_inputs, selector)
-    map!(select, graph, [selector, choices...], output)
+    select!(callback, graph, selector, choices, output)
     return
 end
 

--- a/ComputePipeline/test/unit_tests.jl
+++ b/ComputePipeline/test/unit_tests.jl
@@ -1734,6 +1734,6 @@ end
 
     update!(graph, user_choice = 3, x = 5, y = 2)
     check_state(graph, [1, 1, 1, 1, 1, 1, 1])
-    @test graph.output[] == 5+2
+    @test graph.output[] == 5 + 2
     check_state(graph, [0, 0, 0, 1, 1, 0, 0])
 end

--- a/ComputePipeline/test/unit_tests.jl
+++ b/ComputePipeline/test/unit_tests.jl
@@ -1697,3 +1697,43 @@ end
     @assert pointer(v) == pointer(graph.vec[]) "this is expected to be memory aliased, but isn't"
     @test graph.vecf[] == [1, 1, 1, 1]
 end
+
+@testset "select" begin
+    graph = ComputeGraph()
+    add_input!(graph, :user_choice, 1)
+    add_input!(graph, :x, 5)
+    add_input!(graph, :y, -1)
+
+    map!(identity, graph, :x, :input1)
+    map!(identity, graph, :y, :input2)
+    map!(+, graph, [:x, :y], :input3)
+
+    select!(graph, :user_choice, [:input1, :input2, :input3], :output)
+
+    # Verify initial state
+    function check_state(graph, state)
+        for (i, name) in enumerate([:user_choice, :x, :y, :input1, :input2, :input3, :output])
+            @test isdirty(graph[name]) == Bool(state[i])
+        end
+    end
+
+    @assert all(isdirty, values(graph.outputs)) "Test expects nodes to not initialize until first resolve"
+
+    @test graph.output[] == 5
+    check_state(graph, [0, 0, 1, 0, 1, 1, 0])
+
+    graph.x = 4
+    check_state(graph, [0, 1, 1, 1, 1, 1, 1])
+    @test graph.output[] == 4
+    check_state(graph, [0, 0, 1, 0, 1, 1, 0])
+
+    graph.user_choice = 2
+    check_state(graph, [1, 0, 1, 0, 1, 1, 1])
+    @test graph.output[] == -1
+    check_state(graph, [0, 0, 0, 0, 0, 1, 0])
+
+    update!(graph, user_choice = 3, x = 5, y = 2)
+    check_state(graph, [1, 1, 1, 1, 1, 1, 1])
+    @test graph.output[] == 5+2
+    check_state(graph, [0, 0, 0, 1, 1, 0, 0])
+end

--- a/docs/src/explanations/compute-pipeline.md
+++ b/docs/src/explanations/compute-pipeline.md
@@ -308,6 +308,8 @@ If any of outputs is requested and not up to date, the edge will be resolved.
 This then resolves every input in `inputs` that is dirty, causing more edges to resolve recursively.
 
 ```@example
+using ComputePipeline
+
 graph = ComputeGraph()
 add_input!(graph, :user_choice, 1) do x
     @info "user choice"
@@ -347,6 +349,7 @@ If the inputs nodes are expensive to resolve it would be nice to skip them if th
 This can be done with `select!(graph, selector, choices, output)` where the `selector` node returns an index selecting which of the `choices` should forward to the `output`:
 
 ```@example
+using ComputePipeline # hide
 graph = ComputeGraph()
 add_input!(graph, :user_choice, 1) do x
     @info "user choice"

--- a/docs/src/explanations/compute-pipeline.md
+++ b/docs/src/explanations/compute-pipeline.md
@@ -300,3 +300,82 @@ graph.deny_output[] # 1
 
 Note that if you want a node to work with plain values and values wrapped in `ExplicitUpdate` you will need to initialize its type to a union.
 For example `set_type!(node, Union{Int64, ExplicitUpdate{Int64}})`.
+
+## Selective/Lazy Resolve
+
+Let's say we have a generic compute edge defined by `map!(callback, graph, inputs, outputs)`.
+If any of outputs is requested and not up to date, the edge will be resolved.
+This then resolves every input in `inputs` that is dirty, causing more edges to resolve recursively.
+
+```@example
+graph = ComputeGraph()
+add_input!(graph, :user_choice, 1) do x
+    @info "user choice"
+    return x
+end
+
+add_input!(graph, :x, 5) do x
+    @info "x"
+    return x
+end
+add_input!(graph, :y, -1) do y
+    @info "y"
+    return y
+end
+
+map!(graph, :x, :input1) do x
+    @info "input 1"
+    return x
+end
+map!(graph, :y, :input2) do y
+    @info "input 2"
+    return y
+end
+map!(graph, [:x, :y], :input3) do x, y
+    @info "input 3"
+    return x + y
+end
+
+map!(graph, [:user_choice, :input1, :input2, :input3], :output) do i, choices...
+    return choices[i]
+end
+
+graph.output[]
+```
+
+If the inputs nodes are expensive to resolve it would be nice to skip them if they are ultimately not selected by `user_choice`.
+This can be done with `select!(graph, selector, choices, output)` where the `selector` node returns an index selecting which of the `choices` should forward to the `output`:
+
+```@example
+graph = ComputeGraph()
+add_input!(graph, :user_choice, 1) do x
+    @info "user choice"
+    return x
+end
+
+add_input!(graph, :x, 5) do x
+    @info "x"
+    return x
+end
+add_input!(graph, :y, -1) do y
+    @info "y"
+    return y
+end
+
+map!(graph, :x, :input1) do x
+    @info "input 1"
+    return x
+end
+map!(graph, :y, :input2) do y
+    @info "input 2"
+    return y
+end
+map!(graph, [:x, :y], :input3) do x, y
+    @info "input 3"
+    return x + y
+end
+
+select!(graph, :user_choice, [:input1, :input2, :input3], :output)
+
+graph.output[]
+```

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -13,7 +13,8 @@ using Statistics: median
 Package = length(ARGS) > 0 ? ARGS[1] : "CairoMakie"
 n_samples = length(ARGS) > 1 ? parse(Int, ARGS[2]) : 7
 # base_branch = length(ARGS) > 2 ? ARGS[3] : "master"
-base_branch = "master"
+# base_branch = "master"
+base_branch = "ff/breaking-0.25"
 
 # Package = "CairoMakie"
 # n_samples = 2


### PR DESCRIPTION
# Description

**Note**: I rewrote this to work based on a `select` function defined in `ComputePipeline` that picks an index instead of using `ifelse` with a bool. This is more generic since you can select between more than 2 inputs but doesn't change the core idea. I'm leaving my old description below since you can just replace `ifelse` with `select` and the `true/false` input with `1/2`.

---

This adds some special handling for `ifelse` callbacks to only evaluate one of the choices. 

```julia
graph = ComputeGraph()
add_input!(graph, :first, true)
add_input!(graph, :a, 99.0)
add_input!(graph, :b, 1.0)

map!(ifelse, graph, [:first, :a, :b], :result)

# Resolves only the :a side of the graph
graph.result[]
```

Benchmarking the same graph without using the new path results in maybe 1% slower timings. So it's pretty little impact. 

```julia
map!(graph, [:first, :a, :b], :result) do a, b, c
    return ifelse(a, b, c)
end

@benchmark begin
    update!($(graph), a = 10 + rand(), b = rand())
    $(graph).result[]
end
```

For reference, making the function type of the callback in `ComputeEdge` a type parameter slows things down by at least 50%. So the `callback === ifelse` check is way faster than dispatch.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- ~~Added reference image tests for new plotting functions, recipes, visual options, etc.~~
