### PR TITLE
Reduce mesh stroke overhead

### DIFF
--- a/Makie/src/basic_plots.jl
+++ b/Makie/src/basic_plots.jl
@@ -529,7 +529,8 @@ Note that `meshscatter` is much better for plotting a single mesh at multiple po
     """
     Sets the width of the stroke along visible mesh edges in pixels. A width of 0 disables stroking.
     The stroke is drawn inwards from each edge as part of the mesh surface itself, replacing the
-    face color rather than being layered on top.
+    face color rather than being layered on top. In WGLMakie, stroking must be enabled when the
+    plot is created to take effect.
     """
     strokewidth = 0.0
     """

--- a/Makie/src/compute-plots.jl
+++ b/Makie/src/compute-plots.jl
@@ -1032,35 +1032,54 @@ function count_mesh_edges(faces, canonical_ids)
     return counts
 end
 
-function corner_wings(incident_edges, positions, v, o1, o2, own_min_width)
+# Picks up to two wing edges for the corner `v` of a triangle whose other corners are
+# `o1` and `o2`, and writes them into `indices`/`widths` at `slot` and `slot + 1`
+# (index 0 marks an unused slot). The two candidates closest in angle to the triangle's
+# own edges are kept, tracked in a single pass so that no intermediate list is built.
+function corner_wings!(indices, widths, slot, incident_edges, positions, v, o1, o2, own_min_width)
     at(u) = to_ndim(Point3d, positions[u], 0)
     direction(u) = normalize(Vec3d(at(u) - at(v)))
     d1 = direction(o1)
     d2 = direction(o2)
     plane_normal = normalize(cross(d1, d2))
 
-    # A wing that leaves the triangle's plane belongs to a face seen at an angle, so its
-    # stroke band should not continue onto this triangle (it would project as a stray
-    # band across the face). Slight non-planarity is allowed for curved surfaces.
-    function is_in_plane((u, _))
-        out_of_plane = abs(dot(plane_normal, direction(u)))
-        return !isnan(out_of_plane) && out_of_plane < 0.3
-    end
-    wings = filter(((u, _),) -> u != o1 && u != o2, incident_edges)
-    # A wing band can only enter this triangle by crossing one of the triangle's own
-    # edges at the corner. If those are themselves stroked at least as wide, the
-    # junction is already covered and the wing would only risk painting stray bands
-    # on curved surfaces (e.g. a triangle sphere with strokeedges = :all).
-    wings = filter!(((_, width),) -> width > own_min_width, wings)
-    wings = filter!(is_in_plane, wings)
-    length(wings) <= 2 && return wings
+    best_u = 0
+    best_w = 0.0f0
+    best_score = -Inf
+    second_u = 0
+    second_w = 0.0f0
+    second_score = -Inf
 
-    function wedge_closeness((u, _))
+    for (u, width) in incident_edges
+        (u == o1 || u == o2) && continue
+        # A wing band can only enter this triangle by crossing one of the triangle's own
+        # edges at the corner. If those are themselves stroked at least as wide, the
+        # junction is already covered and the wing would only risk painting stray bands
+        # on curved surfaces (e.g. a triangle sphere with strokeedges = :all).
+        width > own_min_width || continue
         du = direction(u)
+        # A wing that leaves the triangle's plane belongs to a face seen at an angle, so
+        # its stroke band should not continue onto this triangle (it would project as a
+        # stray band across the face). Slight non-planarity is allowed for curved surfaces.
+        out_of_plane = abs(dot(plane_normal, du))
+        (!isnan(out_of_plane) && out_of_plane < 0.3) || continue
+
         score = max(dot(du, d1), dot(du, d2))
-        return isnan(score) ? -Inf : score
+        isnan(score) && (score = -Inf)
+        # `*_u == 0` keeps empty slots fillable when every candidate scores -Inf
+        if best_u == 0 || score > best_score
+            second_u, second_w, second_score = best_u, best_w, best_score
+            best_u, best_w, best_score = u, width, score
+        elseif second_u == 0 || score > second_score
+            second_u, second_w, second_score = u, width, score
+        end
     end
-    return partialsort(wings, 1:2; by = wedge_closeness, rev = true)
+
+    indices[slot] = best_u
+    widths[slot] = best_w
+    indices[slot + 1] = second_u
+    widths[slot + 1] = second_w
+    return
 end
 
 """
