### PR TITLE
Resampling Interface

### DIFF
--- a/ComputePipeline/src/ComputePipeline.jl
+++ b/ComputePipeline/src/ComputePipeline.jl
@@ -1269,10 +1269,10 @@ function _delete!(attr::ComputeGraph, edge::AbstractEdge, force::Bool, recursive
     return unsafe_delete!(attr, edge)
 end
 
-function unsafe_delete!(attr::ComputeGraph, edge::ComputeEdge)
+function unsafe_delete!(graph::ComputeGraph, edge::ComputeEdge)
     # all dependents become invalid as their parent computation no longer runs
     for dependent in edge.dependents
-        unsafe_delete!(attr, dependent)
+        unsafe_delete!(graph, dependent)
     end
 
     # deregister this edge as a dependency of its parents
@@ -1285,11 +1285,11 @@ function unsafe_delete!(attr::ComputeGraph, edge::ComputeEdge)
     # Delete output nodes of this edge
     for computed in edge.outputs
         k = computed.name
-        @assert haskey(attr.outputs, k) && attr.outputs[k] === computed
-        delete!(attr.outputs, k)
+        @assert haskey(graph.outputs, k) && graph.outputs[k] === computed
+        delete!(graph.outputs, k)
     end
 
-    return attr
+    return graph
 end
 
 function unsafe_delete!(attr::ComputeGraph, edge::Input)
@@ -1409,6 +1409,7 @@ function TypedEdge_no_call(edge::ComputeEdge)
 end
 
 include("io.jl")
+include("modification.jl")
 
 export Computed, ComputeEdge
 export ComputeGraph

--- a/ComputePipeline/src/modification.jl
+++ b/ComputePipeline/src/modification.jl
@@ -1,0 +1,229 @@
+invalid_callback(args...) = error("The output node related to this callback is invalid and cannot not be resolved.")
+
+"""
+    modify_edge!(edge::ComputeEdge[; callback, inputs, outputs])
+
+Modifies an existing compute edge.
+
+## Keyword Arguments
+
+`callback` can be given to replace the callback of the edge. If one or more
+outputs have already been initialized the new callback must produce matching
+types for those outputs. Note that for `map!` callbacks `packed` can be set to
+`true` to mark the callback as returning a value that needs to be packed into
+a tuple. Without this the callback is assumed to return a tuple.
+
+`inputs` can be given to replace the inputs of the edge. The new inputs must
+exist beforehand. This is generally safe to do assuming the callback can handle
+the new inputs.
+
+`outputs` can be given to replace the outputs of the edge. The new outputs must
+exist beforehand. For each new output that has already been initialized the edge
+must produce a value of matching type in its callback. Any old output that is
+orphaned by replacing the edge outputs is considered invalid and will error when
+resolved.
+"""
+function modify_edge!(edge::ComputeEdge; kwargs...)
+    graph = edge.graph::ComputeGraph
+
+    @lock graph.lock begin
+        if haskey(kwargs, :inputs)
+            if !all(name -> haskey(graph.outputs, name), kwargs[:inputs])
+                error("Some inputs in $(kwargs[:inputs]) do not exist")
+            end
+
+            # disconnect old input.parent.dependents -> edge connections
+            for old in edge.inputs
+                filter!(e -> e !== edge, old.parent.dependents)
+            end
+
+            # replace inputs
+            resize!(edge.inputs, length(kwargs[:inputs]))
+            map!(name -> graph[name], edge.inputs, kwargs[:inputs])
+            resize!(edge.inputs_dirty, length(kwargs[:inputs]))
+            fill!(edge.inputs_dirty, true)
+
+            # connect new inputs.parent.dependents -> edge connections
+            for new in edge.inputs
+                push!(new.parent.dependents, edge)
+            end
+        end
+
+        # Note: This is quite unsafe when orphaned outputs have computations depending
+        # on them. If those are pulled without the output being attached to something
+        # no reasonable result can be produced.
+        if haskey(kwargs, :outputs)
+            if !all(name -> haskey(graph.outputs, name), kwargs[:outputs])
+                error("Some outputs in $(kwargs[:outputs]) do not exist")
+            end
+
+            # disconnect all outputs
+            # to keep track of dependencies we create dummy edges
+            for node in edge.outputs
+                dependents = filter(dep -> node in dep.inputs, edge.dependents)
+                node.parent = ComputeEdge(
+                    graph, invalid_callback,
+                    Computed[], Bool[], [node],
+                    Ref(true), dependents, Ref{TypedEdge}()
+                )
+                node.parent_idx = 1
+            end
+
+            # replace and connect outputs
+            empty!(edge.dependents)
+            resize!(edge.outputs, length(kwargs[:outputs]))
+            for (i, name) in enumerate(kwargs[:outputs])
+                node = graph[name]
+                for dep in node.parent.dependents
+                    if !in(dep, edge.dependents)
+                        push!(edge.dependents, dep)
+                    end
+                end
+                node.parent = edge
+                node.parent_idx = i
+                edge.outputs[i] = node
+            end
+        end
+
+        if haskey(kwargs, :callback)
+            # TODO: How do we deal with invalid_callback?
+            # TODO: Or more generally decide between map-like and
+            # TODO: register_computation-like callback handling?
+            callback = kwargs[:callback]
+            if !isa(callback, MapFunctionWrapper) && (isa(edge.callback, MapFunctionWrapper) || haskey(kwargs, :packed))
+                callback = MapFunctionWrapper(callback, get(kwargs, :packed, false))
+            end
+
+            # Can't set callback, so need to replace edge
+            new_edge = ComputeEdge(
+                graph, callback,
+                edge.inputs, edge.inputs_dirty, edge.outputs,
+                Ref(false), edge.dependents, Ref{TypedEdge}()
+            )
+            for input in edge.inputs
+                replace!(input.parent.dependents, edge => new_edge)
+            end
+            foreach(output -> output.parent = new_edge, edge.outputs)
+
+            edge = new_edge
+        end
+
+        # If the edge has been initialized before we need to reinitialize it
+        mark_dirty!(edge)
+        if isassigned(edge.typed_edge)
+            # Note: This is a locked resolve that sets edge.typed_edge
+            foreach(_resolve!, edge.inputs)
+            edge.typed_edge[] = TypedEdge(edge)
+            edge.got_resolved[] = true
+            fill!(edge.inputs_dirty, false)
+            for dep in edge.dependents
+                mark_input_dirty!(edge, dep)
+            end
+            foreach(comp -> comp.dirty = false, edge.outputs)
+        end
+    end
+
+    return
+end
+
+"""
+    modify_edge!(edge::Input[; callback, output])
+
+Modifies an existing Input edge.
+
+## Keyword Arguments
+
+`callback` can be given to replace the callback of the edge. If one or more
+outputs have already been initialized the new callback must produce matching
+types for those outputs. Note that for `map!` callbacks `packed` can be set to
+`true` to mark the callback as returning a value that needs to be packed into
+a tuple. Without this the callback is assumed to return a tuple.
+
+`outputs` can be given to replace the outputs of the edge. The new outputs must
+exist beforehand. For each new output that has already been initialized the edge
+must produce a value of matching type in its callback. Any old output that is
+orphaned by replacing the edge outputs is considered invalid and will error when
+resolved.
+"""
+function modify_edge!(edge::Input; kwargs...)
+    graph = edge.graph::ComputeGraph
+
+    @lock graph.lock begin
+        # Note: This is quite unsafe when orphaned outputs have computations depending
+        # on them. If those are pulled without the output being attached to something
+        # no reasonable result can be produced.
+        if haskey(kwargs, :output)
+            name = kwargs[:output]
+            if !haskey(graph.outputs, name)
+                error("Node $name does not exist.")
+            end
+
+            # disconnect output
+            # to keep track of dependencies we create dummy edges
+            node = edge.output
+            node.parent = ComputeEdge(
+                graph, invalid_callback,
+                Computed[], Bool[], [node],
+                Ref(true), copy(node.parent.dependents), Ref{TypedEdge}()
+            )
+            node.parent_idx = 1
+
+            # replace and connect outputs
+            empty!(edge.dependents)
+            node = graph[name]
+            append!(edge.dependents, node.parent.dependents)
+            setfield!(edge, :output, node)
+            node.parent = edge
+            node.parent_idx = 1
+        end
+
+        if haskey(kwargs, :callback)
+            edge.callback = kwargs[:callback]
+        end
+
+        mark_dirty!(edge)
+    end
+
+    return
+end
+
+"""
+    add_orphaned_node!(graph, name)
+
+Creates a `Computed` node in the compute graph that is not connected to anything.
+Such a node can not be resolved but it can be used as input with the promise
+that it will later become an output via `modify_edge!`.
+"""
+function add_orphaned_node!(graph, name)
+    node = Computed(name)
+    node.parent = ComputeEdge(
+        graph, invalid_callback,
+        Computed[], Bool[], [node],
+        Ref(true), ComputeEdge{ComputeGraph}[], Ref{TypedEdge}()
+    )
+    node.parent_idx = 1
+    graph.outputs[name] = node
+    return node
+end
+
+function replace_output!(edge::ComputeEdge, replacements::Pair{Symbol, Symbol}...)
+    outputs = getproperty.(edge.outputs, :name)
+    for (old, new) in replacements
+        idx = findfirst(==(old), outputs)
+        if isnothing(idx)
+            new in outputs || error("Could not find $old in edge outputs $outputs.")
+        else
+            outputs[idx] = new
+        end
+    end
+    modify_edge!(edge; outputs)
+    return
+end
+
+function replace_output!(edge::Input, replacement::Pair{Symbol, Symbol})
+    if !in(edge.output.name, replacement)
+        error("Could not replace $(replacement[1]) as the given Input writes to $(edge.output.name).")
+    end
+    modify_edge!(edge; output = replacement[2])
+    return
+end

--- a/Makie/src/Makie.jl
+++ b/Makie/src/Makie.jl
@@ -207,6 +207,7 @@ include("themes/theme_latexfonts.jl")
 
 # layouting of plots
 include("layouting/transformation.jl")
+include("layouting/resampling.jl")
 include("layouting/data_limits.jl")
 include("layouting/text_layouting.jl")
 include("layouting/boundingbox.jl")

--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -35,6 +35,7 @@ function generic_plot_attributes!(attr)
     attr[:inspector_clear] = automatic
     attr[:inspector_hover] = automatic
     attr[:clip_planes] = automatic
+    attr[:resampler] = nothing
     return attr
 end
 
@@ -53,6 +54,7 @@ function generic_plot_attributes(attr)
         inspector_clear = attr[:inspector_clear],
         inspector_hover = attr[:inspector_hover],
         clip_planes = attr[:clip_planes],
+        resampler = attr[:resampler],
     )
 end
 
