### PR TITLE
Minor compute pipeline cleanup/improvements

### DIFF
--- a/CairoMakie/src/lines.jl
+++ b/CairoMakie/src/lines.jl
@@ -80,7 +80,7 @@ function add_projected_line_points!(attr)
     Makie.add_computation!(attr, Val(:uniform_clip_planes), :clip)
     inputs = [:clipspace_points, :computed_color, :uniform_linewidth, :is_lines_plot, :uniform_clip_planes, :resolution]
     outputs = [:clipped_points, :clipped_colors, :clipped_linewidths]
-    return register_computation!(attr, inputs, outputs) do (clip_points, colors, linewidths, is_lines_plot, clip_planes, res), _, _
+    return map!(attr, inputs, outputs) do clip_points, colors, linewidths, is_lines_plot, clip_planes, res
         return clip_line_points(clip_points, colors, linewidths, is_lines_plot, clip_planes, res)
     end
 end

--- a/CairoMakie/src/mesh.jl
+++ b/CairoMakie/src/mesh.jl
@@ -19,13 +19,11 @@ function cairo_project_to_screen(
         attr;
         input_name = :positions_transformed_f32c, yflip = true, output_type = Point2f
     )
-    Makie.register_computation!(
+    map!(
         attr,
-        [:projectionview, :resolution, :model_f32c, input_name], [:cairo_screen_pos]
-    ) do inputs, changed, cached
-
-        output = cairo_project_to_screen_impl(values(inputs)..., output_type, yflip)
-        return (output,)
+        [:projectionview, :resolution, :model_f32c, input_name], :cairo_screen_pos
+    ) do inputs...
+        return cairo_project_to_screen_impl(inputs..., output_type, yflip)
     end
 
     return attr[:cairo_screen_pos][]

--- a/CairoMakie/src/utils.jl
+++ b/CairoMakie/src/utils.jl
@@ -1,6 +1,6 @@
 function extract_attributes!(attr::ComputeGraph, inputs::Vector{Symbol}, output::Symbol)
     # Make a namedtuple that holds all the attributes we need
-    return register_computation!(attr, inputs, [output]) do inputs, changed, outputs
+    return register_computation!(attr, inputs, [output]) do inputs, @nospecialize(changed), @nospecialize(outputs)
         return (inputs,)
     end
 end

--- a/GLMakie/src/plot-primitives.jl
+++ b/GLMakie/src/plot-primitives.jl
@@ -84,7 +84,7 @@ struct RenderObjectUpdater <: Function
     gl_names::Dict{Symbol, Symbol}
 end
 
-function (updater::RenderObjectUpdater)(args::NamedTuple, changed::NamedTuple, last)
+function (updater::RenderObjectUpdater)(args::NamedTuple, changed::NamedTuple, @nospecialize(last))
     update_robjs!(updater.robj, args, changed, updater.gl_names)
     updater.screen.requires_update = true
     return (updater.robj,)

--- a/GLMakie/src/plot-primitives.jl
+++ b/GLMakie/src/plot-primitives.jl
@@ -376,14 +376,10 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Scatter)
             return depthsort!(pos, depth_vals, indices, pvm)
         end
     else
-        register_computation!(attr, [:positions_transformed_f32c], [:gl_indices]) do (ps,), changed, last
-            return (length(ps),)
-        end
+        map!(length, attr, :positions_transformed_f32c, :gl_indices)
     end
 
-    register_computation!(attr, [:positions_transformed_f32c], [:gl_len]) do (ps,), changed, last
-        return (Int32(length(ps)),)
-    end
+    map!(ps -> Int32(length(ps)), attr, :positions_transformed_f32c, :gl_len)
 
     inputs = [
         # Special
@@ -392,15 +388,13 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Scatter)
         :sdf_marker_shape,
     ]
     if attr[:marker][] isa FastPixel
-        register_computation!(attr, [:markerspace], [:gl_markerspace]) do (space,), changed, last
-            space == :pixel && return (Int32(0),)
-            space == :data  && return (Int32(1),)
+        map!(attr, :markerspace, :gl_markerspace) do space
+            space == :pixel && return Int32(0)
+            space == :data  && return Int32(1)
             return error("Unsupported markerspace for FastPixel marker: $space")
         end
 