@@ -1118,18 +1137,15 @@ function stroke_edge_data(mesh, gl_faces, strokeedges::Symbol)
             end
         )
 
-        indices .= 0
-        widths .= 0.0f0
         for i in 1:3
             v = corners[i]
             o1 = corners[mod1(i + 1, 3)]
             o2 = corners[mod1(i + 2, 3)]
             own_min_width = min(edge_widths[t][i], edge_widths[t][mod1(i + 2, 3)])
-            wings = corner_wings(get(incident, v, no_wings), positions, v, o1, o2, own_min_width)
-            for (j, (u, width)) in enumerate(wings)
-                indices[2 * (i - 1) + j] = u
-                widths[2 * (i - 1) + j] = width
-            end
+            corner_wings!(
+                indices, widths, 2 * (i - 1) + 1, get(incident, v, no_wings),
+                positions, v, o1, o2, own_min_width
+            )
         end
         wing_indices[t] = Vec{6, Int32}(indices)
         wing_widths[t] = Vec{6, Float32}(widths)
@@ -1138,12 +1154,22 @@ function stroke_edge_data(mesh, gl_faces, strokeedges::Symbol)
     return edge_widths, wing_indices, wing_widths
 end
 
+# The edge data only depends on whether stroking is on, not on how wide the stroke is.
+# Depending on this flag rather than on :strokewidth keeps width changes from
+# recomputing the mesh adjacency, which is by far the most expensive part of stroking.
+function register_stroke_enabled!(attr)
+    haskey(attr, :stroke_enabled) && return
+    map!(!iszero, attr, :strokewidth, :stroke_enabled)
+    return
+end
+
 function register_mesh_stroke!(attr)
+    register_stroke_enabled!(attr)
     return map!(
-        attr, [:mesh, :faces, :strokeedges, :strokewidth],
+        attr, [:mesh, :faces, :strokeedges, :stroke_enabled],
         [:stroke_edge_widths, :stroke_wing_indices, :stroke_wing_widths]
-    ) do mesh, gl_faces, strokeedges, strokewidth
-        if iszero(strokewidth)
+    ) do mesh, gl_faces, strokeedges, stroke_enabled
+        if !stroke_enabled
             return (Vec3f[], Vec{6, Int32}[], Vec{6, Float32}[])
         end
         return stroke_edge_data(mesh, gl_faces, strokeedges)
@@ -1190,11 +1216,12 @@ end
 function register_surface_stroke!(attr)
     haskey(attr, :stroke_edge_widths) && return
     haskey(attr, :positions_transformed_f32c) || add_surface_vertex_positions!(attr)
+    register_stroke_enabled!(attr)
     map!(
-        attr, [:positions_transformed_f32c, :z, :strokeedges, :strokewidth],
+        attr, [:positions_transformed_f32c, :z, :strokeedges, :stroke_enabled],
         [:stroke_edge_widths, :stroke_wing_indices, :stroke_wing_widths, :stroke_faces]
-    ) do positions, z, strokeedges, strokewidth
-        if iszero(strokewidth)
+    ) do positions, z, strokeedges, stroke_enabled
+        if !stroke_enabled
             return (Vec3f[], Vec{6, Int32}[], Vec{6, Float32}[], GLTriangleFace[])
         end
         m = surface2mesh(positions, size(z))

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -698,7 +698,7 @@ function create_shader(scene::Scene, plot::Makie.Mesh)
 
     # Stroking needs the de-indexed mesh path, which replaces the shared vertices by one
     # per triangle corner, so it is only taken when stroking is enabled at plot creation.