@@ -112,6 +114,10 @@ function mixin_generic_plot_attributes()
         parent plot or scene. You can remove parent `clip_planes` by passing `Plane3f[]`.
         """
         clip_planes = @inherit clip_planes automatic
+        """
+        TODO: docs
+        """
+        resampler = @inherit resampler nothing
     end
 end
 

--- a/Makie/src/basic_recipes/scatterlines.jl
+++ b/Makie/src/basic_recipes/scatterlines.jl
@@ -12,6 +12,7 @@ Plots `scatter` markers and `lines` between them.
             :fxaa, :visible, :transparency, :space, :clip_planes, :ssao, :overdraw,
             :cycle, :transformation, :model, :depth_shift,
             :inspector_clear, :inspector_hover, :inspector_label, :inspectable,
+            :resampler
         )
     )...
     "The color of the line, and by default also of the scatter markers."

--- a/Makie/src/basic_recipes/scatterlines.jl
+++ b/Makie/src/basic_recipes/scatterlines.jl
@@ -12,7 +12,7 @@ Plots `scatter` markers and `lines` between them.
             :fxaa, :visible, :transparency, :space, :clip_planes, :ssao, :overdraw,
             :cycle, :transformation, :model, :depth_shift,
             :inspector_clear, :inspector_hover, :inspector_label, :inspectable,
-            :resampler
+            :resampler,
         )
     )...
     "The color of the line, and by default also of the scatter markers."

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -865,6 +865,7 @@ function connect_plot!(parent::SceneLike, plot::Plot{Func}) where {Func}
 
     plot!(plot)
 
+    register_resampling!(plot)
 
     documented_attr = plot_attributes(scene, Plot{Func})
     for (k, v) in plot.kw

--- a/Makie/src/layouting/resampling.jl
+++ b/Makie/src/layouting/resampling.jl
@@ -1,0 +1,184 @@
+abstract type AbstractResampler end
+
+# TODO: fill out a reasonable set of default methods
+
+"""
+    mandatory_resampling_inputs(::Type{<:Plot}, ::AbstractResampler)
+
+Defines a minimal set of inputs required to resample the plot. These should be
+given as a `Vector{Symbol}` and typically just include `[:positions]`.
+"""
+mandatory_resampling_inputs(::Type{<:Plot}, ::AbstractResampler) = Symbol[]
+mandatory_resampling_inputs(::Type{<:Plot}, ::Nothing) = Symbol[]
+
+"""
+    resample(::Type{<:Plot}, ::AbstractResampler, transform_func, inputs...)
+
+This function processes the inputs defined in `mandatory_resampling_inputs`. It
+produces two things:
+1. A resampler that can be used to resample attributes.
+2. A resampled output for each input.
+"""
+resample(::Type{<:Plot}, ::AbstractResampler, transform_func, args...) = (nothing, args...)
+resample(::Type{<:Plot}, ::Nothing, transform_func) = (nothing, )
+
+# TODO: Might be preferable to give this the graph so it can check what attributes
+# are appropriately sized?
+# Or the Resampler can just save a length for `resample` to check
+"""
+    resampled_attributes(::Type{<:Plot}, ::AbstractResampler)
+
+Defines all attributes of a plot that resampling could apply to.
+"""
+resampled_attributes(::Type{<:Plot}, ::AbstractResampler) = Symbol[]
+resampled_attributes(::Type{<:Plot}, ::Nothing) = tuple()
+
+"""
+    resample(resampler, data[, ::Makie.key"attribute_name", ::Makie.key"plot_name"])
+
+Resamples `data` using a given `resampler`. May optionally contain an attribute
+name key and a plot name key for dispatch.
+"""
+resample(interp, data, attrib_key, plot_key) = resample(interp, data, attrib_key)
+resample(interp, data, attrib_key) = resample(interp, data)
+resample(interp, data) = data
+
+################################################################################
+
+# More or less an example...
+struct Resampler <: AbstractResampler end
+
+
+struct LinearResampler <: AbstractResampler
+    samples::Vector{Float64}
+    N::Int
+end
+
+mandatory_resampling_inputs(::Type{<:Scatter}, ::AbstractResampler) = [:positions]
+function resample(::Type{<:Plot}, ::Resampler, transform_func, positions)
+    steps = [i + di for i in eachindex(positions) for di in (0.0, 0.5)]
+    interp = LinearResampler(steps, length(positions))
+    new_pos = resample(interp, positions)
+    return interp, new_pos
+end
+
+
+resampled_attributes(::Type{<:Scatter}, ::AbstractResampler) = [:color, :markersize]
+resample(::LinearResampler, data) = data
+resample(::LinearResampler, data::VecTypes) = data
+
+# Other Resamplers could maybe hook into this as a default?
+function resample(interp::LinearResampler, data::AbstractVector)
+    N = length(data)
+    if N == interp.N
+        return map(interp.samples) do sample
+            i0 = clamp(floor(Int, sample), 1, N)
+            i1 = clamp(ceil(Int, sample), 1, N)
+            return lerp(data[i0], data[i1], sample - i0)
+        end
+    else
+        return data
+    end
+end
+
+################################################################################
+
+struct ResampleCallback{attr_key, plot_key} <: Function end
+function (::ResampleCallback{attr_key, plot_key})(interp, data) where {attr_key, plot_key}
+    return resample(interp, data, attr_key, plot_key)
+end
+
+function register_resampling!(plot::PlotType) where {PlotType}
+    graph = plot.attributes
+
+    # add_input!((k, v) -> Ref{Any}(v), graph, :resampler, Resampler())
+
+    map!(graph, [:resampler, :transform_func], [:interpolator]) do args...
+        return resample(PlotType, args...)
+    end
+
+    reset_info = Symbol[]
+    on(graph.resampler, update = true) do resampler
+        @lock graph.lock begin
+            # Step 1: Reset previously deferred nodes
+            for name in reset_info
+                deferred_name = Symbol(:deferred_, name)
+                parent = graph[deferred_name].parent
+                ComputePipeline.replace_output!(parent, deferred_name => name)
+            end
+            empty!(reset_info)
+
+            # Step 2: Build up the core resampling edge
+            update_resample_producer!(graph, PlotType, resampler, reset_info)
+
+            # Step 3: splice in resample edges for attributes
+            update_resampled_attributes!(graph, PlotType, resampler, reset_info)
+
+            return
+        end
+    end
+
+    return
+end
+
+function update_resample_producer!(graph, PlotType, resampler, reset_info)
+    outputs = mandatory_resampling_inputs(PlotType, resampler)
+    if !all(haskey.(Ref(graph), outputs))
+        failed = filter(name -> !haskey(graph, name), outputs)
+        error("Failed to get inputs $failed for $resampler in $PlotType. These nodes don't exist.")
+    end
+
+    # Gather/create deferred inputs
+    inputs = Symbol[:resampler, :transform_func]
+    for name in outputs
+        node = graph[name]
+        input = Symbol(:deferred_, name)
+        haskey(graph, input) || ComputePipeline.add_orphaned_node!(graph, input)
+        ComputePipeline.replace_output!(node.parent, name => input)
+        push!(inputs, input)
+    end
+
+    # Update core resampling edge
+    pushfirst!(outputs, :interpolator)
+    ComputePipeline.modify_edge!(graph.interpolator.parent; inputs, outputs)
+
+    append!(reset_info, outputs)
+
+    return
+end
+
+function update_resampled_attributes!(graph, PlotType, resampler, reset_info)
+    outputs = resampled_attributes(PlotType, resampler)
+    if !all(haskey.(Ref(graph), outputs))
+        failed = filter(name -> !haskey(graph, name), outputs)
+        error("Failed to get inputs $failed for $resampler in $PlotType. These nodes don't exist.")
+    end
+
+    # Gather/create deferred inputs
+    inputs = Symbol[]
+    for name in outputs
+        node = graph[name]
+        input = Symbol(:deferred_, name)
+        haskey(graph, input) || ComputePipeline.add_orphaned_node!(graph, input)
+        ComputePipeline.replace_output!(node.parent, name => input)
+        push!(inputs, input)
+    end
+
+    plot_key = Key{plotsym(PlotType)}()
+
+    for (input, output) in zip(inputs, outputs)
+        attr_key = Key{output}()
+        callback = ResampleCallback{attr_key, plot_key}()
+        ComputePipeline.modify_edge!(
+            graph[output].parent,
+            callback = callback,
+            inputs = [:interpolator, input],
+            outputs = [output],
+            packed = true
+        )
+    end
+
+    append!(reset_info, outputs)
+
+    return
+end

--- a/Makie/src/layouting/resampling.jl
+++ b/Makie/src/layouting/resampling.jl
@@ -46,7 +46,7 @@ resample(interp, data) = data
 ################################################################################
 
 # More or less an example...
-struct Resampler <: AbstractResampler end
+struct TestResampler <: AbstractResampler end
 
 
 struct LinearResampler <: AbstractResampler
@@ -55,7 +55,7 @@ struct LinearResampler <: AbstractResampler
 end
 
 mandatory_resampling_inputs(::Type{<:Scatter}, ::AbstractResampler) = [:positions]
-function resample(::Type{<:Plot}, ::Resampler, transform_func, positions)
+function resample(::Type{<:Plot}, ::TestResampler, transform_func, positions)
     steps = [i + di for i in eachindex(positions) for di in (0.0, 0.5)]
     interp = LinearResampler(steps, length(positions))
     new_pos = resample(interp, positions)
@@ -89,7 +89,7 @@ function register_resampling!(plot::PlotType) where {PlotType}
     graph = plot.attributes
 
     if !haskey(graph, :resampler)
-        add_input!((k, v) -> Ref{Any}(v), graph, :resampler, Resampler())
+        add_input!((k, v) -> Ref{Any}(v), graph, :resampler, TestResampler())
     end
 
     map!(graph, [:resampler, :transform_func], [:interpolator]) do args...

--- a/Makie/src/layouting/resampling.jl
+++ b/Makie/src/layouting/resampling.jl
@@ -20,7 +20,7 @@ produces two things:
 2. A resampled output for each input.
 """
 resample(::Type{<:Plot}, ::AbstractResampler, transform_func, args...) = (nothing, args...)