-        register_computation!(attr, [:marker], [:sdf_marker_shape]) do (marker,), changed, last
-            return (marker.marker_type,)
-        end
+        map!(marker -> marker.marker_type, attr, :marker, :sdf_marker_shape)
 
         uniforms = [
             :positions_transformed_f32c,
@@ -481,14 +475,10 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Text)
             return depthsort!(pos, depth_vals, indices, pvm)
         end
     else
-        register_computation!(attr, [:per_char_positions_transformed_f32c], [:gl_indices]) do (ps,), changed, last
-            return (length(ps),)
-        end
+        map!(length, attr, :per_char_positions_transformed_f32c, :gl_indices)
     end
 
-    register_computation!(attr, [:per_char_positions_transformed_f32c], [:gl_len]) do (ps,), changed, last
-        return (Int32(length(ps)),)
-    end
+    map!(ps -> Int32(length(ps)), attr, :per_char_positions_transformed_f32c, :gl_len)
 
     Makie.add_computation!(attr, scene, Val(:meshscatter_f32c_scale))
 
@@ -567,8 +557,8 @@ function draw_atomic(screen::Screen, scene::Scene, plot::MeshScatter)
     Makie.register_world_normalmatrix!(attr)
     Makie.register_view_normalmatrix!(attr)
 
-    register_computation!(attr, [:positions_transformed_f32c], [:instances, :gl_len]) do (pos,), changed, cached
-        return (length(pos), Int32(length(pos)))
+    map!(attr, :positions_transformed_f32c, [:instances, :gl_len]) do pos
+        return length(pos), Int32(length(pos))
     end
 
     inputs = [
@@ -749,17 +739,12 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Lines)
         map!(pos -> collect(Float32.(eachindex(pos))), attr, positions, :gl_last_length)
     else
         positions = :gl_projected_positions
-        register_computation!(attr, [positions, :resolution], [:gl_last_length]) do (pos, res), changed, cached
-            return (sumlengths(pos, res),)
-        end
+        map!(sumlengths, attr, [positions, :resolution], :gl_last_length)
     end
 
     # Derived vertex attributes
     register_computation!(generate_indices, attr, [positions], [:gl_indices, :gl_valid_vertex])
