### PR TITLE
WGLMakie: keep a live session's figures renderable from a static snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- WGLMakie: a figure displayed through a live session (REPL, Pluto, Jupyter) is serialized into its initial payload again when `resize_to` is unset (the default), instead of only after the browser reported the canvas size. A static snapshot of that session — Pluto's or Jupyter's HTML export, "save page as" — therefore contains the scene and renders offline, where it used to show the loading spinner forever waiting for a reply that no Julia process could give. Scene inits also no longer block forever when an earlier scene's output is missing from the page (re-run notebook cell, partial export); after a short grace period they continue in order.
+- WGLMakie: a figure displayed through a live session (REPL, Pluto, Jupyter) is serialized into its initial payload again when `resize_to` is unset (the default), instead of only after the browser reported the canvas size. A static snapshot of that session — Pluto's or Jupyter's HTML export, "save page as" — therefore contains the scene and renders offline, where it used to show the loading spinner forever waiting for a reply that no Julia process could give. Scene inits also no longer block forever when an earlier scene's output is missing from the page (re-run notebook cell, partial export); after a short grace period they continue in order. [#5766](https://github.com/MakieOrg/Makie.jl/pull/5766)
 
 ## [0.24.13] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- WGLMakie: a figure displayed through a live session (REPL, Pluto, Jupyter) is serialized into its initial payload again when `resize_to` is unset (the default), instead of only after the browser reported the canvas size. A static snapshot of that session — Pluto's or Jupyter's HTML export, "save page as" — therefore contains the scene and renders offline, where it used to show the loading spinner forever waiting for a reply that no Julia process could give. Scene inits also no longer block forever when an earlier scene's output is missing from the page (re-run notebook cell, partial export); after a short grace period they continue in order.