-resample(::Type{<:Plot}, ::Nothing, transform_func) = (nothing, )
+resample(::Type{<:Plot}, ::Nothing, transform_func) = (nothing,)
 
 # TODO: Might be preferable to give this the graph so it can check what attributes
 # are appropriately sized?
@@ -64,10 +64,7 @@ end
 
 
 resampled_attributes(::Type{<:Scatter}, ::AbstractResampler) = [:color, :markersize]
-resample(::LinearResampler, data) = data
-resample(::LinearResampler, data::VecTypes) = data
 
-# Other Resamplers could maybe hook into this as a default?
 function resample(interp::LinearResampler, data::AbstractVector)
     N = length(data)
     if N == interp.N
@@ -91,7 +88,9 @@ end
 function register_resampling!(plot::PlotType) where {PlotType}
     graph = plot.attributes
 
-    # add_input!((k, v) -> Ref{Any}(v), graph, :resampler, Resampler())
+    if !haskey(graph, :resampler)
+        add_input!((k, v) -> Ref{Any}(v), graph, :resampler, Resampler())
+    end
 
     map!(graph, [:resampler, :transform_func], [:interpolator]) do args...
         return resample(PlotType, args...)

--- a/Makie/src/theming.jl
+++ b/Makie/src/theming.jl
@@ -62,6 +62,7 @@ const MAKIE_DEFAULT_THEME = Attributes(
     patchstrokewidth = 0,
     size = (600, 450), # 4/3 aspect ratio
     visible = true,
+    resampler = nothing,
     Axis = Attributes(),
     Axis3 = Attributes(),
     legend = Attributes(),


### PR DESCRIPTION
# Description

This is (currently) a prototype for how resampling plot data could work. 

Related:
- related to #5685
- could enable a solution for #2563
- closes #5162

## Description & Problems to solve

Resampling is useful for any transformation that curves space, e.g. `Polar`. If you draw a line in polar coordinates it is generally expected that this line is straight in polar space and therefore curved in Cartesian space (if theta changes). To implement this in Makie we generally need to resample the vertices of the line in polar coordinates so they are sufficiently dense to look curved after the transformation. Resampling also has to affect all attributes that are per-vertex. In lines this would be color and linewidth.

Note that resampling something like `mesh` is more complex as it may require re-meshing as well. I.e. it may be based on and affect faces alongside positions, and affect not just per-vertex attributes but also face-related attributes.

## User Interface

Users can set the `resampler` attribute to control whether and what kind of resampling a plot does. Whatever is given to this attribute can contain further settings.

## Developer Interface

The user interface consists of four steps:
1. `mandatory_resampling_inputs(::Type{<:Plot}, ::AbstractResampler)` defines what's required to do resampling, e.g. positions or vertices + faces
2. `resample(::Type{<:Plot}, ::AbstractResampler, transform_func, inputs...)` generates an object that describes how the resampling works and resamples the `inputs` which are given by the previous step
3. `resampled_attributes(::Type{<:Plot}, ::AbstractResampler)` defines all other attributes/compute nodes that could need resampling
4. `resample(interpolator, data, attr_key, plot_key)` is called on each of the attributes/nodes defined above using the first output of step 2. This should check if the attribute needs resampling (typically by type) and apply the resampling if it does.

So as a developer, you can define a new `AbstractResampler`, that inputs it requires to prepare resampling, the affected nodes and how they are affected. The currently implemented `Resampler` is more or less an example for the interface.

The current TestResampler acts as an example:
```julia
# define a user facing Resampler
struct TestResampler <: AbstractResampler end

# and an internal representation that can be used to apply the resampling
struct LinearResampler <: AbstractResampler
    samples::Vector{Float64}
    N::Int
end

# Define what is needed to generate the internal representation
mandatory_resampling_inputs(::Type{<:Scatter}, ::AbstractResampler) = [:positions]

# and generate it (while also resampling the mandatory inputs)
function resample(::Type{<:Plot}, ::TestResampler, transform_func, positions)
    steps = [i + di for i in eachindex(positions) for di in (0.0, 0.5)]
    interp = LinearResampler(steps, length(positions))
    new_pos = resample(interp, positions)
    return interp, new_pos
end

# Define what else could need resampling
resampled_attributes(::Type{<:Scatter}, ::AbstractResampler) = [:color, :markersize]

# And a way to apply the internal resampling representation to resampleable data
function resample(interp::LinearResampler, data::AbstractVector)
    N = length(data)
    if N == interp.N
        return map(interp.samples) do sample
            i0 = clamp(floor(Int, sample), 1, N)
            i1 = clamp(ceil(Int, sample), 1, N)
            return lerp(data[i0], data[i1], sample - i0)
        end
    else
        return data
    end
end
```

## Internals

The current implementation heavily relies on modifying an existing compute graph. Whenever `resampler` changes, any nodes listed in `mandatory_resampling_inputs` and `resampled_attributes` gets redirected from `parent -> node` to `parent -> intermediate -- resample --> node`. 

This being interactive allows `resampler` to change at runtime. The redirection means that recipes don't need to hard-code what resamples and what doesn't. That saves a lot of changes in recipes and backends, and allows both recipe developers and resampler developers to extend the interface. But it does require somewhat hacky (?) edge modifications and replacements as well as somewhat magical intermediate nodes.

## Example

```julia
# TestResampler currently adds half-points for just scatter
f,a,p = scatter(
    1:10, color = 1:10, markersize = [10, 40, 10, 40, 10, 40, 10, 40, 10, 40], 
    resampler = Makie.TestResampler()
)
scatter!(1:10, color = :red, markersize = 10, marker = :cross, resampler = nothing)
f
```

<img width="628" height="516" alt="image" src="https://github.com/user-attachments/assets/3429c1e9-30bf-49c6-b47d-718e6bb69f62" />

## TODO

- [ ] Discuss the prototype
- [ ] (figure out what to do about the name collision with heatmap Resampler - maybe create something else?)
- [ ] (make a useful default Resampler, good defaults for `resample`, tests, docs)
- [ ] (consider implementing smoothing, equal-step resampling)
- [ ] (handle dendrogram resampling with this interface)

CC @asinghvi17 

## Type of change

Delete options that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [ ] Added or changed relevant sections in the documentation
- [ ] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.
