### PR TITLE
Fix the unit selection

### DIFF
--- a/Makie/src/dim-converts/unitful-integration.jl
+++ b/Makie/src/dim-converts/unitful-integration.jl
@@ -8,7 +8,8 @@ expand_dimensions(::PointBased, y::AbstractVector{<:SupportedUnits}) = (keys(y),
 create_dim_conversion(::Type{<:SupportedUnits}) = UnitfulConversion()
 should_dim_convert(::Type{<:SupportedUnits}) = true
 
-const UNIT_POWER_OF_TENS = sort!(collect(keys(Unitful.prefixdict)))
+# deca and hecto are excluded because they are uncommon plot labels
+const COMMON_PREFIX_POWERS = Unitful.prefixdict |> keys |> collect |> filter(∉((1, 2))) |> sort!
 const TIME_UNIT_NAMES = [:yr, :wk, :d, :hr, :minute, :s, :ds, :cs, :ms, :μs, :ns, :ps, :fs, :as, :zs, :ys]
 
 base_unit(q::Quantity) = base_unit(typeof(q))
@@ -81,7 +82,7 @@ end
 get_all_base10_units(value) = get_all_base10_units(base_unit(value))
 
 function get_all_base10_units(value::Unitful.Unit{Sym, Unitful.𝐋}) where {Sym}
-    return Unitful.Unit{Sym, Unitful.𝐋}.(UNIT_POWER_OF_TENS, value.power)
+    return Unitful.Unit{Sym, Unitful.𝐋}.(COMMON_PREFIX_POWERS, value.power)
 end
 
 function get_all_base10_units(value::Unitful.Unit)
@@ -95,16 +96,20 @@ function get_all_base10_units(x::Unitful.Unit{Sym, Unitful.𝐓}) where {Sym}
 end
 
 function best_unit(min, max)
-    middle = (min + max) / 2.0
-    all_units = get_all_base10_units(middle)
-    _, index = findmin(all_units) do unit
-        raw_value = abs(unit_convert(unit, middle))
-        # We want the unit that displays the value with the smallest number possible, but not something like 1.0e-19
-        # So, for fractions between 0..1, we use inv to penalize really small fractions
-        positive = raw_value < 1.0 ? (inv(raw_value) + 100) : raw_value
-        return positive
-    end
-    return all_units[index]
+    # The unit is chosen from the largest magnitude the axis has to display. A midpoint
+    # would be useless here since it vanishes for a range symmetric around zero.
+    usable = filter(x -> isfinite(x) && !iszero(x), (min, max))
+    isempty(usable) && return base_unit(min)
+    reference = maximum(abs, usable)
+    all_units = get_all_base10_units(reference)
+    values = map(unit -> unit_convert(unit, reference), all_units)
+    # Pick the largest unit the reference fills at least twice, so that ticks below the
+    # maximum stay clear of fractions too. For data starting at zero this selects the same
+    # unit as the previous midpoint, which was just half the maximum. If the reference is
+    # below every unit, use the smallest one available.
+    big_enough = filter(>=(2), values)
+    target = isempty(big_enough) ? maximum(values) : minimum(big_enough)
+    return all_units[findfirst(==(target), values)]
 end
 
 best_unit(min::LogScaled, max) = Unitful.logunit(min)

--- a/Makie/test/conversions/dim-converts.jl
+++ b/Makie/test/conversions/dim-converts.jl
@@ -102,6 +102,34 @@ function test_cleanup(arg)
     return @test length(obs.listeners) == 0
 end
 
+@testset "best_unit" begin
+    meter(power) = Unitful.Unit{:Meter, Unitful.𝐋}(power, 1 // 1)
+
+    # the unit must only depend on the largest magnitude, not on the midpoint, which
+    # vanishes for a range symmetric around zero
+    for (mini, maxi) in [(-731.0u"m", 731.0u"m"), (-731.0u"m", 730.9u"m"), (-731.0u"m", -15.0u"m"), (15.0u"m", 731.0u"m")]
+        @test Makie.best_unit(mini, maxi) == meter(0)
+    end
+
+    # the largest unit that the maximum fills at least twice wins
+    @test Makie.best_unit(0.0u"m", 1500.0u"m") == meter(0)
+    @test Makie.best_unit(0.0u"m", 1.0u"m") == meter(-1)
+    @test Makie.best_unit(0.0u"m", 0.05u"m") == meter(-2)
+    # filling it exactly twice is enough
+    @test Makie.best_unit(0.0u"m", 2.0u"m") == meter(0)
+    @test Makie.best_unit(0.0u"m", 1.99u"m") == meter(-1)
+    # below every unit the smallest one is the best available
+    @test Makie.best_unit(0.0u"m", 1.0e-30u"m") == meter(-24)
+
+    # limits without a usable magnitude are ignored, resorting to the base unit
+    @test Makie.best_unit(-731.0u"m", NaN * u"m") == meter(0)
+    @test Makie.best_unit(0.0u"m", 0.0u"m") == meter(0)
+    @test Makie.best_unit(-Inf * u"m", Inf * u"m") == meter(0)
+
+    # time units are not a base 10 ladder
+    @test Makie.best_unit(0.0u"s", 4599.8u"s") == u"minute"
+end
+
 @testset "clean up observables" begin
     @testset "UnitfulConversion" begin
         test_cleanup([0.01u"km", 0.02u"km", 0.03u"km", 0.04u"km"])


### PR DESCRIPTION
Current master selects the midpoint of the extrema. However, this is a rather dumb choice, especially when your data is symmetric around 0, leading to always getting the smallest possible unit (i.e. yottameter when your data is from -1 lightyear to +1 lightyear).

Fix this by using the maximum absolute value. However, in quite some cases this would change existing axis labels, as the logic often did a division by two when calculating the midpoint. Fix this by taking this factor of 2 explicitly into account.

Also avoid using units like hectometer. Seriously, who wants to have their plots using hectometer automatically?

This might not be perfect, but it fixes some problems and does not seem to introduce major new problems.

## Type of change

Delete options that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
