### PR TITLE
Support `fillto` for stacked barplots and make the automatic baseline log-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added `fillto` support for stacked `barplot`s and made the automatic `fillto` log-scale aware for stacks, so stacked bars no longer disappear under `yscale = log10` [#5784](https://github.com/MakieOrg/Makie.jl/pull/5784).
 - Fixed a segfault in CairoMakie when saving a vector graphic (pdf, svg, eps) of a figure while recording it with a `VideoStream` [#5772](https://github.com/MakieOrg/Makie.jl/pull/5772).
 - Added support for exporting .mov video files. Transparent-background rendering for .mov outputs is now supported [#5764](https://github.com/MakieOrg/Makie.jl/pull/5764).
 - Increased precision of `Vec3f` to `Quaternionf` conversion to reduce quantization/improve precision around `Vec3f(0, 0, ±1)` rotations in `meshscatter`. [#5758](https://github.com/MakieOrg/Makie.jl/pull/5758)

--- a/Makie/src/basic_recipes/barplot.jl
+++ b/Makie/src/basic_recipes/barplot.jl
@@ -24,15 +24,64 @@ end
 
 # `fillto` is related to `y-axis` transformation only, thus we expect `tf::Tuple`
 function bar_default_fillto(tf::Tuple, ys, offset, in_y_direction)
-    _logT = Union{typeof(log), typeof(log2), typeof(log10), Base.Fix1{typeof(log), <:Real}}
-    if in_y_direction && tf[2] isa _logT || (!in_y_direction && tf[1] isa _logT)
-        # x-scale log and !(in_y_direction) is equiavlent to y-scale log in_y_direction
-        # use the minimal non-zero y divided by 2 as lower bound for log scale
-        smart_fillto = minimum(y -> y <= 0 ? oftype(y, Inf) : y, ys) / 2
+    if is_log_transform(tf, in_y_direction)
+        smart_fillto = smart_log_fillto(ys)
         return clamp.(ys, smart_fillto, Inf), smart_fillto
     else
         return ys, offset
     end
+end
+
+is_log_transform(tf, in_y_direction) = false
+function is_log_transform(tf::Tuple, in_y_direction)
+    _logT = Union{typeof(log), typeof(log2), typeof(log10), Base.Fix1{typeof(log), <:Real}}
+    # x-scale log and !(in_y_direction) is equiavlent to y-scale log in_y_direction
+    return in_y_direction ? tf[2] isa _logT : tf[1] isa _logT
+end
+
+# use the minimal non-zero y divided by 2 as lower bound for log scale
+smart_log_fillto(ys) = minimum(y -> y <= 0 ? oftype(y, Inf) : y, ys) / 2
+
+"""
+    bar_default_stack_fillto(tf, tos, in_y_direction)::Real
+
+Returns the default baseline of stacked bars for the given transform `tf`. This is
+zero unless the value axis is log scaled, in which case half the minimum positive
+stack total is used, mirroring [`bar_default_fillto`](@ref).
+
+In order to customize this for your own transformation type, you can dispatch on
+`tf`.
+
+## Arguments
+- `tf`: `plot.transformation.transform_func[]`.
+- `tos`: The cumulative stack heights (`to` values) computed by `stack_grouped_from_to`.
+"""
+bar_default_stack_fillto(tf, tos, in_y_direction) = 0.0
+function bar_default_stack_fillto(tf::Tuple, tos, in_y_direction)
+    is_log_transform(tf, in_y_direction) || return 0.0
+    fillto = smart_log_fillto(tos)
+    return isfinite(fillto) ? fillto : 0.0
+end
+
+"""
+    clamp_stack_to_fillto!(from, to, fillto)
+
+Clamps the stack boundaries `from`/`to` so that stacks of positive values never
+extend below `fillto` and stacks of negative values never extend above it. This
+makes `fillto` the baseline of the stack and, for a log scaled axis, replaces the
+zeros that would otherwise map to `-Inf` (dropping the whole segment).
+"""
+function clamp_stack_to_fillto!(from, to, fillto)
+    for i in eachindex(from, to)
+        if from[i] >= 0 && to[i] >= 0
+            from[i] = max(from[i], fillto)
+            to[i] = max(to[i], fillto)
+        else
+            from[i] = min(from[i], fillto)
+            to[i] = min(to[i], fillto)
+        end
+    end
+    return from, to
 end
 
 """
@@ -45,6 +94,11 @@ Plots bars of the given `heights` at the given (scalar) `positions`.
     Controls the baseline of the bars. This is zero in the default `automatic` case
     unless the barplot is in a log-scaled `Axis`. With a log scale, the automatic
     default is half the minimum value because zero is an invalid value for a log scale.
+
+    When `stack` is used, `fillto` must be a single number and acts as the baseline
+    of each stack: positive stacks never extend below it and negative stacks never
+    extend above it. With a log scale, the automatic default is half the minimum
+    positive stack total.
     """
     fillto = automatic
     "Offsets all bars by the given real value. Can also be set per-bar."
@@ -350,7 +404,6 @@ function Makie.plot!(p::BarPlot)
                 y, fillto = bar_default_fillto(transformation, y, offset, in_y_direction)
             end
         elseif eltype(stack) <: Integer
-            fillto === automatic || @warn "Ignore keyword fillto when keyword stack is provided"
             if !iszero(offset)
                 @warn "Ignore keyword offset when keyword stack is provided"
                 offset = 0.0
@@ -358,6 +411,12 @@ function Makie.plot!(p::BarPlot)
             i_stack = stack
 
             from, to = stack_grouped_from_to(i_stack, y, (x = x̂,))
+            if fillto === automatic
+                fillto = bar_default_stack_fillto(transformation, to, in_y_direction)
+            elseif !(fillto isa Real)
+                throw(ArgumentError("`fillto` must be a single number when `stack` is provided, got $(typeof(fillto))"))
+            end
+            iszero(fillto) || clamp_stack_to_fillto!(from, to, fillto)
             y, fillto = to, from
         else
             ArgumentError("The keyword argument `stack` currently supports only `AbstractVector{<: Integer}`") |> throw

--- a/Makie/test/plots/barplot.jl
+++ b/Makie/test/plots/barplot.jl
@@ -127,4 +127,51 @@
         @test from == from_
         @test to == to_
     end
+
+    @testset "stack fillto" begin
+        # https://github.com/MakieOrg/Makie.jl/issues/4549
+        rects(p) = p.plots[1][1][]
+        bottoms(p) = [r.origin[2] for r in rects(p)]
+        tops(p) = [r.origin[2] + r.widths[2] for r in rects(p)]
+
+        x = [1, 2, 3, 1, 2, 3]
+        y = [1, 2, 3, 1, 2, 3]
+        stack = [1, 1, 1, 2, 2, 2]
+
+        # explicit fillto is the baseline of the stack
+        f, ax, p = barplot(x, y; stack, fillto = 0.5)
+        @test bottoms(p) == [0.5, 0.5, 0.5, 1.0, 2.0, 3.0]
+        @test tops(p) == [1.0, 2.0, 3.0, 2.0, 4.0, 6.0]
+
+        # log scale automatic fillto: half of the smallest positive stack total
+        f, ax, p = barplot(x, y; stack, axis = (; yscale = log10))
+        @test bottoms(p) == [0.5, 0.5, 0.5, 1.0, 2.0, 3.0]
+        @test tops(p) == [1.0, 2.0, 3.0, 2.0, 4.0, 6.0]
+        @test all(>(0), bottoms(p))
+
+        # zeros anywhere in the stack must not produce a 0 (-> -Inf) boundary
+        x = [1, 2, 3, 4, 1, 2, 3, 4]
+        y = [0, 2, 3, 0, 1, 0, 3, 0]
+        stack = [1, 1, 1, 1, 2, 2, 2, 2]
+        f, ax, p = barplot(x, y; stack, axis = (; yscale = log10))
+        @test all(>(0), bottoms(p))
+        @test all(>(0), tops(p))
+        @test bottoms(p) == [0.5, 0.5, 0.5, 0.5, 0.5, 2.0, 3.0, 0.5]
+        @test tops(p) == [0.5, 2.0, 3.0, 0.5, 1.0, 2.0, 6.0, 0.5]
+
+        # log scale in x direction
+        f, ax, p = barplot(x, y; stack, direction = :x, axis = (; xscale = log10))
+        @test [r.origin[1] for r in rects(p)] == [0.5, 0.5, 0.5, 0.5, 0.5, 2.0, 3.0, 0.5]
+
+        # linear scale is unchanged by default
+        f, ax, p = barplot(x, y; stack)
+        @test bottoms(p) == [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 3.0, 0.0]
+
+        # negative stacks are clamped symmetrically
+        f, ax, p = barplot([1, 1, 2, 2], [-1, -2, 1, 2]; stack = [1, 2, 1, 2], fillto = -0.5)
+        @test bottoms(p) == [-1.0, -3.0, 0.0, 1.0]
+        @test tops(p) == [-0.5, -1.0, 1.0, 3.0]
+
+        @test_throws ArgumentError barplot(x, y; stack, fillto = zeros(length(x)))
+    end
 end

--- a/docs/src/reference/plots/barplot.md
+++ b/docs/src/reference/plots/barplot.md
@@ -59,6 +59,21 @@ barplot(tbl.cat, tbl.height,
         )
 ```
 
+Stacked bars start at zero by default, which cannot be shown on a log-scaled axis.
+In that case the baseline of each stack is automatically placed at half the smallest positive stack total.
+You can also set the baseline explicitly with `fillto`, which then applies to every stack:
+
+```@figure barplot
+barplot(tbl.cat, tbl.height,
+        stack = tbl.grp,
+        color = tbl.grp,
+        fillto = 0.05,
+        axis = (xticks = (1:3, ["left", "middle", "right"]),
+                yscale = log10,
+                title = "Stacked bars on a log axis"),
+        )
+```
+
 Passing `grp` to `dodge` will instead draw the individual height values as separate bars side by side.
 Here 1 is the left most and 3 the right most bar.
 The gap between dodged bars can be adjusted with `dodge_gap`.


### PR DESCRIPTION
## Description

Fixes #4549 (and downstream Moelf/FHist.jl#124).

Stacked bars always started at zero. Under a log transform zero maps to `-Inf`, so the bottom segment of every stack, and every segment sitting on top of a zero-height one, was silently dropped by the backends. `fillto` was also explicitly ignored (with a warning) whenever `stack` was given, so there was no way to work around it short of not using `stack`.

```julia
barplot([1,2,3,1,2,3], [1,2,3,1,2,3], stack=[1,1,1,2,2,2], color=[1,1,1,2,2,2], gap=0; axis=(; yscale=log))
```

Before: only the top stack level is drawn. After: both levels are drawn, the stack starts at half the smallest positive stack total (0.5 here).

Changes:

- `fillto` is now honoured for stacked bars and acts as the baseline of the stack. Stack boundaries are clamped so that positive stacks never extend below it and negative stacks never extend above it, so zeros inside a stack stay drawable on a log axis too. A non-scalar `fillto` with `stack` throws an `ArgumentError`.
- With `fillto = automatic` and a log-scaled value axis, the baseline defaults to half the smallest positive stack total (`bar_default_stack_fillto`), mirroring the existing non-stacked rule in `bar_default_fillto`. It is dispatchable on the transform like `bar_default_fillto`.
- Linear axes without an explicit `fillto` are unchanged (baseline stays 0, no clamping).
- The log-transform detection was factored out of `bar_default_fillto` into `is_log_transform` so both paths share it.
- Added a docs example (stacked bars on a log axis with `fillto`) and unit tests in `Makie/test/plots/barplot.jl` covering explicit `fillto`, automatic log baseline in both directions, zeros inside the stack, negative stacks and the linear default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Added an entry in CHANGELOG.md (for new features and breaking changes)
- [x] Added or changed relevant sections in the documentation
- [x] Added unit tests for new algorithms, conversion methods, etc.
- [ ] Added reference image tests for new plotting functions, recipes, visual options, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
