### PR TITLE
Speed up datashader aggregation and equalize_histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- `datashader` is much faster: with 100M points, aggregating and displaying an update went from 47 ms to 26 ms, and per-update allocations from 9.2 MiB to 11 KiB [#5750](https://github.com/MakieOrg/Makie.jl/pull/5750).
+- Fixed `datashader` counting points twice at thread chunk boundaries, and erroring or writing out of bounds for points exactly at the upper axis limits [#5750](https://github.com/MakieOrg/Makie.jl/pull/5750).
+- `Makie.equalize_histogram` no longer errors on `NaN` or constant input [#5750](https://github.com/MakieOrg/Makie.jl/pull/5750).
 - Added `StageCamera` (`stage_cam!`), a 3D camera with photographic settings that keeps a stage of a given size in view [#5472](https://github.com/MakieOrg/Makie.jl/pull/5472).
 - `Menu` is now searchable: typing while it is open filters the options. Set `searchable = false` for the old behavior [#5642](https://github.com/MakieOrg/Makie.jl/pull/5642)
 - Added `textcolor_active` and `textcolor_hover` attributes to `Menu`, with the selected entry now white by default [#5642](https://github.com/MakieOrg/Makie.jl/pull/5642)

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -273,16 +273,44 @@ module Aggregation
 end
 
 using ..Aggregation
-using ..Aggregation: Canvas, change_op!, aggregate!
+using ..Aggregation: Canvas, bin_scale, change_op!, aggregate!
 
 function equalize_histogram(matrix; nbins = 256)
-    h_eq = StatsBase.fit(StatsBase.Histogram, vec(matrix); nbins = nbins)
-    h_eq = normalize(h_eq; mode = :density)
-    cdf = cumsum(h_eq.weights)
-    cdf = cdf / cdf[end]
-    edg = h_eq.edges[1]
-    # TODO is this the correct linear interpolation?
-    return Makie.interpolated_getindex.((cdf,), matrix, (Vec2f(first(edg), last(edg)),))
+    # binning happens in the element type's own precision, so that the scaled offsets
+    # below stay within the range `bin_scale` was checked against
+    FT = float(eltype(matrix))
+    mini, maxi = FT(Inf), FT(-Inf)
+    @inbounds for x in matrix
+        if isfinite(x)
+            mini = min(mini, x)
+            maxi = max(maxi, x)
+        end
+    end
+    mini < maxi || return fill!(similar(matrix, Float32), 1.0f0)
+
+    binscale = bin_scale(nbins, maxi - mini)
+    # one bin of headroom, so the interpolation below can always read the following entry
+    counts = zeros(Float32, nbins + 1)
+    @inbounds for x in matrix
+        isfinite(x) || continue
+        counts[1 + unsafe_trunc(Int, binscale * (x - mini))] += 1
+    end
+    cdf = cumsum!(counts, counts)
+    cdf ./= cdf[end]
+
+    result = similar(matrix, Float32)
+    @inbounds for i in eachindex(matrix, result)
+        x = matrix[i]
+        if !isfinite(x)
+            result[i] = NaN32
+            continue
+        end
+        pos = binscale * (x - mini)
+        bin = unsafe_trunc(Int, pos)
+        low, high = cdf[bin + 1], cdf[bin + 2]
+        result[i] = low + (high - low) * (pos - bin)
+    end
+    return result
 end
 
 """

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -97,7 +97,6 @@ module Aggregation
         v0 = value(op, o0)
         aggbuffer = fill(o0, n_elements)
         pixelbuffer = fill(v0, n_elements)
-        # using ReshapedArray directly like this is not advised, but as it lives only briefly it should be ok
         return Canvas(Rect2{Float64}(bounds), resolution, op, aggbuffer, pixelbuffer, (v0, v0))
     end
 

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -139,6 +139,23 @@ module Aggregation
         return aggregation_implementation!(method, aggbuffer, pixelbuffer, c, c.op, points, point_transform)
     end
 
+    """
+        bin_scale(size::Integer, width::Real)
+
+    Scaling factor from a coordinate offset to a bin index, chosen so that
+    `bin_scale(size, width) * width < size` holds exactly in floating point.
+    That way `unsafe_trunc` of a scaled in-bounds offset can never reach `size`,
+    which lets the aggregation loop skip a bounds clamp per point.
+    """
+    function bin_scale(size::Integer, width::Real)
+        width > 0 || return zero(float(width))
+        scale = size / width
+        while scale * width >= size
+            scale = prevfloat(scale)
+        end
+        return scale
+    end
+
     function aggregation_implementation!(
             ::AggSerial,
             aggbuffer::AbstractVector, pixelbuffer::AbstractVector,
@@ -147,9 +164,8 @@ module Aggregation
         )
         (xmin, ymin), (xmax, ymax) = extrema(c.bounds)
         xsize, ysize = size(c)
-        xwidth, ywidth = widths(c.bounds)
-        xscale = xsize / (xwidth + eps(xwidth))
-        yscale = ysize / (ywidth + eps(ywidth))
+        xscale = bin_scale(xsize, xmax - xmin)
+        yscale = bin_scale(ysize, ymax - ymin)
 
         @assert length(aggbuffer) == xsize * ysize
         @assert length(pixelbuffer) == xsize * ysize
@@ -157,23 +173,7 @@ module Aggregation
 
         # using ReshapedArray directly like this is not advised, but as it lives only briefly it should be ok
         out = Base.ReshapedArray(aggbuffer, (xsize, ysize), ())
-        for point in points
-            p = point_transform(point)
-            x = p[1]
-            y = p[2]
-            if length(p) > 2 # should compile away
-                z = p[3]
-            end
-            xmin ≤ x ≤ xmax || continue
-            ymin ≤ y ≤ ymax || continue
-            i = 1 + floor(Int, xscale * (x - xmin))
-            j = 1 + floor(Int, yscale * (y - ymin))
-            if length(p) == 2 # should compile away
-                out[i, j] = update(op, out[i, j])
-            elseif length(p) == 3
-                out[i, j] = update(op, out[i, j], z)
-            end
-        end
+        aggregate_points!(out, op, points, point_transform, xmin, xmax, ymin, ymax, xscale, yscale)
         mini, maxi = Inf, -Inf
 
         for i in eachindex(pixelbuffer, aggbuffer)
@@ -188,6 +188,31 @@ module Aggregation
         return c
     end
 
+    # point_transform is annotated so this stays specialized on it when called through
+    # aggregation_implementation!, which only passes it along
+    function aggregate_points!(out, op, points, point_transform::F, xmin, xmax, ymin, ymax, xscale, yscale) where {F}
+        @inbounds for point in points
+            p = point_transform(point)
+            x = p[1]
+            y = p[2]
+            if length(p) > 2 # should compile away
+                z = p[3]
+            end
+            xmin ≤ x ≤ xmax || continue
+            ymin ≤ y ≤ ymax || continue
+            # the bounds checks above make the scaled values non-negative and `bin_scale`
+            # keeps them below the axis length, so unsafe_trunc stays in range
+            i = 1 + unsafe_trunc(Int, xscale * (x - xmin))
+            j = 1 + unsafe_trunc(Int, yscale * (y - ymin))
+            if length(p) == 2 # should compile away
+                out[i, j] = update(op, out[i, j])
+            elseif length(p) == 3
+                out[i, j] = update(op, out[i, j], z)
+            end
+        end
+        return out
+    end
+
     function aggregation_implementation!(
             ::AggThreads,
             aggbuffer::AbstractVector, pixelbuffer::AbstractVector,
@@ -196,63 +221,50 @@ module Aggregation
         )
         (xmin, ymin), (xmax, ymax) = extrema(c.bounds)
         xsize, ysize = size(c)
-        # by adding eps to width we can use the scaling factor plus floor directly to compute the bin indices
-        xwidth = xmax - xmin
-        xscale = xsize / (xwidth + eps(xwidth))
-        ywidth = ymax - ymin
-        yscale = ysize / (ywidth + eps(ywidth))
+        xscale = bin_scale(xsize, xmax - xmin)
+        yscale = bin_scale(ysize, ymax - ymin)
         # each thread reduces some of the data separately
         @assert length(aggbuffer) == Threads.nthreads() * xsize * ysize
         @assert length(pixelbuffer) == xsize * ysize
         @assert eltype(aggbuffer) === typeof(null(op)) "$(eltype(aggbuffer)) !== $(typeof(null(op)))"
 
-        # using ReshapedArray directly like this is not advised, but as it lives only briefly it should be ok
-        # https://stackoverflow.com/questions/41781621/resizing-a-matrix/41804908#41804908
-        out = Base.ReshapedArray(aggbuffer, (xsize, ysize, Threads.nthreads()), ())
-        out2 = Base.ReshapedArray(pixelbuffer, (xsize, ysize), ())
-
+        nthreads = Threads.nthreads()
+        npixel = xsize * ysize
         n = length(points)
-        chunks = round.(Int, range(1, n; length = Threads.nthreads() + 1))
+        chunks = round.(Int, range(0, n; length = nthreads + 1))
 
-        @threads for t in 1:Threads.nthreads()
-            from = chunks[t]
-            to = chunks[t + 1]
-            @inbounds for idx in from:to
-                p = point_transform(points[idx])
-                x = p[1]
-                y = p[2]
-                if length(p) > 2 # should compile away
-                    z = p[3]
-                end
-                xmin ≤ x ≤ xmax || continue
-                ymin ≤ y ≤ ymax || continue
-                i = 1 + floor(Int, xscale * (x - xmin))
-                j = 1 + floor(Int, yscale * (y - ymin))
-                if length(p) == 2 # should compile away
-                    out[i, j, t] = update(op, out[i, j, t])
-                elseif length(p) == 3
-                    out[i, j, t] = update(op, out[i, j, t], z)
+        @threads for t in 1:nthreads
+            # using ReshapedArray directly like this is not advised, but as it lives only briefly it should be ok
+            # https://stackoverflow.com/questions/41781621/resizing-a-matrix/41804908#41804908
+            out = Base.ReshapedArray(view(aggbuffer, ((t - 1) * npixel + 1):(t * npixel)), (xsize, ysize), ())
+            chunk = view(points, (chunks[t] + 1):chunks[t + 1])
+            aggregate_points!(out, op, chunk, point_transform, xmin, xmax, ymin, ymax, xscale, yscale)
+        end
+
+        # reduce the per-thread results into the first slice and finalize into the
+        # pixelbuffer, split over pixel ranges so this runs in parallel too
+        pixel_chunks = round.(Int, range(0, npixel; length = nthreads + 1))
+        extremas = fill((Inf, -Inf), nthreads)
+        @threads for t in 1:nthreads
+            pixels = (pixel_chunks[t] + 1):pixel_chunks[t + 1]
+            for s in 2:nthreads
+                offset = (s - 1) * npixel
+                @inbounds for idx in pixels
+                    aggbuffer[idx] = merge(op, aggbuffer[idx], aggbuffer[offset + idx])
                 end
             end
-        end
-        # reduce along the thread dimension
-        mini, maxi = Inf, -Inf
-        for j in 1:ysize
-            @inbounds for i in 1:xsize
-                val = out[i, j, 1]
-                for t in 2:Threads.nthreads()
-                    val = merge(op, val, out[i, j, t])
-                end
-                # update the value in out2 directly in this loop
-                final_value = value(op, val)
+            mini, maxi = Inf, -Inf
+            @inbounds for idx in pixels
+                final_value = value(op, aggbuffer[idx])
                 if isfinite(final_value)
                     mini = min(final_value, mini)
                     maxi = max(final_value, maxi)
                 end
-                out2[i, j] = final_value
+                pixelbuffer[idx] = final_value
             end
+            extremas[t] = (mini, maxi)
         end
-        c.data_extrema = (mini, maxi)
+        c.data_extrema = (minimum(first, extremas), maximum(last, extremas))
         return c
     end
 

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -28,17 +28,29 @@ module Aggregation
         # temporaries / results
         aggbuffer::Vector
         pixelbuffer::Vector
+        resultbuffer::Matrix
         data_extrema::Tuple{Float64, Float64}
     end
 
+    function result_buffer!(canvas::Canvas)
+        ET = eltype(canvas.pixelbuffer)
+        buffer = canvas.resultbuffer
+        if !(buffer isa Matrix{ET}) || size(buffer) != canvas.resolution
+            buffer = Matrix{ET}(undef, canvas.resolution)
+            canvas.resultbuffer = buffer
+        end
+        return buffer
+    end
+
     """
-        get_aggregation(canvas::Canvas; operation=equalize_histogram, local_operation=identity, result=similar(canvas.pixelbuffer, canvas.resolution))
+        get_aggregation(canvas::Canvas; operation=equalize_histogram, local_operation=identity, result=result_buffer!(canvas))
 
     Basically does `operation(map!(local_operation, result, canvas.pixelbuffer))`, but does the correct reshaping of the flat pixelbuffer and
     simplifies passing a local or global operation.
-    Allocates the result buffer every time and can be made non allocating by passing the correct result buffer.
+    By default this reuses a result buffer owned by the canvas, so the returned array is
+    overwritten by the next call for the same canvas. Pass `result` to write into your own buffer.
     """
-    function get_aggregation(canvas::Canvas; operation = equalize_histogram, local_operation = identity, result = similar(canvas.pixelbuffer, canvas.resolution))
+    function get_aggregation(canvas::Canvas; operation = equalize_histogram, local_operation = identity, result = result_buffer!(canvas))
         pix_reshaped = Base.ReshapedArray(canvas.pixelbuffer, canvas.resolution, ())
         # we want to make it easy to set local_operation or operation, without them clashing, while also being able to set both!
         if operation === Makie.automatic
@@ -46,7 +58,10 @@ module Aggregation
         else
             postfunc = operation
         end
-        return postfunc(map!(local_operation, result, pix_reshaped))
+        mapped = map!(local_operation, result, pix_reshaped)
+        # the default operation can run in place, which keeps the whole call allocation free
+        postfunc === Makie.equalize_histogram && return Makie.equalize_histogram!(mapped, mapped)
+        return postfunc(mapped)
     end
 
     Base.size(c::Canvas) = c.resolution
@@ -97,7 +112,8 @@ module Aggregation
         v0 = value(op, o0)
         aggbuffer = fill(o0, n_elements)
         pixelbuffer = fill(v0, n_elements)
-        return Canvas(Rect2{Float64}(bounds), resolution, op, aggbuffer, pixelbuffer, (v0, v0))
+        resultbuffer = Matrix{typeof(v0)}(undef, 0, 0)
+        return Canvas(Rect2{Float64}(bounds), resolution, op, aggbuffer, pixelbuffer, resultbuffer, (v0, v0))
     end
 
     n_threads(::AggSerial) = 1
@@ -275,7 +291,14 @@ end
 using ..Aggregation
 using ..Aggregation: Canvas, bin_scale, change_op!, aggregate!
 
-function equalize_histogram(matrix; nbins = 256)
+equalize_histogram(matrix; nbins = 256) = equalize_histogram!(similar(matrix, Float32), matrix; nbins = nbins)
+
+"""
+    equalize_histogram!(result::AbstractMatrix{Float32}, matrix; nbins = 256)
+
+In-place version of [`equalize_histogram`](@ref). `result` may alias `matrix`.
+"""
+function equalize_histogram!(result::AbstractMatrix{Float32}, matrix; nbins = 256)
     # binning happens in the element type's own precision, so that the scaled offsets
     # below stay within the range `bin_scale` was checked against
     FT = float(eltype(matrix))
@@ -286,7 +309,7 @@ function equalize_histogram(matrix; nbins = 256)
             maxi = max(maxi, x)
         end
     end
-    mini < maxi || return fill!(similar(matrix, Float32), 1.0f0)
+    mini < maxi || return fill!(result, 1.0f0)
 
     binscale = bin_scale(nbins, maxi - mini)
     # one bin of headroom, so the interpolation below can always read the following entry
@@ -298,7 +321,6 @@ function equalize_histogram(matrix; nbins = 256)
     cdf = cumsum!(counts, counts)
     cdf ./= cdf[end]
 
-    result = similar(matrix, Float32)
     @inbounds for i in eachindex(matrix, result)
         x = matrix[i]
         if !isfinite(x)

--- a/Makie/test/plots/datashader.jl
+++ b/Makie/test/plots/datashader.jl
@@ -109,6 +109,23 @@ end
         @test Makie.equalize_histogram(constant) == fill(1.0f0, 3, 3)
     end
 
+    @testset "get_aggregation reuses the canvas result buffer" begin
+        canvas = Canvas(bounds; resolution = (16, 16), op = AggCount{Float32}())
+        aggregate!(canvas, [Point2f(0, 0), Point2f(1, 1), Point2f(1, 1)])
+        first_result = Makie.Aggregation.get_aggregation(canvas; operation = Makie.automatic)
+        second_result = Makie.Aggregation.get_aggregation(canvas; operation = Makie.automatic)
+        @test first_result === second_result
+        @test second_result == Makie.equalize_histogram(reshape(copy(canvas.pixelbuffer), canvas.resolution))
+        own_buffer = zeros(Float32, 16, 16)
+        @test Makie.Aggregation.get_aggregation(canvas; operation = Makie.automatic, result = own_buffer) === own_buffer
+    end
+
+    @testset "equalize_histogram! may alias its input" begin
+        values = Float32[0 0 0 0; 1 1 2 3]
+        aliased = copy(values)
+        @test Makie.equalize_histogram!(aliased, aliased; nbins = 4) == Makie.equalize_histogram(values; nbins = 4)
+    end
+
     @testset "point_transform" begin
         points = [Point2f(0.5, -1.5), Point2f(2.0, 1.0)]
         expected = reference_aggregation(map(reverse, points), bounds, resolution, AggCount{Int}())

--- a/Makie/test/plots/datashader.jl
+++ b/Makie/test/plots/datashader.jl
@@ -88,6 +88,27 @@ end
         end
     end
 
+    @testset "equalize_histogram" begin
+        values = Float32[0 0 0 0; 1 1 2 3]
+        eq = Makie.equalize_histogram(values; nbins = 4)
+        @test size(eq) == size(values)
+        # counts 4, 2, 1, 1 give a cdf of 0.5, 0.75, 0.875, 1, and each value is
+        # interpolated by how far it sits into its own bin
+        @test all(==(0.5f0), eq[1, :])
+        @test eq[2, 1] ≈ 0.75f0 + (0.875f0 - 0.75f0) / 3
+        @test eq[2, 2] == eq[2, 1]
+        @test eq[2, 3] ≈ 0.875f0 + (1.0f0 - 0.875f0) * 2 / 3
+        @test eq[2, 4] == 1.0f0
+
+        with_nan = Float32[0 NaN; 1 2]
+        eq_nan = Makie.equalize_histogram(with_nan; nbins = 4)
+        @test isnan(eq_nan[1, 2])
+        @test !any(isnan, eq_nan[[1, 2, 4]])
+
+        constant = fill(5.0f0, 3, 3)
+        @test Makie.equalize_histogram(constant) == fill(1.0f0, 3, 3)
+    end
+
     @testset "point_transform" begin
         points = [Point2f(0.5, -1.5), Point2f(2.0, 1.0)]
         expected = reference_aggregation(map(reverse, points), bounds, resolution, AggCount{Int}())

--- a/Makie/test/plots/datashader.jl
+++ b/Makie/test/plots/datashader.jl
@@ -1,0 +1,100 @@
+using Makie.Aggregation
+using Makie.Aggregation: Canvas, aggregate!, bin_scale, null, update, value
+
+function reference_aggregation(points, bounds, resolution, op)
+    (xmin, ymin), (xmax, ymax) = extrema(bounds)
+    xscale = resolution[1] / ((xmax - xmin) + eps(xmax - xmin))
+    yscale = resolution[2] / ((ymax - ymin) + eps(ymax - ymin))
+    out = fill(null(op), resolution)
+    for p in points
+        x, y = p[1], p[2]
+        (xmin <= x <= xmax && ymin <= y <= ymax) || continue
+        i = min(resolution[1], 1 + floor(Int, xscale * (x - xmin)))
+        j = min(resolution[2], 1 + floor(Int, yscale * (y - ymin)))
+        out[i, j] = length(p) == 2 ? update(op, out[i, j]) : update(op, out[i, j], p[3])
+    end
+    return value.(Ref(op), out)
+end
+
+@testset "aggregation" begin
+    bounds = Rect2(-3.0, -3.0, 6.0, 6.0)
+    resolution = (133, 77)
+
+    @testset "$op" for (op, points) in [
+            AggCount{Float32}() => Point2f[(-1.2, 0.3), (-1.2, 0.3), (0.0, 0.0), (2.9, -2.9)],
+            AggCount{Int}() => Point2f[(-1.2, 0.3), (-1.2, 0.3), (0.0, 0.0)],
+            AggAny() => Point2f[(-1.2, 0.3), (2.0, 2.0)],
+            AggSum{Float64}() => Point3f[(-1.2, 0.3, 2.0), (-1.2, 0.3, 3.5), (1.0, 1.0, -1.0)],
+            AggMean{Float64}() => Point3f[(-1.2, 0.3, 2.0), (-1.2, 0.3, 3.0), (1.0, 1.0, -1.0)],
+        ]
+        seeded = copy(points)
+        if eltype(points) <: Point2
+            append!(seeded, [Point2f(5 * randn(), 5 * randn()) for _ in 1:10_000])
+        else
+            append!(seeded, [Point3f(5 * randn(), 5 * randn(), rand()) for _ in 1:10_000])
+        end
+        expected = reference_aggregation(seeded, bounds, resolution, op)
+        for method in (AggSerial(), AggThreads())
+            canvas = Canvas(bounds; resolution = resolution, op = op)
+            aggregate!(canvas, seeded; method = method)
+            result = reshape(canvas.pixelbuffer, resolution)
+            @test all(splat((a, b) -> a == b || (isnan(a) && isnan(b))), zip(result, expected))
+            finite = filter(isfinite, vec(expected))
+            @test canvas.data_extrema == (minimum(finite), maximum(finite))
+        end
+    end
+
+    @testset "bin_scale maps the widest offset into the last bin" begin
+        for (size, width) in [(133, 6.0), (800, 6.0), (1, 1.0), (999, 3.7), (2048, 1.0e-6)]
+            scale = bin_scale(size, width)
+            @test scale * width < size
+            @test 1 + unsafe_trunc(Int, scale * width) == size
+        end
+        @test bin_scale(800, 0.0) == 0.0
+    end
+
+    @testset "zero width bounds put everything in the first bin" begin
+        for method in (AggSerial(), AggThreads())
+            canvas = Canvas(Rect2(1.0, 1.0, 0.0, 0.0); resolution = (4, 4), op = AggCount{Int}())
+            aggregate!(canvas, [Point2f(1, 1), Point2f(1, 1)]; method = method)
+            @test reshape(canvas.pixelbuffer, (4, 4))[1, 1] == 2
+            @test sum(canvas.pixelbuffer) == 2
+        end
+    end
+
+    @testset "points at the max bounds land in the last bin" begin
+        for method in (AggSerial(), AggThreads())
+            canvas = Canvas(bounds; resolution = resolution, op = AggCount{Int}())
+            aggregate!(canvas, [Point2f(3, 3), Point2f(-3, -3)]; method = method)
+            result = reshape(canvas.pixelbuffer, resolution)
+            @test result[end, end] == 1
+            @test result[1, 1] == 1
+        end
+    end
+
+    @testset "NaN and out-of-bounds points are skipped" begin
+        for method in (AggSerial(), AggThreads())
+            canvas = Canvas(bounds; resolution = resolution, op = AggCount{Int}())
+            aggregate!(canvas, [Point2f(NaN), Point2f(4, 0), Point2f(0, -4), Point2f(0, 0)]; method = method)
+            @test sum(canvas.pixelbuffer) == 1
+        end
+    end
+
+    @testset "empty input" begin
+        for method in (AggSerial(), AggThreads())
+            canvas = Canvas(bounds; resolution = resolution, op = AggCount{Int}())
+            aggregate!(canvas, Point2f[]; method = method)
+            @test all(==(0), canvas.pixelbuffer)
+        end
+    end
+
+    @testset "point_transform" begin
+        points = [Point2f(0.5, -1.5), Point2f(2.0, 1.0)]
+        expected = reference_aggregation(map(reverse, points), bounds, resolution, AggCount{Int}())
+        for method in (AggSerial(), AggThreads())
+            canvas = Canvas(bounds; resolution = resolution, op = AggCount{Int}())
+            aggregate!(canvas, points; method = method, point_transform = reverse)
+            @test reshape(canvas.pixelbuffer, resolution) == expected
+        end
+    end
+end

--- a/Makie/test/runtests.jl
+++ b/Makie/test/runtests.jl
@@ -48,6 +48,7 @@ end
         include("plots/contourf.jl")
         include("plots/tricontour.jl")
         include("plots/voronoiplot.jl")
+        include("plots/datashader.jl")
     end
 
     @testset "Scenes, Blocks & Figures" begin


### PR DESCRIPTION
This PR improves `datashader` performance.


<details>
<summary>
Benchmark, 100M points on a 1000x800 canvas with 10 threads, where one update is `aggregate!` plus `get_aggregation`, i.e. what a zoom or pan does:
</summary>

```julia
using Makie
import Makie.Aggregation: AggCount, AggThreads, AggSerial, Canvas, aggregate!, get_aggregation
using Statistics, Printf

points = [Point2f(randn(), randn()) for _ in 1:100_000_000]
canvas = Canvas(Rect2(-3.0, -3.0, 6.0, 6.0); resolution = (1000, 800), op = AggCount{Float32}())

function report(canvas, points, method, updates)
    update!() = (aggregate!(canvas, points; method); get_aggregation(canvas; operation = Makie.automatic))
    for _ in 1:5; update!(); end
    GC.gc(true)
    gc_before, alloc_before = Base.gc_num(), Base.gc_bytes()
    times = [1000 * @elapsed update!() for _ in 1:updates]
    gc_after, alloc_after = Base.gc_num(), Base.gc_bytes()
    @printf("min %.1f  median %.1f  p99 %.1f  max %.1f ms | %.1f KiB/update | gc %.1f ms in %d collections\n",
        minimum(times), median(times), quantile(times, 0.99), maximum(times),
        (alloc_after - alloc_before) / updates / 2^10,
        (gc_after.total_time - gc_before.total_time) / 1e6, gc_after.pause - gc_before.pause)
end

report(canvas, points, AggThreads(), 1000)
report(canvas, points, AggSerial(), 100)
```

</details>

```
# master
AggThreads, 1000 updates   min  40.9  median  47.1  p99  58.0  max  90.8 ms | 9405.3 KiB/update | gc 81.7 ms in 179 collections
AggSerial,   100 updates   min 209.2  median 214.7  p99 218.8  max 219.4 ms | 9400.6 KiB/update | gc  4.2 ms in  15 collections

# this PR
AggThreads, 1000 updates   min  21.8  median  25.6  p99  30.2  max  32.2 ms |   10.7 KiB/update | gc  0.0 ms in   0 collections
AggSerial,   100 updates   min 121.3  median 124.3  p99 129.1  max 129.3 ms |    1.3 KiB/update | gc  0.0 ms in   0 collections
```

So a bit under 2x on the median, and it should reduce GC jitter due to fewer allocations.

Dump of more Claude info:

---

- Both aggregation methods now share one point loop with `@inbounds` and `unsafe_trunc` instead of `floor`. The bounds guard already makes the scaled offsets non-negative, and a new `bin_scale` picks a scaling factor for which the widest in-bounds offset stays strictly below the axis length, so no clamping is needed per point. The old code added an `eps` to the width for the same purpose, but an eps of the width is far too small to change how the product rounds: for a 6.0 wide range and 133 bins, `133/(6+eps(6))*6` is still exactly `133.0`.
- The threaded method reduces the per-thread buffers and finalizes the pixel buffer in parallel over pixel ranges. That was the largest serial section left, 691 to 154 us at 800x800.
- `equalize_histogram` no longer uses StatsBase, which takes an 800x800 buffer from 10.3 ms to 1.7 ms. StatsBase isn't at fault: `Histogram` supports non-uniform edges, either closed side and weights, so `fit!` does a range search per element where uniform bins only need a multiply. Of master's 11.9 ms, 2.2 ms is the `extrema` inside `histrange`, 4.9 ms is `fit` (3.1 ms of that in `searchsortedlast`) and 4.6 ms the final broadcast. Keeping StatsBase and only replacing the broadcast gains nothing; keeping it just for edge selection still lands at 5.7 ms.
- `get_aggregation` writes into a result buffer owned by the canvas, and the default operation runs through a new in-place `equalize_histogram!`. Returning the same array each time is fine for the compute graph, since `is_same` in ComputePipeline treats a value whose identity did not change as dirty.

Two bugs fixed along the way. Thread chunk ranges overlapped at their boundaries, so points on the seams were aggregated twice. Points exactly at the upper bound produced an index one past the end, which raised a `BoundsError` with `AggSerial` and silently wrote out of bounds with `AggThreads`; both now land in the last bin. Zero width bounds used to produce an infinite scale and a `NaN` index, and now put everything in the first bin.

Behavior changes worth noting: `equalize_histogram` passes `NaN` through instead of raising, so the default operation now also works with aggregations that produce `NaN` such as `AggMean` over empty bins, and constant input returns ones where it previously raised from `interpolated_getindex`. Equalized values can differ from master by around 0.01 because the bins now span the exact data range instead of StatsBase's rounded edges. Rendering was identical (0 differing pixels via PixelMatch) on the cases I checked, so I don't expect reference images to move, but CI will say for sure.

Since the hot loops now truncate without checking, I ran the equalizer over 16000 random inputs with `--check-bounds=yes` (Float32/Float64/Int32/Int64, ranges from 1e-20 to 1e20, values pinned at both extremes, NaN and +-Inf mixed in, `nbins` from 2 to 1000) to be sure no index escapes. Tests are in `Makie/test/plots/datashader.jl`, which previously had no coverage beyond reference images.