-    register_computation!(attr, [:gl_indices], [:gl_total_length]) do (indices,), changed, cached
-        return (Int32(length(indices) - 2),)
-    end
-
+    map!(indices -> Int32(length(indices) - 2), attr, :gl_indices, :gl_total_length)
 
     inputs = [
         # relevant to creation time decisions
@@ -823,9 +808,7 @@ function draw_atomic(screen::Screen, scene::Scene, plot::LineSegments)
     # costs ~1µs per clip plane
     Makie.add_computation!(attr, Val(:uniform_clip_planes), :clip)
 
-    register_computation!(attr, [:positions_transformed_f32c], [:indices]) do (positions,), changed, cached
-        return (length(positions),)
-    end
+    map!(length, attr, :positions_transformed_f32c, :indices)
 
     inputs = [
         :space,
@@ -959,8 +942,8 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Heatmap)
 
     Makie.add_computation!(attr, scene, Val(:heatmap_transform))
 
-    register_computation!(attr, [:x_transformed_f32c, :y_transformed_f32c], [:instances]) do (x, y), changed, cached
-        return ((length(x) - 1) * (length(y) - 1),)
+    map!(attr, [:x_transformed_f32c, :y_transformed_f32c], :instances) do x, y
+        return (length(x) - 1) * (length(y) - 1)
     end
 
     inputs = [
@@ -1014,9 +997,7 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Surface)
     Makie.register_view_normalmatrix!(attr)
     Makie.add_computation!(attr, scene, Val(:pattern_uv_transform))
 
-    register_computation!(attr, [:z], [:instances]) do (z,), changed, cached
-        return ((size(z, 1) - 1) * (size(z, 2) - 1),)
-    end
+    map!(z -> (size(z, 1) - 1) * (size(z, 2) - 1), attr, :z, :instances)
 
     inputs = [
         # Special
@@ -1167,9 +1148,9 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Voxels)
 
     Makie.register_world_normalmatrix!(attr, :voxel_model)
 
-    register_computation!(attr, [:chunk_u8, :gap], [:instances]) do (chunk, gap), changed, cached
+    map!(attr, [:chunk_u8, :gap], :instances) do chunk, gap
         N = sum(size(chunk))
-        return (ifelse(gap > 0.01, 2 * N, N + 3),)
+        return ifelse(gap > 0.01, 2 * N, N + 3)
     end
 
     Makie.add_computation!(attr, scene, Val(:voxel_uv_transform))
@@ -1229,9 +1210,7 @@ function draw_atomic(screen::Screen, scene::Scene, plot::Volume)
     Makie.add_computation!(attr, Val(:uniform_clip_planes), :model, :uniform_model)
 
     # TODO: reuse in clip planes
-    register_computation!(attr, [:uniform_model], [:modelinv]) do (model,), changed, cached
-        return (Mat4f(inv(model)),)
-    end
+    map!(model -> Mat4f(inv(model)), attr, :uniform_model, :modelinv)
 
     inputs = [
         # Special

--- a/Makie/src/backend-functionality.jl
+++ b/Makie/src/backend-functionality.jl
@@ -340,7 +340,9 @@ function add_computation!(attr, ::Val{:uniform_clip_planes}, target_space::Symbo
     target_space == :model && push!(inputs, modelname)
     target_space == :clip && push!(inputs, :projectionview)
 
-    register_computation!(attr, inputs, [:uniform_clip_planes, :uniform_num_clip_planes]) do input, changed, last
+    register_computation!(
+        attr, inputs, [:uniform_clip_planes, :uniform_num_clip_planes]
+    ) do input, @nospecialize(changed), @nospecialize(last)
         # TODO
         # If we want to remove allocations
         # we need to check what has changed manually, since is_same(input, last) will always return false

--- a/Makie/src/basic_recipes/datashader.jl
+++ b/Makie/src/basic_recipes/datashader.jl
@@ -399,18 +399,22 @@ function Makie.plot!(p::DataShader{<:Tuple{<:AbstractVector{<:Point}}})
     add_input!(p.attributes, :pixel_area, scene.viewport)
     canvas_computation!(p)
 
-    register_computation!(p, [:points, :point_transform], [:data_limits]) do (points, f), _, _
-        return (fast_bb(points, f),)
+    map!(p, [:points, :point_transform], :data_limits) do points, f
+        return fast_bb(points, f)
     end
 
-    register_computation!(p, [:canvas, :points, :point_transform, :method, :colorrange], [:canvas_with_aggregation, :raw_colorrange]) do (canvas, points, f, method, crange), changed, _
+    map!(
+        p,
+        [:canvas, :points, :point_transform, :method, :colorrange],
+        [:canvas_with_aggregation, :raw_colorrange]
+    ) do canvas, points, f, method, crange
         Aggregation.aggregate!(canvas, points; point_transform = f, method = method)
         if crange isa Automatic
             cr = Vec2f(distinct_extrema_nan(canvas.data_extrema))
         else
             cr = Vec2f(crange)
         end
-        return (canvas, cr)
+        return canvas, cr
     end
     image!(
         p, p.canvas_with_aggregation, p.operation, p.local_operation;
@@ -449,9 +453,9 @@ function Makie.plot!(p::DataShader{<:Tuple{Dict{String, Vector{Point{2, Float32}
     add_axis_limits!(p)
     add_input!(p.attributes, :pixel_area, scene.viewport)
     canvas_computation!(p)
-    register_computation!(p, [:points, :point_transform], [:data_limits]) do (categories, f), _, _
+    map!(p, [:points, :point_transform], :data_limits) do categories, f
         rects = map(points -> fast_bb(points, f), values(categories))
-        return (reduce(union, rects),)
+        return reduce(union, rects)
     end
     categories = p.points[]
     canvas = p.canvas[]
@@ -460,14 +464,14 @@ function Makie.plot!(p::DataShader{<:Tuple{Dict{String, Vector{Point{2, Float32}
             for (k, v) in categories
     )
 
-    register_computation!(p, [:canvas, :points], [:canvas_with_aggregation, :total_value]) do (canvas, cats), _, _
+    map!(p, [:canvas, :points], [:canvas_with_aggregation, :total_value]) do canvas, cats
         for (k, c) in canvases
             Base.resize!(c, canvas.resolution)
             c.bounds = canvas.bounds
         end
         aggregate_categories!(canvases, cats; method = p.method[])
         total_value = Float32(maximum(sum(map(x -> x.pixelbuffer, values(canvases)))))
-        return (canvases, total_value)
+        return canvases, total_value
     end
     colors = Dict(k => Makie.wong_colors()[i] for (i, (k, v)) in enumerate(categories))
     p._categories = colors

--- a/Makie/src/basic_recipes/error_and_rangebars.jl
+++ b/Makie/src/basic_recipes/error_and_rangebars.jl
@@ -254,7 +254,7 @@ function _plot_bars!(plot)
         if widths isa Vec2f
             return widths, isvisible
         end
-        [widths[i] for i in 1:length(widths) for j in 1:2], isvisible
+        return [widths[i] for i in 1:length(widths) for j in 1:2], isvisible
     end
 
     map!(attr, [:color], :whiskercolors) do color

--- a/Makie/src/basic_recipes/stem.jl
+++ b/Makie/src/basic_recipes/stem.jl
@@ -74,7 +74,7 @@ trunkpoint(stempoint::P, offset::Point3) where {P <: Point3} = P(offset...)
 function plot!(s::Stem{<:Tuple{<:AbstractVector{<:Point}}})
 
     map!(s, [:converted_1, :offset], :stemtuples) do ps, to
-        tuple.(trunkpoint.(ps, to), ps)
+        return tuple.(trunkpoint.(ps, to), ps)
     end
 
     map!(s, [:stemtuples], :trunkpoints) do st

--- a/Makie/src/basic_recipes/tooltip.jl
+++ b/Makie/src/basic_recipes/tooltip.jl
@@ -186,7 +186,7 @@ end
 function plot!(p::Tooltip)
 
     map!(p, [:maybe_text, :text], :extracted_text) do arg, text
-        return isnothing(arg) ? text : arg
+        return something(arg, text)
     end
 
     map!(ToolTipShape, p, [:placement, :align, :triangle_size], :shape)

--- a/Makie/src/basic_recipes/tricontour.jl
+++ b/Makie/src/basic_recipes/tricontour.jl
@@ -124,7 +124,7 @@ function plot!(c::Tricontour{<:Tuple{<:DelTri.Triangulation, <:AbstractVector{<:
     end
 
     map!(c, [:color, :line_colors], :final_color) do col, lc
-        return isnothing(col) ? lc : col
+        return something(col, lc)
     end
 
     lines!(

--- a/Makie/src/basic_recipes/voxels.jl
+++ b/Makie/src/basic_recipes/voxels.jl
@@ -122,7 +122,7 @@ function register_voxel_colormapping!(attr)
             return cm
         end
     else
-        register_computation!(attr, [:color, :alpha], [:voxel_color]) do (color, alpha), changed, cached
+        map!(attr, [:color, :alpha], :voxel_color) do color, alpha
             if color isa AbstractVector # one color per id
                 output = Vector{RGBAf}(undef, 255)
                 @inbounds for i in 1:min(255, length(color))
@@ -131,14 +131,14 @@ function register_voxel_colormapping!(attr)
                 for i in (min(255, length(color)) + 1):255
                     output[i] = RGBAf(0, 0, 0, 0)
                 end
-                return (output,)
+                return output
             elseif color isa AbstractArray # image/texture
                 output = add_alpha.(to_color.(color), alpha)
-                return (output,)
+                return output
             elseif color isa Colorant # static
                 c = add_alpha(to_color(color), alpha)
                 output = [c for _ in 1:255]
-                return (output,)
+                return output
             else
                 error("Invalid color type $(typeof(color))")
             end

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -347,7 +347,7 @@ function register_positions_transformed_f32c!(
 
     register_computation!(
         attr, [input_name, :model, :f32c, :space], [output_name]
-    ) do (positions, model, f32c, space), changed, last
+    ) do (positions, model, f32c, space), changed, @nospecialize(last)
 
         trans, scale = decompose_translation_scale_matrix(model)
         # is_rot_free = is_translation_scale_matrix(model)
@@ -452,7 +452,7 @@ function add_convert_kwargs!(graph, user_kw, P, args)
             push!(conv_attr_input, key)
         end
     end
-    register_computation!(graph, conv_attr_input, [:convert_kwargs]) do inputs, changed, last
+    register_computation!(graph, conv_attr_input, [:convert_kwargs]) do inputs, @nospecialize(changed), @nospecialize(last)
         return (_filter(!isnothing, inputs),)
     end
     ComputePipeline.set_type!(graph[:convert_kwargs], Any)

--- a/Makie/src/makielayout/blocks/axis.jl
+++ b/Makie/src/makielayout/blocks/axis.jl
@@ -586,7 +586,7 @@ function initialize_limit_computations!(ax)
         attr,
         [:limits, :_limit_update_rule, :transform_func, :inverse_transform_func, :xautolimitmargin, :yautolimitmargin],
         [:localxlimits, :localylimits],
-    ) do (limits, rule, tf, itf, xmargins, ymargins), changed, cached
+    ) do (limits, rule, tf, itf, xmargins, ymargins), changed, @nospecialize(cached)
         lims = calculate_local_limits(ax, limits, tf, itf, xmargins, ymargins)
         if changed._limit_update_rule
             # The update comes from (x/y)lims!() which explicitly set update rules

--- a/Makie/test/SceneLike/figures.jl
+++ b/Makie/test/SceneLike/figures.jl
@@ -251,5 +251,5 @@ end
     fig = Figure()
     io = IOBuffer()
     # if there were no show method with backend and update kwargs then MethodError would be thrown instead
-    @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend = missing, update = false)
+    @test_throws FieldError show(io, MIME"text/plain"(), fig, backend = missing, update = false)
 end

--- a/Makie/test/SceneLike/figures.jl
+++ b/Makie/test/SceneLike/figures.jl
@@ -251,5 +251,9 @@ end
     fig = Figure()
     io = IOBuffer()
     # if there were no show method with backend and update kwargs then MethodError would be thrown instead
-    @test_throws FieldError show(io, MIME"text/plain"(), fig, backend = missing, update = false)
+    if VERSION >= v"1.12"
+        @test_throws FieldError show(io, MIME"text/plain"(), fig, backend = missing, update = false)
+    else
+        @test_throws ErrorException show(io, MIME"text/plain"(), fig, backend = missing, update = false)
+    end
 end

--- a/Makie/test/specapi.jl
+++ b/Makie/test/specapi.jl
@@ -10,7 +10,7 @@ end
 # Track the changes from the backends view (we prune updates that don't actually change anything)
 function all_changes!(plot)
     all_outputs = collect(keys(plot.attributes.outputs))
-    return register_computation!(plot.attributes, all_outputs, [:changed]) do attr, changeset, _
+    return register_computation!(plot.attributes, all_outputs, [:changed]) do attr, changeset, @nospecialize(_)
         res = Dict{Symbol, Any}()
         for k in keys(attr)
             changeset[k] && (res[k] = attr[k])

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -57,13 +57,19 @@ function backend_colors!(attr, color_name = :scaled_color)
         return color isa AbstractVector ? color : false
     end
 
-    return register_computation!(attr, [:alpha_colormap, :scaled_colorrange, :color_mapping_type], [:uniform_colormap, :uniform_colorrange]) do (cmap, crange, ctype), changed, last
+    register_computation!(
+        attr,
+        [:alpha_colormap, :scaled_colorrange, :color_mapping_type],
+        [:uniform_colormap, :uniform_colorrange]
+    ) do (cmap, crange, ctype), changed, @nospecialize(last)
         isnothing(crange) && return (false, false)
         cmap_minfilter = ctype === Makie.continuous ? :linear : :nearest
         cmap_changed = changed.alpha_colormap || changed.color_mapping_type
         cmap_s = cmap_changed ? Sampler(cmap, minfilter = cmap_minfilter) : nothing
         return (cmap_s, Vec2f(crange))
     end
+
+    return
 end
 
 function handle_color!(data, attr)

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -37,18 +37,18 @@ function backend_colors!(attr, color_name = :scaled_color)
     if !haskey(attr, :interpolate)
         Makie.add_input!(attr, :interpolate, false)
     end
-    register_computation!(attr, [color_name, :interpolate, :fetch_pixel], [:uniform_color, :pattern]) do (color, interpolate, is_pattern), changed, last
+    map!(attr, [color_name, :interpolate, :fetch_pixel], [:uniform_color, :pattern]) do color, interpolate, is_pattern
         filter = interpolate ? :linear : :nearest
         if color isa Sampler
-            return (color, is_pattern)
+            return color, is_pattern
         elseif color isa AbstractMatrix || color isa AbstractArray{<:Any, 3}
             # TODO, don't construct a sampler every time
-            return (Sampler(color, minfilter = filter), false)
+            return Sampler(color, minfilter = filter), false
         elseif color isa Union{Real, Colorant}
-            return (color, false)
+            return color, false
         else
             # Not a uniform color
-            return (false, false)
+            return false, false
         end
     end
 
@@ -259,11 +259,11 @@ function create_shader(scene::Scene, plot::Scatter)
         markersym = :fast_pixel_marker
     end
     Makie.all_marker_computations!(attr, markersym)
-    register_computation!(attr, [:sdf_marker_shape, :marker, :font], [:glyph_data]) do (shape, markers, fonts), changed, last
+    map!(attr, [:sdf_marker_shape, :marker, :font], :glyph_data) do shape, markers, fonts
         shape != 3 && return nothing
         data = get_scatter_data(scene, markers, fonts)
         dict = Dict(:atlas_updates => data)
-        return (dict,)
+        return dict
     end
 
     map!(attr, [:marker, :scaled_color], :scatter_color) do marker, color
@@ -337,15 +337,16 @@ function register_text_computation!(attr, scene)
     map!(attr, [:text_blocks, :text_scales], :glyph_scales) do text_blocks, fontsize
         return Makie.map_per_glyph(text_blocks, Vec2f, Makie.to_2d_scale(fontsize))
     end
-    return register_computation!(attr, [:glyphindices, :font_per_char, :glyph_scales], [:glyph_data]) do (glyphs, fonts, glyph_scales), changed, last
+    map!(attr, [:glyphindices, :font_per_char, :glyph_scales], :glyph_data) do glyphs, fonts, glyph_scales
         hashes, updates = get_glyph_data(scene, glyphs, fonts)
         dict = Dict(
             :glyph_hashes => hashes,
             :atlas_updates => updates,
             :scales => serialize_three(glyph_scales)
         )
-        return (dict,)
+        return dict
     end
+    return
 end
 
 function create_shader(scene::Scene, plot::Makie.Text)
@@ -664,9 +665,7 @@ function create_shader(scene::Scene, plot::Volume)
     Makie.add_computation!(attr, Val(:uniform_clip_planes), :model, :uniform_model)
 
     # TODO: reuse in clip planes
-    register_computation!(attr, [:uniform_model], [:modelinv]) do (model,), changed, cached
-        return (Mat4f(inv(model)),)
-    end
+    map!(model -> Mat4f(inv(model)), attr, :uniform_model, :modelinv)
     backend_colors!(attr)
     inputs = [
         # Special

--- a/WGLMakie/src/voxel.jl
+++ b/WGLMakie/src/voxel.jl
@@ -37,17 +37,17 @@ function create_shader(scene::Scene, plot::Voxels)
         end
     elseif haskey(attr, :voxel_color)
         Makie.add_computation!(attr, scene, Val(:voxel_uv_transform))
-        register_computation!(
-            attr, [:voxel_color, :packed_uv_transform, :interpolate],
+        map!(
+            attr,
+            [:voxel_color, :packed_uv_transform, :interpolate],
             [:wgl_colormap, :wgl_uv_transform, :wgl_color]
-        ) do inputs, changed, cached
+        ) do color, uvt, interpolate
             # how interpolate?
-            color, uvt, interpolate = inputs
             filter = ifelse(interpolate, :linear, :nearest)
             if isnothing(uvt)
-                return (false, false, Sampler(color, minfilter = filter)) # color vector
+                return false, false, Sampler(color, minfilter = filter) # color vector
             else
-                return (false, Sampler(uvt, minfilter = :nearest), Sampler(color, minfilter = filter)) # texture map
+                return false, Sampler(uvt, minfilter = :nearest), Sampler(color, minfilter = filter) # texture map
             end
         end
     else

--- a/metrics/ttfp/run-benchmark.jl
+++ b/metrics/ttfp/run-benchmark.jl
@@ -12,8 +12,7 @@ using JSON, AlgebraOfGraphics, CairoMakie, DataFrames, Bootstrap
 using Statistics: median
 Package = length(ARGS) > 0 ? ARGS[1] : "CairoMakie"
 n_samples = length(ARGS) > 1 ? parse(Int, ARGS[2]) : 7
-# base_branch = length(ARGS) > 2 ? ARGS[3] : "master"
-base_branch = "master"
+base_branch = length(ARGS) > 2 ? ARGS[3] : "master"
 
 # Package = "CairoMakie"
 # n_samples = 2


### PR DESCRIPTION
# Description

Just replaces some `register_computation!` calls to `map!` calls (which are generally a bit faster because they avoid extra method compilation via `@nospecialize`), adds some `@nospecialize` annotation to `register_computation!` callbacks where it's appropriate and does some minor code clean ups here and there

## Type of change

- minor performance improvements & code cleanup