-    if !iszero(plot.strokewidth[])
+    if plot.stroke_enabled[]::Bool
         register_wgl_mesh_expansion!(attr)
         register_wgl_mesh_stroke!(attr)
         return create_wgl_renderobject(

--- a/WGLMakie/src/plot-primitives.jl
+++ b/WGLMakie/src/plot-primitives.jl
@@ -618,6 +618,54 @@ function register_wgl_mesh_stroke!(attr)
     return
 end
 
+# Inputs of the de-indexed (stroked) mesh and surface programs.
+function deindexed_mesh_inputs()
+    return [
+        # Special
+        :space,
+        # Needs explicit handling
+        :uniform_colormap, :uniform_color, :uniform_colorrange, :pattern,
+        :lowclip_color, :highclip_color, :nan_color, :model_f32c, :matcap,
+        :diffuse, :specular, :shininess, :backlight, :world_normalmatrix,
+        :wgl_uv_transform, :fetch_pixel, :primitive_shading, :color_mapping_type,
+        :depth_shift,
+        :wgl_mesh_positions, :wgl_mesh_faces, :wgl_mesh_vertex_index,
+        :wgl_mesh_normals, :wgl_mesh_uv, :wgl_mesh_vertex_color,
+        :strokewidth, :strokecolor, :wgl_stroke_data, :wgl_viewport_origin,
+        :uniform_clip_planes, :uniform_num_clip_planes, :visible,
+    ]
+end
+
+# JS buffers and uniforms keep the standard names, so updates of the de-indexed
+# buffers have to be renamed to reach them
+function deindexed_mesh_renames()
+    return Dict(
+        :wgl_mesh_positions => :positions_transformed_f32c,
+        :wgl_mesh_faces => :faces,
+        :wgl_mesh_vertex_index => :vertex_index,
+        :wgl_mesh_normals => :normals,
+        :wgl_mesh_uv => :texturecoordinates,
+        :wgl_mesh_vertex_color => :vertex_color,
+        :wgl_stroke_data => :stroke_data,
+        :wgl_viewport_origin => :viewport_origin,
+    )
+end
+
+# Inputs of the regular indexed mesh and surface programs.
+function indexed_mesh_inputs()
+    return [
+        # Special
+        :space,
+        # Needs explicit handling
+        :uniform_colormap, :uniform_color, :vertex_color, :uniform_colorrange, :pattern,
+        :lowclip_color, :highclip_color, :nan_color, :model_f32c, :matcap,
+        :diffuse, :specular, :shininess, :backlight, :world_normalmatrix,
+        :wgl_uv_transform, :fetch_pixel, :primitive_shading, :color_mapping_type,
+        :depth_shift, :positions_transformed_f32c, :faces, :normals, :texturecoordinates,
+        :uniform_clip_planes, :uniform_num_clip_planes, :visible,
+    ]
+end
+
 function create_shader(::Scene, plot::Union{Heatmap, Image})
     attr = plot.attributes
     if plot isa Image
@@ -647,35 +695,19 @@ function create_shader(scene::Scene, plot::Makie.Mesh)
     map!(to_3x3, attr, :pattern_uv_transform, :wgl_uv_transform)
     backend_colors!(attr)
     add_primitive_shading!(scene, attr)
-    register_wgl_mesh_expansion!(attr)
-    register_wgl_mesh_stroke!(attr)
-    inputs = [
-        # Special
-        :space,
-        # Needs explicit handling
-        :uniform_colormap, :uniform_color, :uniform_colorrange, :pattern,
-        :lowclip_color, :highclip_color, :nan_color, :model_f32c, :matcap,
-        :diffuse, :specular, :shininess, :backlight, :world_normalmatrix,
-        :wgl_uv_transform, :fetch_pixel, :primitive_shading, :color_mapping_type,
-        :depth_shift,
-        :wgl_mesh_positions, :wgl_mesh_faces, :wgl_mesh_vertex_index,
-        :wgl_mesh_normals, :wgl_mesh_uv, :wgl_mesh_vertex_color,
-        :strokewidth, :strokecolor, :wgl_stroke_data, :wgl_viewport_origin,
-        :uniform_clip_planes, :uniform_num_clip_planes, :visible,
-    ]
-    # JS buffers and uniforms keep the standard names, so updates of the de-indexed
-    # buffers have to be renamed to reach them
-    rename_updates = Dict(
-        :wgl_mesh_positions => :positions_transformed_f32c,
-        :wgl_mesh_faces => :faces,
-        :wgl_mesh_vertex_index => :vertex_index,
-        :wgl_mesh_normals => :normals,
-        :wgl_mesh_uv => :texturecoordinates,
-        :wgl_mesh_vertex_color => :vertex_color,
-        :wgl_stroke_data => :stroke_data,
-        :wgl_viewport_origin => :viewport_origin,
-    )
-    return create_wgl_renderobject(mesh_program, attr, inputs; rename_updates)
+
+    # Stroking needs the de-indexed mesh path, which replaces the shared vertices by one
+    # per triangle corner, so it is only taken when stroking is enabled at plot creation.
+    if !iszero(plot.strokewidth[])
+        register_wgl_mesh_expansion!(attr)
+        register_wgl_mesh_stroke!(attr)
+        return create_wgl_renderobject(
+            mesh_program, attr, deindexed_mesh_inputs();
+            rename_updates = deindexed_mesh_renames()
+        )
+    end
+
+    return create_wgl_renderobject(mesh_program, attr, indexed_mesh_inputs())
 end
 
 
@@ -724,45 +756,13 @@ function create_shader(scene::Scene, plot::Surface)
         Makie.register_surface_stroke!(attr)
         register_wgl_mesh_expansion!(attr)
         register_wgl_mesh_stroke!(attr)
-        inputs = [
-            # Special
-            :space,
-            # Needs explicit handling
-            :uniform_colormap, :uniform_color, :uniform_colorrange, :pattern,
-            :lowclip_color, :highclip_color, :nan_color, :model_f32c, :matcap,
-            :diffuse, :specular, :shininess, :backlight, :world_normalmatrix,
-            :wgl_uv_transform, :fetch_pixel, :primitive_shading, :color_mapping_type,
-            :depth_shift,
-            :wgl_mesh_positions, :wgl_mesh_faces, :wgl_mesh_vertex_index,
-            :wgl_mesh_normals, :wgl_mesh_uv, :wgl_mesh_vertex_color,
-            :strokewidth, :strokecolor, :wgl_stroke_data, :wgl_viewport_origin,
-            :uniform_clip_planes, :uniform_num_clip_planes, :visible,
-        ]
-        rename_updates = Dict(
-            :wgl_mesh_positions => :positions_transformed_f32c,
-            :wgl_mesh_faces => :faces,
-            :wgl_mesh_vertex_index => :vertex_index,
-            :wgl_mesh_normals => :normals,
-            :wgl_mesh_uv => :texturecoordinates,
-            :wgl_mesh_vertex_color => :vertex_color,
-            :wgl_stroke_data => :stroke_data,
-            :wgl_viewport_origin => :viewport_origin,
+        return create_wgl_renderobject(
+            mesh_program, attr, deindexed_mesh_inputs();
+            rename_updates = deindexed_mesh_renames()
         )
-        return create_wgl_renderobject(mesh_program, attr, inputs; rename_updates)
     end
 
-    inputs = [
-        # Special
-        :space,
-        # Needs explicit handling
-        :uniform_colormap, :uniform_color, :vertex_color, :uniform_colorrange, :pattern,
-        :lowclip_color, :highclip_color, :nan_color, :model_f32c, :matcap,
-        :diffuse, :specular, :shininess, :backlight, :world_normalmatrix,
-        :wgl_uv_transform, :fetch_pixel, :primitive_shading, :color_mapping_type,
-        :depth_shift, :positions_transformed_f32c, :faces, :normals, :texturecoordinates,
-        :uniform_clip_planes, :uniform_num_clip_planes, :visible,
-    ]
-    return create_wgl_renderobject(mesh_program, attr, inputs)
+    return create_wgl_renderobject(mesh_program, attr, indexed_mesh_inputs())
 end
 
 function create_volume_shader(attr)


### PR DESCRIPTION
Three performance fixes for #5727, measured against `4c433f6ca`.

- **`strokewidth` no longer invalidates the adjacency.** The width was an input to
  `stroke_edge_data` but only used for its `iszero` check, so every change recomputed the
  whole edge and wing search. It now depends on a `Bool` `:stroke_enabled` node.
  179k triangles: 185 ms → 0 ms per change.
- **`corner_wings!` is allocation free.** One pass tracking the best two candidates,
  written into the caller's scratch arrays, instead of `filter` + two `filter!` +
  `partialsort` per corner. `:all` on 179k triangles: 151 ms / 204 MiB → 92 ms / 69 MiB.
- **WGLMakie only de-indexes when stroking**, like `Surface` already did. Unstroked meshes
  were paying ~4x the vertex bytes over the websocket and on the GPU; a 576-vertex sphere
  now sends 576 vertices instead of 3174.

Wing slot order can differ from before. It isn't part of the contract — both consumers
`min` over all six slots and the tests compare with `Set` — and the wings are identical as
a per-corner set on seven meshes in both `strokeedges` modes, `edge_widths` bit-identical.
Reference scenes render identical at `px_per_unit` 1 .