+
 ## [0.24.13] - 2026-07-02
 
 - WGLMakie: fixed a `Cannot destructure property 'geometry' of 'mesh'` JS error and allow `Bonito@v5` [#5683](https://github.com/MakieOrg/Makie.jl/pull/5683)

--- a/GLMakie/Project.toml
+++ b/GLMakie/Project.toml
@@ -21,6 +21,9 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ShaderAbstractions = "65257c39-d410-5151-9873-9b3e5be5013e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[sources.Makie]
+path = "../Makie"
+
 [compat]
 ColorTypes = "0.9, 0.10, 0.11, 0.12"
 Colors = "0.11, 0.12, 0.13"
@@ -30,7 +33,7 @@ FreeTypeAbstraction = "0.10"
 GLFW = "3.4.3"
 GeometryBasics = "0.5"
 LinearAlgebra = "1.0, 1.6"
-Makie = "=0.24.13"
+Makie = "=0.24.13, 0.24"
 Markdown = "1.0, 1.6"
 MeshIO = "0.5"
 ModernGL = "1"
@@ -40,6 +43,3 @@ Printf = "1.0, 1.6"
 ShaderAbstractions = "0.5"
 StaticArrays = "0.12, 1.0"
 julia = "1"
-
-[sources.Makie]
-path = "../Makie"

--- a/WGLMakie/src/javascript/WGLMakie.bundled.js
+++ b/WGLMakie/src/javascript/WGLMakie.bundled.js
@@ -24572,9 +24572,11 @@ const mod1 = {
     Scatter: Scatter
 };
 window.THREE = mod;
+const ORDER_GAP_GRACE_MS = 1000;
 const orderedExecutor = {
     tasks: new Map(),
     nextExpected: 1,
+    gapTimer: null,
     insert (f, order) {
         if (this.tasks.has(order)) {
             throw new Error(`Duplicate task for order ${order}`);
@@ -24588,6 +24590,17 @@ const orderedExecutor = {
             f();
             this.tasks.delete(this.nextExpected);
             this.nextExpected += 1;
+        }
+        if (this.tasks.size > 0 && this.gapTimer === null) {
+            this.gapTimer = setTimeout(()=>{
+                this.gapTimer = null;
+                if (this.tasks.size > 0 && !this.tasks.has(this.nextExpected)) {
+                    const pending = Math.min(...this.tasks.keys());
+                    console.warn(`WGLMakie: scene order ${this.nextExpected} never arrived, continuing with ${pending}`);
+                    this.nextExpected = pending;
+                    this.flush();
+                }
+            }, ORDER_GAP_GRACE_MS);
         }
     }
 };

--- a/WGLMakie/src/javascript/WGLMakie.js
+++ b/WGLMakie/src/javascript/WGLMakie.js
@@ -19,9 +19,15 @@ import {get_texture_atlas} from "./TextureAtlas.js";
 
 window.THREE = THREE;
 
+// A scene init whose predecessor never arrives (its notebook output was re-run,
+// or a page reload / static export carries only some outputs) must not block
+// the rest forever: after this grace period, continue with the smallest pending order.
+const ORDER_GAP_GRACE_MS = 1000;
+
 const orderedExecutor = {
     tasks: new Map(),
     nextExpected: 1,
+    gapTimer: null,
 
     insert(f, order) {
         if (this.tasks.has(order)) {
@@ -37,6 +43,17 @@ const orderedExecutor = {
             f();
             this.tasks.delete(this.nextExpected);
             this.nextExpected += 1;
+        }
+        if (this.tasks.size > 0 && this.gapTimer === null) {
+            this.gapTimer = setTimeout(() => {
+                this.gapTimer = null;
+                if (this.tasks.size > 0 && !this.tasks.has(this.nextExpected)) {
+                    const pending = Math.min(...this.tasks.keys());
+                    console.warn(`WGLMakie: scene order ${this.nextExpected} never arrived, continuing with ${pending}`);
+                    this.nextExpected = pending;
+                    this.flush();
+                }
+            }, ORDER_GAP_GRACE_MS);
         }
     },
 };

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -309,12 +309,16 @@ function get_atlas_tracker(f, scene::Scene)
         return f(Set{UInt32}())
     end
     session = screen.session
-    atlas = Bonito.get_metadata(session, :wglmakie_scene_atlas, nothing)
-    if isnothing(atlas)
-        atlas = Set{UInt32}()
-        Bonito.set_metadata!(session, :wglmakie_scene_atlas, atlas)
+    # One tracker per session, not per root: a notebook output (Pluto, IJulia) is
+    # its own session and has to carry the glyphs it uses — a static export or a
+    # page reload has nothing but the outputs. Within a session a glyph is still
+    # sent once. Weak keys: an entry goes away with its session.
+    trackers = Bonito.get_metadata(session, :wglmakie_atlas_trackers, nothing)
+    if isnothing(trackers)
+        trackers = WeakKeyDict{Session, Set{UInt32}}()
+        Bonito.set_metadata!(session, :wglmakie_atlas_trackers, trackers)
     end
-    return f(atlas)
+    return f(get!(() -> Set{UInt32}(), trackers, session))
 end
 
 function get_scatter_data(scene::Scene, markers, fonts)

--- a/WGLMakie/src/three_plot.jl
+++ b/WGLMakie/src/three_plot.jl
@@ -66,9 +66,10 @@ function three_display(screen::Screen, session::Session, scene::Scene)
     # Create observable for scene serialization that updates asynchronously
     scene_serialized = Observable{Union{Nothing, Dict{Symbol, Any}}}(nothing)
     done_init = Observable{Any}(nothing)
-    if is_offline
-        # For offline connections, we have to serialize immediately
-        # Since we cant do any round trip communication
+    # Nothing to learn from the browser when offline or with `resize_to` unset
+    # (JS reports exactly `initial_size` back): serialize now, so a static
+    # snapshot of a live session (Pluto/Jupyter HTML export) carries the scene.
+    if is_offline || isnothing(config.resize_to)
         scene_serialized[] = serialize_scene(scene)
     else
         # Query the real canvas size (resize_to) from JS first, resize the scene to

--- a/WGLMakie/test/runtests.jl
+++ b/WGLMakie/test/runtests.jl
@@ -23,6 +23,8 @@ import Electron
     @test !showable("blaaa", f)
 end
 
+include("static_snapshot.jl")
+
 excludes = Set(
     [
         "Image on Surface Sphere", # TODO: texture rotated 180°

--- a/WGLMakie/test/static_snapshot.jl
+++ b/WGLMakie/test/static_snapshot.jl
@@ -1,0 +1,53 @@
+# A figure displayed through a live session has to be serialized into its
+# initial payload when `resize_to` is unset (the default): the browser cannot
+# change the size then, and a static snapshot of the session — Pluto's or
+# Jupyter's HTML export — only ever has that payload, with no Julia process
+# left to answer a size round trip. With `resize_to` set the round trip stays.
+
+function queued_scene_payloads(session, scene)
+    uuid = WGLMakie.js_uuid(scene)
+    payloads = Any[]
+    for msg in session.message_queue, (_, obj) in msg.cache.objects
+        obj isa Bonito.SerializedObservable || continue
+        value = obj.value
+        if value isa AbstractDict && get(value, "uuid", nothing) == uuid
+            push!(payloads, value)
+        end
+    end
+    return payloads
+end
+
+function display_into(session; screen_config...)
+    fig, ax, pl = scatter(1:4)
+    Makie.update_state_before_display!(fig)
+    scene = Makie.get_scene(fig)
+    screen = WGLMakie.Screen(; screen_config...)
+    screen.scene = scene
+    WGLMakie.render_with_init(screen, session, scene, fig)
+    return scene
+end
+
+@testset "scene serialized into the initial payload" begin
+    # A live-type session no browser ever connects to.
+    session = Bonito.Session(Bonito.WebSocketConnection(); asset_server = Bonito.NoServer())
+    try
+        @testset "default resize_to" begin
+            sub = Bonito.Session(session)
+            scene = display_into(sub)
+            @test length(queued_scene_payloads(sub, scene)) == 1
+        end
+        @testset "resize_to = :parent waits for the browser" begin
+            sub = Bonito.Session(session)
+            scene = display_into(sub; resize_to = :parent)
+            @test isempty(queued_scene_payloads(sub, scene))
+        end
+        @testset "offline" begin
+            offline = Bonito.Session(Bonito.NoConnection(); asset_server = Bonito.NoServer())
+            scene = display_into(offline; resize_to = :parent)
+            @test length(queued_scene_payloads(offline, scene)) == 1
+            close(offline)
+        end
+    finally
+        close(session)
+    end
+end


### PR DESCRIPTION
# Description

Fixes #1343 (Bonito half: SimonDanisch/Bonito.jl#423). Pluto's static HTML export of WGLMakie figures showed the spinner forever; once the first figure's output was replaced, a reload lost text and markers or stalled.

- `three_plot.jl`: with `resize_to` unset (default) the browser reports exactly `initial_size`, so serialize the scene right away instead of after the size round trip; a snapshot then contains the scene. The round trip stays for `resize_to`.
- `plot-primitives.jl`: glyph SDFs were sent once per root, so outputs after the first carried only hashes; track per session instead.
- `javascript/WGLMakie.js`: `execute_in_order` no longer waits forever for a missing order number; after 1 s it continues with the smallest pending one.

MWE: three plot cells in Pluto 1.0.3, `Pluto.generate_html(nb)`, also after `update_save_run!` on the first plot cell. Both render offline with this and the Bonito PR; before: spinner, then no text.

| before (unpatched) | after (this PR alone) |
|---|---|
| ![before](https://raw.githubusercontent.com/greimel/Makie.jl/pr-assets/export-before-unpatched.png) | ![after](https://raw.githubusercontent.com/greimel/Makie.jl/pr-assets/makie-only-plain.png) |

Pre-existing, not touched: `render_with_init` logs "Plot initialized multiple times?" when a reloaded page re-inits a scene.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Added an entry in CHANGELOG.md
- [x] Added unit tests: `WGLMakie/test/static_snapshot.jl`, no browser needed (full Electron suite not run locally)

Written with Claude Fable 5.