### PR TITLE
Validate Figure and Legend keywords with extension theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reject unknown `Figure` and specialized `Legend` keyword arguments while preserving custom plot, block, and backend theme overrides (issue [#4217](https://github.com/MakieOrg/Makie.jl/issues/4217)).
+
 - Fixed a segfault in CairoMakie when saving a vector graphic (pdf, svg, eps) of a figure while recording it with a `VideoStream` [#5772](https://github.com/MakieOrg/Makie.jl/pull/5772).
 - Added support for exporting .mov video files. Transparent-background rendering for .mov outputs is now supported [#5764](https://github.com/MakieOrg/Makie.jl/pull/5764).
 - Increased precision of `Vec3f` to `Quaternionf` conversion to reduce quantization/improve precision around `Vec3f(0, 0, ±1)` rotations in `meshscatter`. [#5758](https://github.com/MakieOrg/Makie.jl/pull/5758)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Reject unknown `Figure` and specialized `Legend` keyword arguments while preserving custom plot, block, and backend theme overrides (issue [#4217](https://github.com/MakieOrg/Makie.jl/issues/4217)).
-
+- Reject unknown `Figure` and specialized `Legend` keyword arguments while preserving custom plot, block, and backend theme overrides [#5773](https://github.com/MakieOrg/Makie.jl/pull/5773).
 - Fixed a segfault in CairoMakie when saving a vector graphic (pdf, svg, eps) of a figure while recording it with a `VideoStream` [#5772](https://github.com/MakieOrg/Makie.jl/pull/5772).
 - Added support for exporting .mov video files. Transparent-background rendering for .mov outputs is now supported [#5764](https://github.com/MakieOrg/Makie.jl/pull/5764).
 - Increased precision of `Vec3f` to `Quaternionf` conversion to reduce quantization/improve precision around `Vec3f(0, 0, ±1)` rotations in `meshscatter`. [#5758](https://github.com/MakieOrg/Makie.jl/pull/5758)

--- a/Makie/src/figures.jl
+++ b/Makie/src/figures.jl
@@ -106,6 +106,70 @@ end
 to_rectsides(n::Number) = to_rectsides((n, n, n, n))
 to_rectsides(t::Tuple{Any, Any, Any, Any}) = GridLayoutBase.RectSides{Float32}(t...)
 
+const FIGURE_SCENE_KEYWORDS = (
+    :figure_padding, :viewport, :events, :clear, :transform_func, :camera,
+    :camera_controls, :transformation, :plots, :children, :current_screens,
+    :parent, :visible, :ssao, :lights, :theme, :deregister_callbacks, :resolution,
+)
+
+function _block_theme_keys!(names, T)
+    children = subtypes(T)
+    if isempty(children)
+        push!(names, nameof(T))
+        union!(names, inherited_theme_keys(T))
+    else
+        foreach(child -> _block_theme_keys!(names, child), children)
+    end
+    return names
+end
+
+function _backend_theme_keys!(names, T)
+    for child in subtypes(T)
+        push!(names, nameof(parentmodule(child)))
+        _backend_theme_keys!(names, child)
+    end
+    return names
+end
+
+function attribute_names(::Type{Figure})
+    names = union(Set(FIGURE_SCENE_KEYWORDS), keys(MAKIE_DEFAULT_THEME), keys(current_default_theme()))
+    # Recipes are parameterizations of Plot, rather than distinct subtypes.
+    # Inspect their plotsym methods so recipes loaded after Makie are included.
+    for method in methods(plotsym)
+        signature = Base.unwrap_unionall(method.sig)
+        length(signature.parameters) == 2 || continue
+        argument = Base.unwrap_unionall(signature.parameters[2])
+        argument isa DataType && argument <: Type || continue
+        plot_type = argument.parameters[1]
+        plot_type = plot_type isa TypeVar ? plot_type.ub : plot_type
+        plot_type isa Type || continue
+        plot_type <: Plot && plot_type !== Plot || continue
+        push!(names, plotsym(plot_type))
+        union!(names, inherited_theme_keys(plot_type))
+    end
+    _block_theme_keys!(names, Block)
+    _backend_theme_keys!(names, MakieScreen)
+    return names
+end
+
+function _check_figure_kwargs(kwargs)
+    # Most figures only use built-in keys. Avoid walking recipes and block types
+    # unless there is an extension key (or a typo) to resolve.
+    isempty(kwargs) && return
+    current_theme = current_default_theme()
+    local_theme = get(kwargs, :theme, nothing)
+    unknown = Set{Symbol}(
+        key for key in keys(kwargs) if !(
+                key in FIGURE_SCENE_KEYWORDS || haskey(MAKIE_DEFAULT_THEME, key) ||
+                haskey(current_theme, key) || (!isnothing(local_theme) && haskey(local_theme, key))
+            )
+    )
+    isempty(unknown) && return
+    setdiff!(unknown, attribute_names(Figure))
+    isempty(unknown) || throw(InvalidAttributeError(Figure, "figure", unknown))
+    return
+end
+
 """
     Figure(; [figure_padding,] kwargs...)
 
@@ -115,10 +179,14 @@ one number or a tuple of four numbers for left, right, bottom and top paddings v
 
 All other keyword arguments such as `size` and `backgroundcolor` are forwarded to the
 [`Scene`](@ref) owned by the figure which acts as the container for all other visual objects.
+Unknown keyword arguments raise an `InvalidAttributeError`. Figure-local theme overrides
+may use registered plot and block names, inherited theme keys, and backend names.
+Additional custom theme entries can be supplied explicitly with `theme = Attributes(...)`.
 """
 function Figure(; kwargs...)
 
     kwargs_dict = Dict(kwargs)
+    _check_figure_kwargs(kwargs_dict)
     padding = pop!(kwargs_dict, :figure_padding, theme(:figure_padding))
     scene = Scene(; camera = campixel!, clear = true, kwargs_dict...)
     padding = convert(Observable{Any}, padding)

--- a/Makie/src/makielayout/blocks.jl
+++ b/Makie/src/makielayout/blocks.jl
@@ -4,6 +4,9 @@ function attribute_default_expressions end
 function _attribute_docs end
 function has_forwarded_layout end
 
+# Keep inheritance sources available without evaluating a block's default values.
+inherited_theme_keys(::Type{<:Block}) = ()
+
 symbol_to_block(symbol::Symbol) = symbol_to_block(Val(symbol))
 symbol_to_block(::Val) = nothing
 
@@ -80,6 +83,7 @@ macro Block(_name::Union{Expr, Symbol}, body::Expr = Expr(:block))
 
         export $name
         $(Makie).symbol_to_block(::Val{$(QuoteNode(name))}) = $name
+        $(Makie).inherited_theme_keys(::Type{$name}) = $(QuoteNode(Tuple(union(Set{Symbol}(), (_inherited_theme_keys(a.default) for a in something(attrs, []))...))))
         function $(Makie).is_attribute(::Type{$(name)}, sym::Symbol)
             return sym in ($((attrs !== nothing ? [QuoteNode(a.symbol) for a in attrs] : [])...),)
         end

--- a/Makie/src/makielayout/blocks/legend.jl
+++ b/Makie/src/makielayout/blocks/legend.jl
@@ -958,7 +958,9 @@ function Legend(
     )
 
     scene = get_topscene(fig_or_scene)
-    legend_defaults = block_defaults(:Legend, Dict{Symbol, Any}(kwargs), scene)
+    kwdict = Dict{Symbol, Any}(kwargs)
+    _check_remaining_kwargs(Legend, kwdict)
+    legend_defaults = block_defaults(:Legend, kwdict, scene)
     entry_groups = to_entry_group(Attributes(legend_defaults), contents, labels, title)
     entrygroups = Observable(entry_groups)
     legend_defaults[:entrygroups] = entrygroups
@@ -992,7 +994,9 @@ function Legend(
     )
 
     scene = get_scene(fig_or_scene)
-    legend_defaults = block_defaults(:Legend, Dict{Symbol, Any}(kwargs), scene)
+    kwdict = Dict{Symbol, Any}(kwargs)
+    _check_remaining_kwargs(Legend, kwdict)
+    legend_defaults = block_defaults(:Legend, kwdict, scene)
     entry_groups = to_entry_group(legend_defaults, contentgroups, labelgroups, titles)
     entrygroups = Observable(entry_groups)
     legend_defaults[:entrygroups] = entrygroups

--- a/Makie/src/recipes.jl
+++ b/Makie/src/recipes.jl
@@ -5,6 +5,36 @@ to_func_name(x::Symbol) = Symbol(lowercase(string(x)))
 # Will get overloaded by recipe Macro
 plotsym(x) = :plot
 
+# Collect literal theme lookups while recipe/block definitions are still syntax.
+# Do not evaluate default expressions just to validate a Figure keyword.
+function _inherited_theme_keys(expr)
+    names = Set{Symbol}()
+    expr isa Expr || return names
+    if expr.head in (:call, :macrocall) && length(expr.args) >= 3
+        func = expr.args[1]
+        if func isa Expr && func.head === :.
+            func = func.args[end]
+        end
+        func = func isa QuoteNode ? func.value : func
+        if func in (:theme, :inherit, Symbol("@inherit"))
+            key = expr.args[3]
+            if key isa Expr && key.head === :tuple && !isempty(key.args)
+                key = first(key.args)
+            end
+            # Unquoted symbols are keys only in the new @inherit syntax.
+            if key isa QuoteNode && key.value isa Symbol
+                push!(names, key.value)
+            elseif key isa Symbol && func === Symbol("@inherit")
+                push!(names, key)
+            end
+        end
+    end
+    for arg in expr.args
+        union!(names, _inherited_theme_keys(arg))
+    end
+    return names
+end
+
 func2string(func::Function) = string(nameof(func))
 
 plotfunc(::Plot{F}) where {F} = F
@@ -189,6 +219,7 @@ macro recipe(theme_func, Tsym::Symbol, args::Symbol...)
         Core.@__doc__ ($funcname)(args...; kw...) = _create_plot($funcname, Dict{Symbol, Any}(kw), args...)
         ($funcname!)(args...; kw...) = _create_plot!($funcname, Dict{Symbol, Any}(kw), args...)
         $(Makie).default_theme(scene, ::Type{<:$PlotType}) = $(esc(theme_func))(scene)
+        $(Makie).inherited_theme_keys(::Type{<:$PlotType}) = $(QuoteNode(Tuple(_inherited_theme_keys(theme_func))))
         $(Makie).symbol_to_plot(::Val{$(QuoteNode(Tsym))}) = $PlotType
         export $PlotType, $funcname, $funcname!
     end
@@ -432,6 +463,12 @@ end
 function types_for_plot_arguments end
 
 documented_attributes(_) = nothing
+
+function inherited_theme_keys(T::Type{<:Plot})
+    attrs = documented_attributes(T)
+    isnothing(attrs) && return ()
+    return Tuple(meta.default_value.key for meta in values(attrs.d) if meta.default_value isa Inherit)
+end
 filtered_attributes(T; kwargs...) = filter_attributes(documented_attributes(T); kwargs...)
 
 function attribute_names(T::Type{<:Plot})

--- a/Makie/src/recipes.jl
+++ b/Makie/src/recipes.jl
@@ -10,14 +10,16 @@ plotsym(x) = :plot
 function _inherited_theme_keys(expr)
     names = Set{Symbol}()
     expr isa Expr || return names
-    if expr.head in (:call, :macrocall) && length(expr.args) >= 3
-        func = expr.args[1]
+    # Semicolon keyword arguments insert a :parameters node before positional arguments.
+    args = expr.head === :call ? filter(arg -> !Meta.isexpr(arg, :parameters), expr.args) : expr.args
+    if expr.head in (:call, :macrocall) && length(args) >= 3
+        func = args[1]
         if func isa Expr && func.head === :.
             func = func.args[end]
         end
         func = func isa QuoteNode ? func.value : func
         if func in (:theme, :inherit, Symbol("@inherit"))
-            key = expr.args[3]
+            key = args[3]
             if key isa Expr && key.head === :tuple && !isempty(key.args)
                 key = first(key.args)
             end

--- a/Makie/test/SceneLike/figure_attributes.jl
+++ b/Makie/test/SceneLike/figure_attributes.jl
@@ -3,7 +3,10 @@ module FigureAttributeTestRecipes
     using Makie: make_block_docstring
 
     @recipe(FigureThemePlot, values) do scene
-        Attributes(color = Makie.inherit(scene, :figure_old_plot_color, :red))
+        Attributes(
+            color = Makie.inherit(scene, :figure_old_plot_color, :red),
+            theme_color = theme(scene, :figure_old_plot_theme_color; default = :red),
+        )
     end
 
     @recipe FigureInheritedPlot (values,) begin
@@ -18,6 +21,7 @@ module FigureAttributeTestRecipes
             legacy_color = Makie.inherit(scene, :figure_old_block_color, :red)
             nested_color = Makie.inherit(scene, (:FigureNestedTheme, :color), :red)
             theme_color = theme(scene, :figure_direct_theme_color)
+            keyword_theme_color = theme(scene, :figure_block_theme_color; default = :red)
         end
     end
 
@@ -72,6 +76,10 @@ end
     inherited = Figure(figure_plot_color = :purple)
     @test Makie.lookup_default(FigureAttributeTestRecipes.FigureInheritedPlot, inherited.scene, :color) === :purple
     @test Axis(f[1, 1]).xgridvisible[] === false
+
+    f = Figure(figure_old_plot_theme_color = :blue, figure_block_theme_color = :green)
+    @test Makie.default_theme(f.scene, FigureAttributeTestRecipes.FigureThemePlot)[:theme_color][] === :blue
+    @test Makie.to_value(Makie.default_attribute_values(FigureAttributeTestRecipes.FigureThemeBlock, f.scene)[:keyword_theme_color]) === :green
 
     with_theme(; custom_figure_setting = :red) do
         f = Figure(custom_figure_setting = :blue)

--- a/Makie/test/SceneLike/figure_attributes.jl
+++ b/Makie/test/SceneLike/figure_attributes.jl
@@ -1,0 +1,96 @@
+module FigureAttributeTestRecipes
+    using Makie
+    using Makie: make_block_docstring
+
+    @recipe(FigureThemePlot, values) do scene
+        Attributes(color = Makie.inherit(scene, :figure_old_plot_color, :red))
+    end
+
+    @recipe FigureInheritedPlot (values,) begin
+        color = @inherit figure_plot_color :red
+    end
+
+    abstract type NestedFigureBlock <: Makie.Block end
+
+    Makie.@Block FigureThemeBlock <: NestedFigureBlock begin
+        @attributes begin
+            color = @inherit(:figure_block_color, :red)
+            legacy_color = Makie.inherit(scene, :figure_old_block_color, :red)
+            nested_color = Makie.inherit(scene, (:FigureNestedTheme, :color), :red)
+            theme_color = theme(scene, :figure_direct_theme_color)
+        end
+    end
+
+    module CustomFigureBackend
+        import Makie
+        abstract type AbstractScreen <: Makie.MakieScreen end
+        struct Screen <: AbstractScreen end
+    end
+end
+
+@testset "Figure keyword validation" begin
+    for kwargs in ((noproblem = false,), (backgrouncolor = :red,), (title = "invalid",))
+        @test_throws Makie.InvalidAttributeError Figure(; kwargs...)
+    end
+    @test_throws Makie.InvalidAttributeError scatter(1:3; figure = (noproblem = false,))
+
+    error = try
+        Figure(backgrouncolor = :red)
+    catch e
+        e
+    end
+    @test error isa Makie.InvalidAttributeError
+    @test occursin("backgroundcolor", sprint(showerror, error; context = :color => false))
+
+    f = Figure(size = (120, 100), backgroundcolor = :white, figure_padding = 0, visible = Observable(false))
+    @test f isa Figure
+    @test f.scene.visible[] == false
+
+    f = Figure(
+        FigureThemePlot = (color = :blue,),
+        FigureInheritedPlot = (color = :green,),
+        FigureThemeBlock = (color = :orange,),
+        figure_plot_color = :purple,
+        figure_block_color = :yellow,
+        figure_old_plot_color = :pink,
+        figure_old_block_color = :brown,
+        FigureNestedTheme = (color = :cyan,),
+        figure_direct_theme_color = :orange,
+        CustomFigureBackend = (antialias = true,),
+        Axis = (xgridvisible = false,),
+    )
+    @test f.scene.theme[:FigureThemePlot][:color][] === :blue
+    @test f.scene.theme[:figure_plot_color][] === :purple
+    @test f.scene.theme[:figure_block_color][] === :yellow
+    @test f.scene.theme[:CustomFigureBackend][:antialias][] === true
+    @test Makie.default_attribute_values(FigureAttributeTestRecipes.FigureThemeBlock, f.scene)[:color] === :yellow
+    @test Makie.to_value(Makie.default_attribute_values(FigureAttributeTestRecipes.FigureThemeBlock, f.scene)[:legacy_color]) === :brown
+    @test Makie.to_value(Makie.default_attribute_values(FigureAttributeTestRecipes.FigureThemeBlock, f.scene)[:nested_color]) === :cyan
+    @test Makie.to_value(Makie.default_attribute_values(FigureAttributeTestRecipes.FigureThemeBlock, f.scene)[:theme_color]) === :orange
+    @test Makie.default_theme(f.scene, FigureAttributeTestRecipes.FigureThemePlot)[:color][] === :pink
+    @test Makie.lookup_default(FigureAttributeTestRecipes.FigureInheritedPlot, f.scene, :color) === :green
+    inherited = Figure(figure_plot_color = :purple)
+    @test Makie.lookup_default(FigureAttributeTestRecipes.FigureInheritedPlot, inherited.scene, :color) === :purple
+    @test Axis(f[1, 1]).xgridvisible[] === false
+
+    with_theme(; custom_figure_setting = :red) do
+        f = Figure(custom_figure_setting = :blue)
+        @test f.scene.theme[:custom_figure_setting][] === :blue
+    end
+    @test_throws Makie.InvalidAttributeError Figure(custom_figure_setting = :blue)
+    f = Figure(theme = Attributes(custom_figure_setting = :red), custom_figure_setting = :blue)
+    @test f.scene.theme[:custom_figure_setting][] === :blue
+
+    # Validation must not silently accept unrelated attributes of child blocks.
+    @test_throws Makie.InvalidAttributeError Figure(xlabel = "not a figure keyword")
+    @test_throws Makie.InvalidAttributeError Figure(UnknownFigureBackend = (antialias = true,))
+    @test Figure(CairoMakie = (antialias = :best,)) isa Figure
+
+    f = Figure()
+    ax = Axis(f[1, 1])
+    p = scatter!(ax, 1:3; label = "points")
+    @test_throws Makie.InvalidAttributeError Legend(f[2, 1], ax; thisshoulderror = true)
+    @test_throws Makie.InvalidAttributeError Legend(f[2, 1], [[p]], [["points"]], ["group"]; thisshoulderror = true)
+    @test Legend(f[2, 1], [[p]], [["points"]], ["group"]; titleposition = :left) isa Legend
+    @test_throws Makie.InvalidAttributeError Axis(f[3, 1]; thisshoulderror = true)
+end

--- a/Makie/test/runtests.jl
+++ b/Makie/test/runtests.jl
@@ -55,6 +55,8 @@ end
         include("SceneLike/figures.jl")
         include("SceneLike/makielayout.jl")
         include("SceneLike/PolarAxis.jl")
+        # Defines extension block types after the built-in block inventory tests.
+        include("SceneLike/figure_attributes.jl")
     end
 
     @testset "Conversion & Projection Pipeline" begin


### PR DESCRIPTION
Fixes #4217.

`Figure(noproblem = false)` silently accepts the unknown keyword, and the specialized `Legend` constructors discard unknown keywords before validation. This uses the existing `InvalidAttributeError` path for both, including spelling suggestions.

Figure validation preserves Scene options, registered plot and leaf Block names, inherited theme sources, current/local theme keys, and loaded backend names. New recipes use their existing attribute metadata; old recipes and Blocks record literal theme lookups when their macros expand, including `theme(scene, :key; default = ...)`. Validation does not evaluate their default expressions. Custom entries can also be supplied explicitly through `theme = Attributes(...)`.

This overlaps #5629 and #5653. The extension handling follows the [compatibility requirements in the review of #5629](https://github.com/MakieOrg/Makie.jl/pull/5629#issuecomment-4576897014).

Local validation on Windows with Julia 1.10.12 and `--depwarn=yes --check-bounds=yes`:

- Full Makie core suite: **6,595 passed, 0 failed, 0 errored, 2 existing tests marked broken**. This includes 32 focused Figure/Legend assertions.
- An independent 24-scenario harness passes. The same cases on the exact base detect 11 missing validation behaviors while preserving all 13 valid-use scenarios. It also caught the keyword-default inheritance regression in the earlier version of this PR; that is now corrected and covered by upstream tests.
- Two Cairo rendering examples pass their attribute checks and produce identical decoded pixels on the base and this implementation. The full backend reference-image suites and Linux/version matrix were not run locally.
- Runic and `git diff --check` pass.

Codex wrote and revised the implementation, tests and this description, and ran the local checks.

If accepted, I would like this considered for the advertised €50 bounty in #4217. Payment details can be arranged privately with the sponsor.
